### PR TITLE
Add license header rules to tslint

### DIFF
--- a/packages/chatdown/src/commands/chatdown.ts
+++ b/packages/chatdown/src/commands/chatdown.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {flags} from '@oclif/command'
 import {CLIError, Command, utils} from '@microsoft/bf-cli-command'
 const chalk = require('chalk')

--- a/packages/chatdown/src/index.ts
+++ b/packages/chatdown/src/index.ts
@@ -1,1 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 export default {}

--- a/packages/chatdown/tslint.json
+++ b/packages/chatdown/tslint.json
@@ -2,6 +2,15 @@
   "extends": "@oclif/tslint",
   "rules": {
     "ordered-imports": [false],
-    "object-literal-sort-keys": [false]
+    "object-literal-sort-keys": [false],
+    "file-header": [
+      true,
+      {
+        "match": "Copyright \\(c\\) Microsoft Corporation\\.*",
+        "allow-single-line-comments": false,
+        "default": "Copyright (c) Microsoft Corporation. All rights reserved.\nLicensed under the MIT License.",
+        "enforce-trailing-newline": false
+      }
+    ]
   }
 }

--- a/packages/cli/src/hooks/init/inithook.ts
+++ b/packages/cli/src/hooks/init/inithook.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {Hook} from '@oclif/config'
 import cli from 'cli-ux'
 import * as fs from 'fs-extra'

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,1 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 export {run} from '@oclif/command'

--- a/packages/cli/tslint.json
+++ b/packages/cli/tslint.json
@@ -1,3 +1,16 @@
 {
-  "extends": "@oclif/tslint"
+  "extends": "@oclif/tslint",
+  "rules": {
+    "ordered-imports": [false],
+    "object-literal-sort-keys": [false],
+    "file-header": [
+      true,
+      {
+        "match": "Copyright \\(c\\) Microsoft Corporation\\.*",
+        "allow-single-line-comments": false,
+        "default": "Copyright (c) Microsoft Corporation. All rights reserved.\nLicensed under the MIT License.",
+        "enforce-trailing-newline": false
+      }
+    ]
+  }
 }

