### PR TITLE
Don't throw an error when we intentionally exit with exit code 0

### DIFF
--- a/packages/chatdown/src/commands/chatdown.ts
+++ b/packages/chatdown/src/commands/chatdown.ts
@@ -67,7 +67,9 @@ export default class Chatdown extends Command {
       if (err.message.match(/Malformed configurations options detected/)) {
         throw new CLIError(err.message)
       }
-      throw err
+      if (err.message.match(/EEXIT: 0/)) {
+        process.exit(0);
+      }
     }
   }
 

--- a/packages/chatdown/src/commands/chatdown.ts
+++ b/packages/chatdown/src/commands/chatdown.ts
@@ -70,6 +70,7 @@ export default class Chatdown extends Command {
       if (err.message.match(/EEXIT: 0/)) {
         process.exit(0);
       }
+      throw err
     }
   }
 


### PR DESCRIPTION
When we issue a command with no flags (ex: 'bf chatdown') the help contents are displayed.

The oclif base command then returns an error with exit code 0, which chatdown then throws in the catch clause:

exit(code = 0) { 
  return Errors.exit(code); 
}

Since exit code 0 is an intentional way to exit the Node program, I believe we should not be throwing an error.

This change looks for 'EEXIT: 0' in the error message returned from oclif and if present exits gracefully with 'process.exit(0)'.