### PR TITLE
Fix descriptions to make them more consistent

### DIFF
--- a/packages/chatdown/README.md
+++ b/packages/chatdown/README.md
@@ -13,7 +13,7 @@ Tool for parsing chat files and outputting replayable activities
 
 ## `bf chatdown`
 
-Converts chat dialog files in <filename>.chat format into transcript file. Writes corresponding <filename>.transcript for each .chat file
+Converts chat dialog files in <filename>.chat format into transcript files. Writes corresponding <filename>.transcript for each .chat file.
 
 ```
 USAGE

--- a/packages/chatdown/src/commands/chatdown.ts
+++ b/packages/chatdown/src/commands/chatdown.ts
@@ -8,7 +8,7 @@ const intercept = require('intercept-stdout')
 const path = require('path')
 
 export default class Chatdown extends Command {
-  static description = 'Converts chat dialog files in <filename>.chat format into transcript file. Writes corresponding <filename>.transcript for each .chat file'
+  static description = 'Converts chat dialog files in <filename>.chat format into transcript files. Writes corresponding <filename>.transcript for each .chat file.'
 
   static examples = [`
   $ bf chatdown

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -76,7 +76,7 @@ _See code: [@microsoft/bf-cli-config](https://github.com/microsoft/botframework-
 
 ## `bf chatdown`
 
-Converts chat dialog files in <filename>.chat format into transcript file. Writes corresponding <filename>.transcript for each .chat file
+Converts chat dialog files in <filename>.chat format into transcript files. Writes corresponding <filename>.transcript for each .chat file.
 
 ```
 USAGE
@@ -107,7 +107,7 @@ _See code: [@microsoft/bf-chatdown](https://github.com/microsoft/botframework-cl
 
 ## `bf config`
 
-The config plugin allows users to configure various settings within the cli.
+Configures various settings within the cli.
 
 ```
 USAGE
@@ -196,7 +196,7 @@ _See code: [@microsoft/bf-cli-config](https://github.com/microsoft/botframework-
 
 ## `bf help [COMMAND]`
 
-display help for bf
+Displays help for bf.
 
 ```
 USAGE
@@ -213,14 +213,14 @@ _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.1.6
 
 ## `bf luis`
 
-Convert, translate luis/lu files or generate source code
+Converts, translates luis/lu files or generates source code.
 
 ```
 USAGE
   $ bf luis
 
 OPTIONS
-  -h, --help  Display Luis available commnads
+  -h, --help  Display Luis available commands
 ```
 
 _See code: [@microsoft/bf-lu](https://github.com/microsoft/botframework-cli/blob/v1.0.0/src/commands/luis/index.ts)_
@@ -429,14 +429,14 @@ USAGE
   $ bf qnamaker
 
 OPTIONS
-  -h, --help  Display QnA Maker CLI available commnads
+  -h, --help  Display QnA Maker CLI available commands
 ```
 
 _See code: [@microsoft/bf-qnamaker](https://github.com/microsoft/botframework-cli/blob/v1.0.0/src/commands/qnamaker/index.ts)_
 
 ## `bf qnamaker:convert`
 
-Convert .lu file(s) to a QnA application JSON model or vice versa
+Converts .lu file(s) to QnA application JSON models or vice versa.
 
 ```
 USAGE

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -8,7 +8,6 @@
 
 # Commands
 <!-- commands -->
-* [`bf `](#bf-)
 * [`bf config`](#bf-config)
 * [`bf config:set:qnamaker`](#bf-configsetqnamaker)
 * [`bf config:set:telemetry`](#bf-configsettelemetry)
@@ -16,23 +15,9 @@
 * [`bf config:show:qnamaker`](#bf-configshowqnamaker)
 * [`bf config:show:telemetry`](#bf-configshowtelemetry)
 
-## `bf `
-
-The config plugin allows users to configure various settings within the cli.
-
-```
-USAGE
-  $ bf
-
-OPTIONS
-  -h, --help  show CLI help
-```
-
-_See code: [src/commands/index.ts](https://github.com/microsoft/botframework-cli/blob/v1.0.0/src/commands/index.ts)_
-
 ## `bf config`
 
-The config plugin allows users to configure various settings within the cli.
+Allows users to configure various settings within the cli.
 
 ```
 USAGE

--- a/packages/config/src/commands/config/index.ts
+++ b/packages/config/src/commands/config/index.ts
@@ -1,7 +1,7 @@
 import {Command, flags} from '@oclif/command'
 
 export default class ConfigIndex extends Command {
-  static description = 'The config plugin allows users to configure various settings within the cli.'
+  static description = 'Configure various settings within the cli.'
 
   static flags = {
     help: flags.help({char: 'h'}),

--- a/packages/config/src/commands/index.ts
+++ b/packages/config/src/commands/index.ts
@@ -1,7 +1,7 @@
 import {Command, flags} from '@oclif/command'
 
 export default class Index extends Command {
-  static description = 'The config plugin allows users to configure various settings within the cli.'
+  static description = 'Configure various settings within the cli.'
 
   static flags = {
     help: flags.help({char: 'h'}),

--- a/packages/lu/README.md
+++ b/packages/lu/README.md
@@ -23,14 +23,14 @@
 
 ## `bf luis`
 
-Convert, translate luis/lu files or generate source code
+Converts, translates luis/lu files or generates source code.
 
 ```
 USAGE
   $ bf luis
 
 OPTIONS
-  -h, --help  Display Luis available commnads
+  -h, --help  Display Luis available commands
 ```
 
 _See code: [src/commands/luis/index.ts](https://github.com/microsoft/botframework-cli/blob/v1.0.0/src/commands/luis/index.ts)_
@@ -115,7 +115,7 @@ _See code: [src/commands/luis/translate.ts](https://github.com/microsoft/botfram
 
 ## `bf qnamaker:convert`
 
-Convert .lu file(s) to a QnA application JSON model or vice versa
+Converts .lu file(s) to QnA application JSON models or vice versa.
 
 ```
 USAGE

--- a/packages/lu/src/commands/luis/index.ts
+++ b/packages/lu/src/commands/luis/index.ts
@@ -1,10 +1,10 @@
 import {Command, flags} from '@microsoft/bf-cli-command'
 
 export default class LuisIndex extends Command {
-  static description = 'Convert, translate luis/lu files or generate source code'
+  static description = 'Converts, translates luis/lu files or generates source code.'
 
   static flags = {
-    help: flags.help({char: 'h', description: 'Display Luis available commnads'}),
+    help: flags.help({char: 'h', description: 'Display Luis available commands'}),
   }
 
   async run() {

--- a/packages/lu/src/commands/qnamaker/convert.ts
+++ b/packages/lu/src/commands/qnamaker/convert.ts
@@ -7,7 +7,7 @@ const qnaConverter = require('./../../parser/converters/qnajsontoqnaconverter')
 const fileExtEnum = require('./../../parser/lufile/helpers').FileExtTypeEnum
 
 export default class QnamakerConvert extends Command {
-  static description = 'Convert .lu file(s) to a QnA application JSON model or vice versa'
+  static description = 'Converts .lu file(s) to QnA application JSON models or vice versa.'
 
   static flags: flags.Input<any> = {
     in: flags.string({description: 'Source .qna file(s) or QnA KB JSON file'}),

--- a/packages/qnamaker/README.md
+++ b/packages/qnamaker/README.md
@@ -41,7 +41,7 @@ USAGE
   $ bf qnamaker
 
 OPTIONS
-  -h, --help  Display QnA Maker CLI available commnads
+  -h, --help  Display QnA Maker CLI available commands
 ```
 
 _See code: [src/commands/qnamaker/index.ts](https://github.com/microsoft/botframework-cli/blob/v1.0.0/src/commands/qnamaker/index.ts)_

--- a/packages/qnamaker/src/commands/qnamaker/index.ts
+++ b/packages/qnamaker/src/commands/qnamaker/index.ts
@@ -4,7 +4,7 @@ export default class QnamakerIndex extends Command {
   static description = 'QnA Maker'
 
   static flags: flags.Input<any> = {
-    help: flags.help({char: 'h', description: 'Display QnA Maker CLI available commnads'}),
+    help: flags.help({char: 'h', description: 'Display QnA Maker CLI available commands'}),
   }
 
   async run() {

--- a/specs/ChatdownDevSpec.md
+++ b/specs/ChatdownDevSpec.md
@@ -1,7 +1,7 @@
 # ChatDown Dev Spec One-Pager
 
 ## Summary
-Converts chat dialog files in *.chat* format into transcript file. Writes corresponding *.transcript* for each .chat file.
+Converts chat dialog files in *.chat* format into transcript files. Writes corresponding *.transcript* for each .chat file.
 
 ## Requirements
 ### Prerequisites


### PR DESCRIPTION
This PR is based on my observations of the output of the `bf` command:

```
Update available
     Run
npm i -g @microsoft/botframework-cli
 ================

VERSION
  @microsoft/botframework-cli/4.5.0-preview.84297 win32-x64 node-v10.16.3

USAGE
  $ bf [COMMAND]

COMMANDS
  chatdown  Converts chat dialog files in <filename>.chat format into transcript file. Writes corresponding
            <filename>.transcript for each .chat file
  config    The config plugin allows users to configure various settings within the cli.
  help      display help for bf
  luis      Convert, translate luis/lu files or generate source code
  plugins   list installed plugins
  qnamaker  Convert .lu file(s) to a QnA application JSON model or vice versa
```

I wanted to edit the command descriptions so that they use a consistent grammatical tense. However, I could not find where `display help for bf` and `list installed plugins` are found in the source code.