--- a/packages/command/src/clierror.ts
+++ b/packages/command/src/clierror.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 export class CLIError extends Error {
   constructor(error: string | Error) {
     const message = error instanceof Error ? error.message : error

--- a/packages/command/src/command.ts
+++ b/packages/command/src/command.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 // tslint:disable:object-curly-spacing ordered-imports
 
 import { Command as Base } from '@oclif/command'

--- a/packages/command/src/index.ts
+++ b/packages/command/src/index.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags} from './command'
 import utils from './utils'
 export {CLIError, Command, flags, utils}

--- a/packages/command/src/readpipeddata.ts
+++ b/packages/command/src/readpipeddata.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 const ReadPipedStdin = {
   read: async () => {
     return new Promise<string>(async (resolve, reject) => {

--- a/packages/command/src/telemetry.ts
+++ b/packages/command/src/telemetry.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import * as AppInsights from 'applicationinsights'
 
 const INSTRUMENTATION_KEY = 'cc91f74a-1abd-4be0-8a96-fddedbc08dd7'

--- a/packages/command/src/utils.ts
+++ b/packages/command/src/utils.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 const fs = require('fs-extra')
 const path = require('path')
 import {CLIError} from './clierror'

--- a/packages/command/tslint.json
+++ b/packages/command/tslint.json
@@ -1,3 +1,16 @@
 {
-  "extends": "@oclif/tslint"
+  "extends": "@oclif/tslint",
+  "rules": {
+    "ordered-imports": [false],
+    "object-literal-sort-keys": [false],
+    "file-header": [
+      true,
+      {
+        "match": "Copyright \\(c\\) Microsoft Corporation\\.*",
+        "allow-single-line-comments": false,
+        "default": "Copyright (c) Microsoft Corporation. All rights reserved.\nLicensed under the MIT License.",
+        "enforce-trailing-newline": false
+      }
+    ]
+  }
 }

--- a/packages/config/src/commands/config/index.ts
+++ b/packages/config/src/commands/config/index.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {Command, flags} from '@oclif/command'
 
 export default class ConfigIndex extends Command {

--- a/packages/config/src/commands/config/set/qnamaker.ts
+++ b/packages/config/src/commands/config/set/qnamaker.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {Command, flags} from '@microsoft/bf-cli-command'
 import {getConfigFile, writeConfigFile, Config} from '../../../utils/configfilehandler'
 

--- a/packages/config/src/commands/config/set/telemetry.ts
+++ b/packages/config/src/commands/config/set/telemetry.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {Command, flags} from '@microsoft/bf-cli-command'
 import {getConfigFile, writeConfigFile, Config} from '../../../utils/configfilehandler'
 

--- a/packages/config/src/commands/config/show.ts
+++ b/packages/config/src/commands/config/show.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {Command, flags} from '@microsoft/bf-cli-command'
 import {getConfigFile, Config} from '../../utils/configfilehandler'
 

--- a/packages/config/src/commands/config/show/qnamaker.ts
+++ b/packages/config/src/commands/config/show/qnamaker.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {Command, flags} from '@microsoft/bf-cli-command'
 import {getConfigFile, Config} from '../../../utils/configfilehandler'
 

--- a/packages/config/src/commands/config/show/telemetry.ts
+++ b/packages/config/src/commands/config/show/telemetry.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {Command, flags} from '@microsoft/bf-cli-command'
 import {getConfigFile, Config} from '../../../utils/configfilehandler'
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,1 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 export default {}

--- a/packages/config/src/utils/configfilehandler.ts
+++ b/packages/config/src/utils/configfilehandler.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 const fs = require('fs-extra')
 const path = require('path')
 

--- a/packages/config/tslint.json
+++ b/packages/config/tslint.json
@@ -2,6 +2,15 @@
   "extends": "@oclif/tslint",
   "rules": {
     "ordered-imports": [false],
-    "object-literal-sort-keys": [false]
+    "object-literal-sort-keys": [false],
+    "file-header": [
+      true,
+      {
+        "match": "Copyright \\(c\\) Microsoft Corporation\\.*",
+        "allow-single-line-comments": false,
+        "default": "Copyright (c) Microsoft Corporation. All rights reserved.\nLicensed under the MIT License.",
+        "enforce-trailing-newline": false
+      }
+    ]
   }
 }

--- a/packages/dialog/src/commands/dialog/merge.ts
+++ b/packages/dialog/src/commands/dialog/merge.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright(c) Microsoft Corporation.All rights reserved.
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
 

--- a/packages/dialog/src/commands/dialog/verify.ts
+++ b/packages/dialog/src/commands/dialog/verify.ts
@@ -1,7 +1,8 @@
-/**
- * Copyright(c) Microsoft Corporation.All rights reserved.
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+
 import { Command, flags } from '@microsoft/bf-cli-command';
 import * as chalk from 'chalk';
 import { Definition, DialogTracker, SchemaTracker } from '../../library/dialogTracker';

--- a/packages/dialog/src/commands/index.ts
+++ b/packages/dialog/src/commands/index.ts
@@ -1,5 +1,5 @@
-/**
- * Copyright(c) Microsoft Corporation.All rights reserved.
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
 

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -1,1 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 export default {}

--- a/packages/dialog/src/library/dialogTracker.ts
+++ b/packages/dialog/src/library/dialogTracker.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
-/**
- * Copyright(c) Microsoft Corporation.All rights reserved.
+
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+
 export * from './schemaTracker';
 import * as fs from 'fs-extra';
 import * as glob from 'globby';

--- a/packages/dialog/src/library/schemaTracker.ts
+++ b/packages/dialog/src/library/schemaTracker.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
-/**
- * Copyright(c) Microsoft Corporation.All rights reserved.
+
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
 

--- a/packages/dialog/tslint.json
+++ b/packages/dialog/tslint.json
@@ -12,6 +12,15 @@
         "no-trailing-whitespace": false,
         "ordered-imports": false,
         "no-empty-line-after-opening-brace": false,
-        "semicolon": false
+        "semicolon": false,
+        "file-header": [
+            true,
+            {
+              "match": "Copyright \\(c\\) Microsoft Corporation\\.*",
+              "allow-single-line-comments": false,
+              "default": "Copyright (c) Microsoft Corporation. All rights reserved.\nLicensed under the MIT License.",
+              "enforce-trailing-newline": false
+            }
+          ]
     }
 }

--- a/packages/lu/src/commands/luis/convert.ts
+++ b/packages/lu/src/commands/luis/convert.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags, utils} from '@microsoft/bf-cli-command'
 const exception = require('./../../parser/lufile/classes/exception')
 const fs = require('fs-extra')

--- a/packages/lu/src/commands/luis/generate/cs.ts
+++ b/packages/lu/src/commands/luis/generate/cs.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags} from '@microsoft/bf-cli-command'
 import {camelCase, upperFirst} from 'lodash'
 import * as path from 'path'

--- a/packages/lu/src/commands/luis/generate/ts.ts
+++ b/packages/lu/src/commands/luis/generate/ts.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags} from '@microsoft/bf-cli-command'
 import {camelCase, kebabCase, upperFirst} from 'lodash'
 import * as path from 'path'

--- a/packages/lu/src/commands/luis/index.ts
+++ b/packages/lu/src/commands/luis/index.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {Command, flags} from '@microsoft/bf-cli-command'
 
 export default class LuisIndex extends Command {

--- a/packages/lu/src/commands/luis/translate.ts
+++ b/packages/lu/src/commands/luis/translate.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags, utils} from '@microsoft/bf-cli-command'
 const fs = require('fs-extra')
 const path = require('path')

--- a/packages/lu/src/commands/qnamaker/convert.ts
+++ b/packages/lu/src/commands/qnamaker/convert.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags, utils} from '@microsoft/bf-cli-command'
 const exception = require('./../../parser/lufile/classes/exception')
 const fs = require('fs-extra')

--- a/packages/lu/src/commands/qnamaker/translate.ts
+++ b/packages/lu/src/commands/qnamaker/translate.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags, utils} from '@microsoft/bf-cli-command'
 const fs = require('fs-extra')
 const path = require('path')

--- a/packages/lu/src/index.ts
+++ b/packages/lu/src/index.ts
@@ -1,1 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 export default {}

--- a/packages/lu/src/utils/filehelper.ts
+++ b/packages/lu/src/utils/filehelper.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, utils} from '@microsoft/bf-cli-command'
 const fs = require('fs-extra')
 const path = require('path')

--- a/packages/lu/tslint.json
+++ b/packages/lu/tslint.json
@@ -4,5 +4,18 @@
     "exclude": [
         "src/parser/**/**.js"
     ]
+  },
+  "rules": {
+    "ordered-imports": [false],
+    "object-literal-sort-keys": [false],
+    "file-header": [
+      true,
+      {
+        "match": "Copyright \\(c\\) Microsoft Corporation\\.*",
+        "allow-single-line-comments": false,
+        "default": "Copyright (c) Microsoft Corporation. All rights reserved.\nLicensed under the MIT License.",
+        "enforce-trailing-newline": false
+      }
+    ]
   }
 }

--- a/packages/qnamaker/src/commands/qnamaker/alterations/index.ts
+++ b/packages/qnamaker/src/commands/qnamaker/alterations/index.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {Command, flags} from '@microsoft/bf-cli-command'
 
 export default class QnamakerAlterationsIndex extends Command {

--- a/packages/qnamaker/src/commands/qnamaker/alterations/list.ts
+++ b/packages/qnamaker/src/commands/qnamaker/alterations/list.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags} from '@microsoft/bf-cli-command'
 
 const qnamaker = require('./../../../../utils/index')

--- a/packages/qnamaker/src/commands/qnamaker/alterations/replace.ts
+++ b/packages/qnamaker/src/commands/qnamaker/alterations/replace.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags} from '@microsoft/bf-cli-command'
 const qnamaker = require('./../../../../utils/index')
 const replaceAlterationsJSON = require('./../../../../utils/payloads/replacealterations')

--- a/packages/qnamaker/src/commands/qnamaker/endpointkeys/index.ts
+++ b/packages/qnamaker/src/commands/qnamaker/endpointkeys/index.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {Command, flags} from '@microsoft/bf-cli-command'
 
 export default class QnamakerEndpointkeysIndex extends Command {

--- a/packages/qnamaker/src/commands/qnamaker/endpointkeys/list.ts
+++ b/packages/qnamaker/src/commands/qnamaker/endpointkeys/list.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags} from '@microsoft/bf-cli-command'
 
 const qnamaker = require('./../../../../utils/index')

--- a/packages/qnamaker/src/commands/qnamaker/endpointkeys/refresh.ts
+++ b/packages/qnamaker/src/commands/qnamaker/endpointkeys/refresh.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags} from '@microsoft/bf-cli-command'
 
 const qnamaker = require('./../../../../utils/index')

