### PR TITLE
Export app info on LUIS JSON -> LU conversion

### DIFF
--- a/packages/luis/src/parser/converters/luistoluconverter.js
+++ b/packages/luis/src/parser/converters/luistoluconverter.js
@@ -33,6 +33,7 @@ module.exports = {
         updateUtterancesList(LUISJSON.patterns, luisObj.intents, 'pattern');
         if(luisObj.intents.length >= 0) {
             fileContent += NEWLINE;
+            fileContent += addAppMetaData(LUISJSON);
             fileContent += '> # Intent definitions' + NEWLINE + NEWLINE;
             // write out intents and utterances..
             luisObj.intents.forEach(function(intent) {
@@ -188,6 +189,19 @@ module.exports = {
     }
 }
 /**
+ * Helper to add application inforamtion metadata
+ * @param {Object} LUISJSON 
+ */
+const addAppMetaData = function(LUISJSON) {
+    let fileContent = '';
+    if (LUISJSON.name) fileContent += `> !# @app.name = ${LUISJSON.name}` + NEWLINE;
+    if (LUISJSON.desc) fileContent += `> !# @app.desc = ${LUISJSON.desc}` + NEWLINE;
+    if (LUISJSON.versionId) fileContent += `> !# @app.versionId = ${LUISJSON.versionId}` + NEWLINE;
+    if (LUISJSON.culture) fileContent += `> !# @app.culture = ${LUISJSON.culture}` + NEWLINE;
+    if (LUISJSON.luis_schema_version) fileContent += `> !# @app.luis_schema_version = ${LUISJSON.luis_schema_version}` + NEWLINE;
+    return fileContent === '' ? fileContent : `> LUIS application information` + NEWLINE + fileContent + NEWLINE + NEWLINE;
+}
+/**
  * Helper function to handle nDepth entity definition
  * @param {Object} entity 
  */
@@ -322,17 +336,6 @@ const objectSortByStartPos = function (objectArray) {
         return a.startPos - b.startPos;
     });
     return ObjectByStartPos;
-}
-
-constructModelDescFromLUISJSON = async function(LUISJSON) {
-    let modelDesc = NEWLINE;
-    modelDesc += '> LUIS application information' + NEWLINE;
-    modelDesc += '> !# @app.name = ' + LUISJSON.name + NEWLINE;
-    modelDesc += '> !# @app.desc = ' + LUISJSON.desc + NEWLINE;
-    modelDesc += '> !# @app.culture = ' + LUISJSON.culture + NEWLINE;
-    modelDesc += '> !# @app.versionId = ' + LUISJSON.versionId + NEWLINE;
-    modelDesc += '> !# @app.luis_schema_version = ' + LUISJSON.luis_schema_version + NEWLINE;
-    return modelDesc;
 }
 
 /**

--- a/packages/luis/test/fixtures/translation/fr/root.luis.json
+++ b/packages/luis/test/fixtures/translation/fr/root.luis.json
@@ -73,41 +73,6 @@
       "entities": []
     },
     {
-      "text": "calendrier pour novembre 1948",
-      "intent": "Calendar.Find",
-      "entities": []
-    },
-    {
-      "text": "afficher les plans de week-end",
-      "intent": "Calendar.Find",
-      "entities": []
-    },
-    {
-      "text": "ai-je quelque chose le mercredi?",
-      "intent": "Calendar.Find",
-      "entities": []
-    },
-    {
-      "text": "Combien de jours y a-t-il entre le 13 mars 2015 et aujourd'hui ?",
-      "intent": "Calendar.Find",
-      "entities": []
-    },
-    {
-      "text": "tirer vers le haut de mon rendez-vous savoir combien de temps j'ai avant mon prochain rendez-vous",
-      "intent": "Calendar.Find",
-      "entities": []
-    },
-    {
-      "text": "recherche de rencontres avec Chris",
-      "intent": "Calendar.Find",
-      "entities": []
-    },
-    {
-      "text": "montrez-moi l'heure de la fête de mariage de demain",
-      "intent": "Calendar.Find",
-      "entities": []
-    },
-    {
       "text": "dites-moi les détails de l'événement",
       "intent": "Calendar.Find",
       "entities": []
@@ -119,37 +84,37 @@
     },
     {
       "text": "suis-je libre d'être avec des amis samedi ?",
-      "intent": "None",
+      "intent": "Calendar.Find",
       "entities": []
     },
     {
       "text": "rendez-vous avec Johnson doit être la semaine prochaine",
-      "intent": "None",
+      "intent": "Calendar.Find",
       "entities": []
     },
     {
       "text": "appeler papa mike",
-      "intent": "None",
+      "intent": "Calendar.Find",
       "entities": []
     },
     {
       "text": "changer la réunion avec Chris à 9: 00 h",
-      "intent": "None",
+      "intent": "Calendar.Find",
       "entities": []
     },
     {
       "text": "email cloney john",
-      "intent": "None",
+      "intent": "Calendar.Find",
       "entities": []
     },
     {
       "text": "prolonger la réunion du déjeuner 30 minutes de plus",
-      "intent": "None",
+      "intent": "Calendar.Find",
       "entities": []
     },
     {
       "text": "Je veux reprogrammer la réuni on au club de l'armée de l'air",
-      "intent": "None",
+      "intent": "Calendar.Find",
       "entities": []
     },
     {
@@ -166,9 +131,48 @@
       "text": "l'atelier durera 10 heures",
       "intent": "None",
       "entities": []
+    },
+    {
+      "text": "change the meeting with chris to 9 : 00 am",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "email cloney john",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "extend lunch meeting 30 minutes extra",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "i want to reschedule the meeting at the air force club",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "marketing meetings on tuesdays will now be every wednesday please change on my calendar",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "move the bbq party to friday",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "the workshop will last for 10 hours",
+      "intent": "None",
+      "entities": []
     }
   ],
   "patterns": [],
   "patternAnyEntities": [],
-  "prebuiltEntities": []
+  "prebuiltEntities": [],
+  "name": "file",
+  "versionId": "0.1",
+  "culture": "en-us",
+  "luis_schema_version": "3.2.0"
 }

--- a/packages/luis/test/fixtures/verified/allGen.lu
+++ b/packages/luis/test/fixtures/verified/allGen.lu
@@ -1,4 +1,11 @@
 
+> LUIS application information
+> !# @app.name = all
+> !# @app.versionId = 0.1
+> !# @app.culture = en-us
+> !# @app.luis_schema_version = 3.2.0
+
+
 > # Intent definitions
 
 ## Greeting

--- a/packages/luis/test/fixtures/verified/luis_sorted.lu
+++ b/packages/luis/test/fixtures/verified/luis_sorted.lu
@@ -1,4 +1,11 @@
 
+> LUIS application information
+> !# @app.name = all
+> !# @app.versionId = 0.1
+> !# @app.culture = en-us
+> !# @app.luis_schema_version = 3.2.0
+
+
 > # Intent definitions
 
 ## AskForUserName

--- a/packages/luis/test/fixtures/verified/modelAsFeatureGen.lu
+++ b/packages/luis/test/fixtures/verified/modelAsFeatureGen.lu
@@ -1,4 +1,10 @@
 
+> LUIS application information
+> !# @app.versionId = 0.1
+> !# @app.culture = en-us
+> !# @app.luis_schema_version = 3.2.0
+
+
 > # Intent definitions
 
 ## test1

--- a/packages/luis/test/fixtures/verified/nDepthEntityInUtterance.lu
+++ b/packages/luis/test/fixtures/verified/nDepthEntityInUtterance.lu
@@ -1,4 +1,10 @@
 
+> LUIS application information
+> !# @app.versionId = 0.1
+> !# @app.culture = en-us
+> !# @app.luis_schema_version = 3.2.0
+
+
 > # Intent definitions
 
 ## None

--- a/packages/luis/test/fixtures/verified/newEntity1.lu
+++ b/packages/luis/test/fixtures/verified/newEntity1.lu
@@ -1,4 +1,10 @@
 
+> LUIS application information
+> !# @app.versionId = 0.1
+> !# @app.culture = en-us
+> !# @app.luis_schema_version = 3.2.0
+
+
 > # Intent definitions
 
 > # Entity definitions

--- a/packages/luis/test/fixtures/verified/newEntity2.lu
+++ b/packages/luis/test/fixtures/verified/newEntity2.lu
@@ -1,4 +1,10 @@
 
+> LUIS application information
+> !# @app.versionId = 0.1
+> !# @app.culture = en-us
+> !# @app.luis_schema_version = 3.2.0
+
+
 > # Intent definitions
 
 > # Entity definitions

--- a/packages/luis/test/fixtures/verified/plFeatures.lu
+++ b/packages/luis/test/fixtures/verified/plFeatures.lu
@@ -1,4 +1,11 @@
 
+> LUIS application information
+> !# @app.name = AppName
+> !# @app.versionId = 0.1
+> !# @app.culture = en-us
+> !# @app.luis_schema_version = 5.0.0
+
+
 > # Intent definitions
 
 ## None

--- a/packages/luis/test/fixtures/verified/regexmodel.lu
+++ b/packages/luis/test/fixtures/verified/regexmodel.lu
@@ -1,4 +1,11 @@
 
+> LUIS application information
+> !# @app.name = regexEntity
+> !# @app.versionId = 0.1
+> !# @app.culture = en-us
+> !# @app.luis_schema_version = 3.2.0
+
+
 > # Intent definitions
 
 > # Entity definitions

--- a/packages/luis/test/fixtures/verified/test269-d.lu
+++ b/packages/luis/test/fixtures/verified/test269-d.lu
@@ -1,4 +1,11 @@
 
+> LUIS application information
+> !# @app.name = Repro
+> !# @app.versionId = 0.1
+> !# @app.culture = en-us
+> !# @app.luis_schema_version = 3.2.0
+
+
 > # Intent definitions
 
 ## None


### PR DESCRIPTION
Ludown CLI had a CLI flag to enable writing app info. This was not brought forward to the BF CLI. 

This PR adds support for exporting the luis app info by default.

Updated tests.