### PR TITLE
Fixes LU library to include upgrade call in the parseFile API route

### DIFF
--- a/packages/lu/src/parser/converters/lutoluisconverter.js
+++ b/packages/lu/src/parser/converters/lutoluisconverter.js
@@ -25,7 +25,7 @@ module.exports = {
             if (haveLUISContent(finalLUISJSON)) {
                 await luisJSON.validateLUISBlob(finalLUISJSON)
             }
-            checkAndUpdateVersion(finalLUISJSON)
+            helpers.checkAndUpdateVersion(finalLUISJSON)
             return finalLUISJSON
         } catch (err) {
             throw(err)
@@ -251,34 +251,7 @@ const mergeResults_closedlists = function (blob, finalCollection, type) {
         });
     }
 }
-/**
- * Helper to detect luis schema version based on content and update the final payload as needed.
- * @param {LUIS} finalLUISJSON 
- */
-const checkAndUpdateVersion = function(finalLUISJSON) {
-    // Detect if there is content specific to 5.0.0 schema
-    // any entity with children
-    if (!finalLUISJSON) {
-        return
-    }
-    let v5DefFound = false;
-    v5DefFound = (finalLUISJSON.entities || []).find(i => i.children || i.features) ||
-                 (finalLUISJSON.intents || []).find(i => i.features) || 
-                 (finalLUISJSON.composites || []).find(i => i.features);
-    if (v5DefFound) {
-        finalLUISJSON.luis_schema_version = "6.0.0";
-        if (finalLUISJSON.model_features && finalLUISJSON.model_features.length !== 0) {
-            finalLUISJSON.phraselists = [];
-            finalLUISJSON.model_features.forEach(item => finalLUISJSON.phraselists.push(Object.assign({}, item)));
-            delete finalLUISJSON.model_features;
-        }
-        (finalLUISJSON.composites || []).forEach(composite => {
-            let children = composite.children;
-            composite.children = [];
-            children.forEach(c => composite.children.push({name : c}));
-        })
-    }
-}
+
 /**
  * Helper function to see if we have any luis content in the blob
  * @param {object} blob Contents of parsed luis blob

--- a/packages/lu/src/parser/lufile/parseFileContents.js
+++ b/packages/lu/src/parser/lufile/parseFileContents.js
@@ -171,7 +171,7 @@ const parseLuAndQnaWithAntlr = async function (parsedContent, fileContent, log, 
     // If utterances have this child, then all parents must be included in the label
     updateModelBasedOnNDepthEntities(parsedContent.LUISJsonStructure.utterances, parsedContent.LUISJsonStructure.entities);
 
-    if (parsedContent.LUISJsonStructure.flatListOfEntityAndRoles) delete parsedContent.LUISJsonStructure.flatListOfEntityAndRoles
+    helpers.checkAndUpdateVersion(parsedContent.LUISJsonStructure);
 
 }
 

--- a/packages/lu/src/parser/luisfile/parseLuisFile.js
+++ b/packages/lu/src/parser/luisfile/parseLuisFile.js
@@ -139,6 +139,7 @@ module.exports = {
 
                 // composite entity definitions must have valid child entity type definitions. 
                 composite.children.forEach(child => {
+                    if (child instanceof Object) child = child.name;
                     // Fix for #1165
                     // Current implementation does not account for explicit role included in a child
                     let childEntityName = child;

--- a/packages/lu/test/fixtures/verified/v5Upgrade.json
+++ b/packages/lu/test/fixtures/verified/v5Upgrade.json
@@ -18,7 +18,9 @@
       "name": "1",
       "children": [
         {
-          "name": "number"
+          "name": {
+            "name": "number"
+          }
         }
       ],
       "roles": []

--- a/packages/lu/test/parser/lufile/parseFileContents.modelAsFeature.test.js
+++ b/packages/lu/test/parser/lufile/parseFileContents.modelAsFeature.test.js
@@ -75,12 +75,12 @@ describe('Model as feature definitions', function () {
 
             parseFile.parseFile(luFile)
                 .then(res => {
-                    assert.equal(res.LUISJsonStructure.model_features.length, 1);
-                    assert.equal(res.LUISJsonStructure.model_features[0].name, 'city');
-                    assert.equal(res.LUISJsonStructure.model_features[0].mode, true);
-                    assert.equal(res.LUISJsonStructure.model_features[0].words, 'Seattle,SEATAC,SEA');
-                    assert.equal(res.LUISJsonStructure.model_features[0].activated, true);
-                    assert.equal(res.LUISJsonStructure.model_features[0].enabledForAllModels, false);
+                    assert.equal(res.LUISJsonStructure.phraselists.length, 1);
+                    assert.equal(res.LUISJsonStructure.phraselists[0].name, 'city');
+                    assert.equal(res.LUISJsonStructure.phraselists[0].mode, true);
+                    assert.equal(res.LUISJsonStructure.phraselists[0].words, 'Seattle,SEATAC,SEA');
+                    assert.equal(res.LUISJsonStructure.phraselists[0].activated, true);
+                    assert.equal(res.LUISJsonStructure.phraselists[0].enabledForAllModels, false);
                     assert.equal(res.LUISJsonStructure.intents.length, 1);
                     assert.equal(res.LUISJsonStructure.intents[0].name, 'getUserProfileIntent');
                     assert.equal(res.LUISJsonStructure.intents[0].features.length, 1);
@@ -107,12 +107,12 @@ describe('Model as feature definitions', function () {
 
             parseFile.parseFile(luFile)
                 .then(res => {
-                    assert.equal(res.LUISJsonStructure.model_features.length, 1);
-                    assert.equal(res.LUISJsonStructure.model_features[0].name, 'city');
-                    assert.equal(res.LUISJsonStructure.model_features[0].mode, false);
-                    assert.equal(res.LUISJsonStructure.model_features[0].words, 'Seattle,SEATAC,SEA');
-                    assert.equal(res.LUISJsonStructure.model_features[0].activated, true);
-                    assert.equal(res.LUISJsonStructure.model_features[0].enabledForAllModels, false);
+                    assert.equal(res.LUISJsonStructure.phraselists.length, 1);
+                    assert.equal(res.LUISJsonStructure.phraselists[0].name, 'city');
+                    assert.equal(res.LUISJsonStructure.phraselists[0].mode, false);
+                    assert.equal(res.LUISJsonStructure.phraselists[0].words, 'Seattle,SEATAC,SEA');
+                    assert.equal(res.LUISJsonStructure.phraselists[0].activated, true);
+                    assert.equal(res.LUISJsonStructure.phraselists[0].enabledForAllModels, false);
                     assert.equal(res.LUISJsonStructure.intents.length, 1);
                     assert.equal(res.LUISJsonStructure.intents[0].name, 'getUserProfileIntent');
                     assert.equal(res.LUISJsonStructure.intents[0].features.length, 1);
@@ -143,17 +143,17 @@ describe('Model as feature definitions', function () {
 
             parseFile.parseFile(luFile)
                 .then(res => {
-                    assert.equal(res.LUISJsonStructure.model_features.length, 2);
-                    assert.equal(res.LUISJsonStructure.model_features[0].name, 'city');
-                    assert.equal(res.LUISJsonStructure.model_features[0].mode, false);
-                    assert.equal(res.LUISJsonStructure.model_features[0].words, 'Seattle,SEATAC,SEA');
-                    assert.equal(res.LUISJsonStructure.model_features[0].activated, true);
-                    assert.equal(res.LUISJsonStructure.model_features[0].enabledForAllModels, false);
-                    assert.equal(res.LUISJsonStructure.model_features[1].name, 'city2');
-                    assert.equal(res.LUISJsonStructure.model_features[1].mode, true);
-                    assert.equal(res.LUISJsonStructure.model_features[1].words, 'portland,PDX');
-                    assert.equal(res.LUISJsonStructure.model_features[1].activated, true);
-                    assert.equal(res.LUISJsonStructure.model_features[1].enabledForAllModels, false);
+                    assert.equal(res.LUISJsonStructure.phraselists.length, 2);
+                    assert.equal(res.LUISJsonStructure.phraselists[0].name, 'city');
+                    assert.equal(res.LUISJsonStructure.phraselists[0].mode, false);
+                    assert.equal(res.LUISJsonStructure.phraselists[0].words, 'Seattle,SEATAC,SEA');
+                    assert.equal(res.LUISJsonStructure.phraselists[0].activated, true);
+                    assert.equal(res.LUISJsonStructure.phraselists[0].enabledForAllModels, false);
+                    assert.equal(res.LUISJsonStructure.phraselists[1].name, 'city2');
+                    assert.equal(res.LUISJsonStructure.phraselists[1].mode, true);
+                    assert.equal(res.LUISJsonStructure.phraselists[1].words, 'portland,PDX');
+                    assert.equal(res.LUISJsonStructure.phraselists[1].activated, true);
+                    assert.equal(res.LUISJsonStructure.phraselists[1].enabledForAllModels, false);
                     assert.equal(res.LUISJsonStructure.intents.length, 1);
                     assert.equal(res.LUISJsonStructure.intents[0].name, 'getUserProfileIntent');
                     assert.equal(res.LUISJsonStructure.intents[0].features.length, 2);
@@ -210,17 +210,17 @@ describe('Model as feature definitions', function () {
                         assert.equal(res.LUISJsonStructure.entities[0].name, 'x1');
                         assert.equal(res.LUISJsonStructure.entities[0].features.length, 1);
                         assert.equal(res.LUISJsonStructure.entities[0].features[0].featureName, 'city');
-                        assert.equal(res.LUISJsonStructure.model_features.length, 2);
-                        assert.equal(res.LUISJsonStructure.model_features[0].name, 'city');
-                        assert.equal(res.LUISJsonStructure.model_features[0].mode, false);
-                        assert.equal(res.LUISJsonStructure.model_features[0].words, 'Seattle,SEATAC,SEA');
-                        assert.equal(res.LUISJsonStructure.model_features[0].activated, true);
-                        assert.equal(res.LUISJsonStructure.model_features[0].enabledForAllModels, false);
-                        assert.equal(res.LUISJsonStructure.model_features[1].name, 'city2');
-                        assert.equal(res.LUISJsonStructure.model_features[1].mode, true);
-                        assert.equal(res.LUISJsonStructure.model_features[1].words, 'portland,PDX');
-                        assert.equal(res.LUISJsonStructure.model_features[1].activated, true);
-                        assert.equal(res.LUISJsonStructure.model_features[1].enabledForAllModels, undefined);
+                        assert.equal(res.LUISJsonStructure.phraselists.length, 2);
+                        assert.equal(res.LUISJsonStructure.phraselists[0].name, 'city');
+                        assert.equal(res.LUISJsonStructure.phraselists[0].mode, false);
+                        assert.equal(res.LUISJsonStructure.phraselists[0].words, 'Seattle,SEATAC,SEA');
+                        assert.equal(res.LUISJsonStructure.phraselists[0].activated, true);
+                        assert.equal(res.LUISJsonStructure.phraselists[0].enabledForAllModels, false);
+                        assert.equal(res.LUISJsonStructure.phraselists[1].name, 'city2');
+                        assert.equal(res.LUISJsonStructure.phraselists[1].mode, true);
+                        assert.equal(res.LUISJsonStructure.phraselists[1].words, 'portland,PDX');
+                        assert.equal(res.LUISJsonStructure.phraselists[1].activated, true);
+                        assert.equal(res.LUISJsonStructure.phraselists[1].enabledForAllModels, undefined);
                         done();
                     })
                     .catch(err => done(err))
@@ -249,17 +249,17 @@ describe('Model as feature definitions', function () {
                         assert.equal(res.LUISJsonStructure.entities[0].features.length, 2);
                         assert.equal(res.LUISJsonStructure.entities[0].features[0].featureName, 'city');
                         assert.equal(res.LUISJsonStructure.entities[0].features[1].featureName, 'city2');
-                        assert.equal(res.LUISJsonStructure.model_features.length, 2);
-                        assert.equal(res.LUISJsonStructure.model_features[0].name, 'city');
-                        assert.equal(res.LUISJsonStructure.model_features[0].mode, false);
-                        assert.equal(res.LUISJsonStructure.model_features[0].words, 'Seattle,SEATAC,SEA');
-                        assert.equal(res.LUISJsonStructure.model_features[0].activated, true);
-                        assert.equal(res.LUISJsonStructure.model_features[0].enabledForAllModels, false);
-                        assert.equal(res.LUISJsonStructure.model_features[1].name, 'city2');
-                        assert.equal(res.LUISJsonStructure.model_features[1].mode, true);
-                        assert.equal(res.LUISJsonStructure.model_features[1].words, 'portland,PDX');
-                        assert.equal(res.LUISJsonStructure.model_features[1].activated, true);
-                        assert.equal(res.LUISJsonStructure.model_features[1].enabledForAllModels, false);
+                        assert.equal(res.LUISJsonStructure.phraselists.length, 2);
+                        assert.equal(res.LUISJsonStructure.phraselists[0].name, 'city');
+                        assert.equal(res.LUISJsonStructure.phraselists[0].mode, false);
+                        assert.equal(res.LUISJsonStructure.phraselists[0].words, 'Seattle,SEATAC,SEA');
+                        assert.equal(res.LUISJsonStructure.phraselists[0].activated, true);
+                        assert.equal(res.LUISJsonStructure.phraselists[0].enabledForAllModels, false);
+                        assert.equal(res.LUISJsonStructure.phraselists[1].name, 'city2');
+                        assert.equal(res.LUISJsonStructure.phraselists[1].mode, true);
+                        assert.equal(res.LUISJsonStructure.phraselists[1].words, 'portland,PDX');
+                        assert.equal(res.LUISJsonStructure.phraselists[1].activated, true);
+                        assert.equal(res.LUISJsonStructure.phraselists[1].enabledForAllModels, false);
                         done();
                     })
                     .catch(err => done(err))
@@ -289,17 +289,17 @@ describe('Model as feature definitions', function () {
                         assert.equal(res.LUISJsonStructure.entities[0].features[0].featureName, 'city');
                         assert.equal(res.LUISJsonStructure.entities[0].roles.length, 1);
                         assert.deepEqual(res.LUISJsonStructure.entities[0].roles, ['r1']);
-                        assert.equal(res.LUISJsonStructure.model_features.length, 2);
-                        assert.equal(res.LUISJsonStructure.model_features[0].name, 'city');
-                        assert.equal(res.LUISJsonStructure.model_features[0].mode, false);
-                        assert.equal(res.LUISJsonStructure.model_features[0].words, 'Seattle,SEATAC,SEA');
-                        assert.equal(res.LUISJsonStructure.model_features[0].activated, true);
-                        assert.equal(res.LUISJsonStructure.model_features[0].enabledForAllModels, false);
-                        assert.equal(res.LUISJsonStructure.model_features[1].name, 'city2');
-                        assert.equal(res.LUISJsonStructure.model_features[1].mode, true);
-                        assert.equal(res.LUISJsonStructure.model_features[1].words, 'portland,PDX');
-                        assert.equal(res.LUISJsonStructure.model_features[1].activated, true);
-                        assert.equal(res.LUISJsonStructure.model_features[1].enabledForAllModels, undefined);
+                        assert.equal(res.LUISJsonStructure.phraselists.length, 2);
+                        assert.equal(res.LUISJsonStructure.phraselists[0].name, 'city');
+                        assert.equal(res.LUISJsonStructure.phraselists[0].mode, false);
+                        assert.equal(res.LUISJsonStructure.phraselists[0].words, 'Seattle,SEATAC,SEA');
+                        assert.equal(res.LUISJsonStructure.phraselists[0].activated, true);
+                        assert.equal(res.LUISJsonStructure.phraselists[0].enabledForAllModels, false);
+                        assert.equal(res.LUISJsonStructure.phraselists[1].name, 'city2');
+                        assert.equal(res.LUISJsonStructure.phraselists[1].mode, true);
+                        assert.equal(res.LUISJsonStructure.phraselists[1].words, 'portland,PDX');
+                        assert.equal(res.LUISJsonStructure.phraselists[1].activated, true);
+                        assert.equal(res.LUISJsonStructure.phraselists[1].enabledForAllModels, undefined);
                         done();
                     })
                     .catch(err => done(err))
@@ -330,17 +330,17 @@ describe('Model as feature definitions', function () {
                         assert.equal(res.LUISJsonStructure.entities[0].features[1].featureName, 'city2');
                         assert.equal(res.LUISJsonStructure.entities[0].roles.length, 2);
                         assert.deepEqual(res.LUISJsonStructure.entities[0].roles, ['r1', 'r2']);
-                        assert.equal(res.LUISJsonStructure.model_features.length, 2);
-                        assert.equal(res.LUISJsonStructure.model_features[0].name, 'city');
-                        assert.equal(res.LUISJsonStructure.model_features[0].mode, false);
-                        assert.equal(res.LUISJsonStructure.model_features[0].words, 'Seattle,SEATAC,SEA');
-                        assert.equal(res.LUISJsonStructure.model_features[0].activated, true);
-                        assert.equal(res.LUISJsonStructure.model_features[0].enabledForAllModels, false);
-                        assert.equal(res.LUISJsonStructure.model_features[1].name, 'city2');
-                        assert.equal(res.LUISJsonStructure.model_features[1].mode, true);
-                        assert.equal(res.LUISJsonStructure.model_features[1].words, 'portland,PDX');
-                        assert.equal(res.LUISJsonStructure.model_features[1].activated, true);
-                        assert.equal(res.LUISJsonStructure.model_features[1].enabledForAllModels, false);
+                        assert.equal(res.LUISJsonStructure.phraselists.length, 2);
+                        assert.equal(res.LUISJsonStructure.phraselists[0].name, 'city');
+                        assert.equal(res.LUISJsonStructure.phraselists[0].mode, false);
+                        assert.equal(res.LUISJsonStructure.phraselists[0].words, 'Seattle,SEATAC,SEA');
+                        assert.equal(res.LUISJsonStructure.phraselists[0].activated, true);
+                        assert.equal(res.LUISJsonStructure.phraselists[0].enabledForAllModels, false);
+                        assert.equal(res.LUISJsonStructure.phraselists[1].name, 'city2');
+                        assert.equal(res.LUISJsonStructure.phraselists[1].mode, true);
+                        assert.equal(res.LUISJsonStructure.phraselists[1].words, 'portland,PDX');
+                        assert.equal(res.LUISJsonStructure.phraselists[1].activated, true);
+                        assert.equal(res.LUISJsonStructure.phraselists[1].enabledForAllModels, false);
                         done();
                     })
                     .catch(err => done(err))
@@ -454,17 +454,17 @@ describe('Model as feature definitions', function () {
                         assert.equal(res.LUISJsonStructure.composites[0].name, 'x1');
                         assert.equal(res.LUISJsonStructure.composites[0].features.length, 1);
                         assert.equal(res.LUISJsonStructure.composites[0].features[0].featureName, 'city');
-                        assert.equal(res.LUISJsonStructure.model_features.length, 2);
-                        assert.equal(res.LUISJsonStructure.model_features[0].name, 'city');
-                        assert.equal(res.LUISJsonStructure.model_features[0].mode, false);
-                        assert.equal(res.LUISJsonStructure.model_features[0].words, 'Seattle,SEATAC,SEA');
-                        assert.equal(res.LUISJsonStructure.model_features[0].activated, true);
-                        assert.equal(res.LUISJsonStructure.model_features[0].enabledForAllModels, false);
-                        assert.equal(res.LUISJsonStructure.model_features[1].name, 'city2');
-                        assert.equal(res.LUISJsonStructure.model_features[1].mode, true);
-                        assert.equal(res.LUISJsonStructure.model_features[1].words, 'portland,PDX');
-                        assert.equal(res.LUISJsonStructure.model_features[1].activated, true);
-                        assert.equal(res.LUISJsonStructure.model_features[1].enabledForAllModels, undefined);
+                        assert.equal(res.LUISJsonStructure.phraselists.length, 2);
+                        assert.equal(res.LUISJsonStructure.phraselists[0].name, 'city');
+                        assert.equal(res.LUISJsonStructure.phraselists[0].mode, false);
+                        assert.equal(res.LUISJsonStructure.phraselists[0].words, 'Seattle,SEATAC,SEA');
+                        assert.equal(res.LUISJsonStructure.phraselists[0].activated, true);
+                        assert.equal(res.LUISJsonStructure.phraselists[0].enabledForAllModels, false);
+                        assert.equal(res.LUISJsonStructure.phraselists[1].name, 'city2');
+                        assert.equal(res.LUISJsonStructure.phraselists[1].mode, true);
+                        assert.equal(res.LUISJsonStructure.phraselists[1].words, 'portland,PDX');
+                        assert.equal(res.LUISJsonStructure.phraselists[1].activated, true);
+                        assert.equal(res.LUISJsonStructure.phraselists[1].enabledForAllModels, undefined);
                         done();
                     })
                     .catch(err => done(err))
@@ -495,17 +495,17 @@ describe('Model as feature definitions', function () {
                         assert.equal(res.LUISJsonStructure.composites[0].features.length, 2);
                         assert.equal(res.LUISJsonStructure.composites[0].features[0].featureName, 'city');
                         assert.equal(res.LUISJsonStructure.composites[0].features[1].featureName, 'city2');
-                        assert.equal(res.LUISJsonStructure.model_features.length, 2);
-                        assert.equal(res.LUISJsonStructure.model_features[0].name, 'city');
-                        assert.equal(res.LUISJsonStructure.model_features[0].mode, false);
-                        assert.equal(res.LUISJsonStructure.model_features[0].words, 'Seattle,SEATAC,SEA');
-                        assert.equal(res.LUISJsonStructure.model_features[0].activated, true);
-                        assert.equal(res.LUISJsonStructure.model_features[0].enabledForAllModels, false);
-                        assert.equal(res.LUISJsonStructure.model_features[1].name, 'city2');
-                        assert.equal(res.LUISJsonStructure.model_features[1].mode, true);
-                        assert.equal(res.LUISJsonStructure.model_features[1].words, 'portland,PDX');
-                        assert.equal(res.LUISJsonStructure.model_features[1].activated, true);
-                        assert.equal(res.LUISJsonStructure.model_features[1].enabledForAllModels, false);
+                        assert.equal(res.LUISJsonStructure.phraselists.length, 2);
+                        assert.equal(res.LUISJsonStructure.phraselists[0].name, 'city');
+                        assert.equal(res.LUISJsonStructure.phraselists[0].mode, false);
+                        assert.equal(res.LUISJsonStructure.phraselists[0].words, 'Seattle,SEATAC,SEA');
+                        assert.equal(res.LUISJsonStructure.phraselists[0].activated, true);
+                        assert.equal(res.LUISJsonStructure.phraselists[0].enabledForAllModels, false);
+                        assert.equal(res.LUISJsonStructure.phraselists[1].name, 'city2');
+                        assert.equal(res.LUISJsonStructure.phraselists[1].mode, true);
+                        assert.equal(res.LUISJsonStructure.phraselists[1].words, 'portland,PDX');
+                        assert.equal(res.LUISJsonStructure.phraselists[1].activated, true);
+                        assert.equal(res.LUISJsonStructure.phraselists[1].enabledForAllModels, false);
                         done();
                     })
                     .catch(err => done(err))

--- a/packages/lu/test/parser/lufile/parseFileContents.nDepthEntity.test.js
+++ b/packages/lu/test/parser/lufile/parseFileContents.nDepthEntity.test.js
@@ -641,8 +641,8 @@ describe('V2 NDepth definitions using @ notation', function () {
                 assert.equal(res.LUISJsonStructure.entities[0].children.length, 1);
                 assert.equal(res.LUISJsonStructure.entities[0].children[0].name, "x1");
                 assert.deepEqual(res.LUISJsonStructure.entities[0].children[0].features, [new helperclasses.featureToModel('pl1', "phraselist")]);
-                assert.equal(res.LUISJsonStructure.model_features.length, 1);
-                assert.equal(res.LUISJsonStructure.model_features[0].name, 'pl1');
+                assert.equal(res.LUISJsonStructure.phraselists.length, 1);
+                assert.equal(res.LUISJsonStructure.phraselists[0].name, 'pl1');
                 done();
             })
             .catch(err => done(err))
@@ -662,8 +662,8 @@ describe('V2 NDepth definitions using @ notation', function () {
                 assert.equal(res.LUISJsonStructure.entities[0].children.length, 1);
                 assert.equal(res.LUISJsonStructure.entities[0].children[0].name, "x1");
                 assert.deepEqual(res.LUISJsonStructure.entities[0].children[0].features, [new helperclasses.featureToModel('pl1', "phraselist"), new helperclasses.modelToFeature('s1', "Entity Extractor"), new helperclasses.modelToFeature('number', "Prebuilt Entity Extractor")]);
-                assert.equal(res.LUISJsonStructure.model_features.length, 1);
-                assert.equal(res.LUISJsonStructure.model_features[0].name, 'pl1');
+                assert.equal(res.LUISJsonStructure.phraselists.length, 1);
+                assert.equal(res.LUISJsonStructure.phraselists[0].name, 'pl1');
                 assert.equal(res.LUISJsonStructure.prebuiltEntities.length, 1);
                 assert.equal(res.LUISJsonStructure.prebuiltEntities[0].name, "number");
                 done();


### PR DESCRIPTION
Issue: 
- LUIS schema version 6.0.0 introduces changes to the schema which was previously handled only at the CLI route
- This PR moves that code over to helpers so the parseFile API also does this version upgrade check.
- Updated existing tests. 