--- a/packages/qnamaker/src/commands/qnamaker/endpointsettings/get.ts
+++ b/packages/qnamaker/src/commands/qnamaker/endpointsettings/get.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags} from '@microsoft/bf-cli-command'
 const qnamaker = require('./../../../../utils/index')
 const getEndpointJSON = require('./../../../../utils/payloads/getendpointsettings')

--- a/packages/qnamaker/src/commands/qnamaker/endpointsettings/index.ts
+++ b/packages/qnamaker/src/commands/qnamaker/endpointsettings/index.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {Command, flags} from '@microsoft/bf-cli-command'
 
 export default class QnamakerEndpointsettingsIndex extends Command {

--- a/packages/qnamaker/src/commands/qnamaker/endpointsettings/update.ts
+++ b/packages/qnamaker/src/commands/qnamaker/endpointsettings/update.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags} from '@microsoft/bf-cli-command'
 const qnamaker = require('./../../../../utils/index')
 const updateJSON = require('./../../../../utils/payloads/updateendpointsettings')

--- a/packages/qnamaker/src/commands/qnamaker/index.ts
+++ b/packages/qnamaker/src/commands/qnamaker/index.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {Command, flags} from '@microsoft/bf-cli-command'
 
 export default class QnamakerIndex extends Command {

--- a/packages/qnamaker/src/commands/qnamaker/init.ts
+++ b/packages/qnamaker/src/commands/qnamaker/init.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {Command, flags} from '@microsoft/bf-cli-command'
 import cli from 'cli-ux'
 

--- a/packages/qnamaker/src/commands/qnamaker/kb/create.ts
+++ b/packages/qnamaker/src/commands/qnamaker/kb/create.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags} from '@microsoft/bf-cli-command'
 
 const qnaconfig = require('../../../../utils/qnaconfig')

--- a/packages/qnamaker/src/commands/qnamaker/kb/delete.ts
+++ b/packages/qnamaker/src/commands/qnamaker/kb/delete.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags} from '@microsoft/bf-cli-command'
 
 const qnamaker = require('./../../../../utils/index')

--- a/packages/qnamaker/src/commands/qnamaker/kb/export.ts
+++ b/packages/qnamaker/src/commands/qnamaker/kb/export.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags} from '@microsoft/bf-cli-command'
 const qnamaker = require('./../../../../utils/index')
 const exportKbJSON = require('./../../../../utils/payloads/exportkb')

--- a/packages/qnamaker/src/commands/qnamaker/kb/get.ts
+++ b/packages/qnamaker/src/commands/qnamaker/kb/get.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags} from '@microsoft/bf-cli-command'
 
 const qnamaker = require('./../../../../utils/index')

--- a/packages/qnamaker/src/commands/qnamaker/kb/index.ts
+++ b/packages/qnamaker/src/commands/qnamaker/kb/index.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {Command, flags} from '@microsoft/bf-cli-command'
 
 export default class QnamakerKbIndex extends Command {

--- a/packages/qnamaker/src/commands/qnamaker/kb/list.ts
+++ b/packages/qnamaker/src/commands/qnamaker/kb/list.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags} from '@microsoft/bf-cli-command'
 
 const qnamaker = require('./../../../../utils/index')

--- a/packages/qnamaker/src/commands/qnamaker/kb/publish.ts
+++ b/packages/qnamaker/src/commands/qnamaker/kb/publish.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags} from '@microsoft/bf-cli-command'
 
 const qnamaker = require('./../../../../utils/index')

--- a/packages/qnamaker/src/commands/qnamaker/kb/replace.ts
+++ b/packages/qnamaker/src/commands/qnamaker/kb/replace.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags} from '@microsoft/bf-cli-command'
 
 const qnamaker = require('./../../../../utils/index')

--- a/packages/qnamaker/src/commands/qnamaker/kb/update.ts
+++ b/packages/qnamaker/src/commands/qnamaker/kb/update.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags} from '@microsoft/bf-cli-command'
 
 const qnaconfig = require('../../../../utils/qnaconfig')

--- a/packages/qnamaker/src/commands/qnamaker/operationdetails/get.ts
+++ b/packages/qnamaker/src/commands/qnamaker/operationdetails/get.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags} from '@microsoft/bf-cli-command'
 
 const qnamaker = require('./../../../../utils/index')

--- a/packages/qnamaker/src/commands/qnamaker/operationdetails/index.ts
+++ b/packages/qnamaker/src/commands/qnamaker/operationdetails/index.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {Command, flags} from '@microsoft/bf-cli-command'
 
 export default class QnamakerOperationdetailsIndex extends Command {

--- a/packages/qnamaker/src/commands/qnamaker/query.ts
+++ b/packages/qnamaker/src/commands/qnamaker/query.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags} from '@microsoft/bf-cli-command'
 const qnamaker = require('./../../../utils/index')
 const queryQuestionJSON = require('./../../../utils/payloads/queryquestion')

--- a/packages/qnamaker/src/commands/qnamaker/train.ts
+++ b/packages/qnamaker/src/commands/qnamaker/train.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError, Command, flags} from '@microsoft/bf-cli-command'
 const qnamaker = require('./../../../utils/index')
 const trainJSON = require('./../../../utils/payloads/train')

--- a/packages/qnamaker/src/index.ts
+++ b/packages/qnamaker/src/index.ts
@@ -1,1 +1,6 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 export default {}

--- a/packages/qnamaker/src/utils/qnamakerbase.ts
+++ b/packages/qnamaker/src/utils/qnamakerbase.ts
@@ -1,3 +1,8 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
 import {CLIError} from '@microsoft/bf-cli-command'
 const fs = require('fs-extra')
 const path = require('path')

--- a/packages/qnamaker/tslint.json
+++ b/packages/qnamaker/tslint.json
@@ -1,3 +1,16 @@
 {
-  "extends": "@oclif/tslint"
+  "extends": "@oclif/tslint",
+  "rules": {
+    "ordered-imports": [false],
+    "object-literal-sort-keys": [false],
+    "file-header": [
+      true,
+      {
+        "match": "Copyright \\(c\\) Microsoft Corporation\\.*",
+        "allow-single-line-comments": false,
+        "default": "Copyright (c) Microsoft Corporation. All rights reserved.\nLicensed under the MIT License.",
+        "enforce-trailing-newline": false
+      }
+    ]
+  }
 }


### PR DESCRIPTION
fix #253

- Adds license checking rule to tslint
- Fixes all checked tslint files (mostly source for cli)

Note: this fixed the issue because all the legacy JS code had licenses manually added, so only new TS code was affected. This won't, however, assert that JS code has licenses, so it's possible we'll miss it. This will be fixed in the future once we convert that code to TS.