### PR TITLE
Adding luis:application:create cmd and tests / refactor utils and clo…

### DIFF
--- a/packages/luis/src/commands/luis/application/create.ts
+++ b/packages/luis/src/commands/luis/application/create.ts
@@ -1,0 +1,62 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {CLIError, Command, flags} from '@microsoft/bf-cli-command'
+
+const utils = require('../../../utils/index')
+
+export default class LuisApplicationCreate extends Command {
+  static description = 'Creates a new LUIS application'
+
+  static examples = [`
+    $ bf luis:version:clone --endpoint {ENDPOINT} --subscriptionKey {SUBSCRIPTION_KEY} --name {NAME} --culture {CULTURE}
+    --domain {DOMAIN} --description {DESCRIPTION} --initialVersionId {INITIAL_VERSION_ID} --usageScenario {USAGE_SCENARIO}
+  `]
+
+  static flags = {
+    help: flags.help({char: 'h'}),
+    endpoint: flags.string({description: 'LUIS endpoint hostname'}),
+    subscriptionKey: flags.string({description: 'LUIS cognitive services subscription key (aka Ocp-Apim-Subscription-Key)'}),
+    name: flags.string({description: 'LUIS application name'}),
+    culture: flags.string({description: 'LUIS application culture'}),
+    domain: flags.string({description: 'LUIS application domain'}),
+    description: flags.string({description: 'LUIS application description'}),
+    initialVersionId: flags.string({description: 'LUIS application initial version Id'}),
+    usageScenario: flags.string({description: 'LUIS application usage scenario'}),
+  }
+
+  async run() {
+    const {flags} = this.parse(LuisApplicationCreate)
+    const flagLabels = Object.keys(LuisApplicationCreate.flags)
+    const configDir = this.config.configDir
+    const configPrefix = 'luis__'
+
+    const {
+      endpoint,
+      subscriptionKey,
+      name,
+      culture,
+      domain,
+      description,
+      initialVersionId,
+      usageScenario
+    } = await utils.processInputs(flags, flagLabels, configDir, configPrefix)
+
+    const requiredProps = {endpoint, subscriptionKey, name, domain}
+    utils.validateRequiredProps(requiredProps)
+
+    const client = utils.getLUISClient(subscriptionKey, endpoint)
+    const options = {}
+
+    const applicationCreateObject = {name, culture, domain, description, initialVersionId, usageScenario}
+
+    try {
+      const newAppId = await client.apps.add(applicationCreateObject, options)
+      this.log(`App successfully created with id ${newAppId}.`)
+    } catch (err) {
+      throw new CLIError(`Failed to create app: ${err}`)
+    }
+  }
+}

--- a/packages/luis/src/commands/luis/application/create.ts
+++ b/packages/luis/src/commands/luis/application/create.ts
@@ -11,7 +11,7 @@ export default class LuisApplicationCreate extends Command {
   static description = 'Creates a new LUIS application'
 
   static examples = [`
-    $ bf luis:version:clone --endpoint {ENDPOINT} --subscriptionKey {SUBSCRIPTION_KEY} --name {NAME} --culture {CULTURE}
+    $ bf luis:application:create --endpoint {ENDPOINT} --subscriptionKey {SUBSCRIPTION_KEY} --name {NAME} --culture {CULTURE}
     --domain {DOMAIN} --description {DESCRIPTION} --initialVersionId {INITIAL_VERSION_ID} --usageScenario {USAGE_SCENARIO}
   `]
 

--- a/packages/luis/src/commands/luis/application/create.ts
+++ b/packages/luis/src/commands/luis/application/create.ts
@@ -31,7 +31,6 @@ export default class LuisApplicationCreate extends Command {
     const {flags} = this.parse(LuisApplicationCreate)
     const flagLabels = Object.keys(LuisApplicationCreate.flags)
     const configDir = this.config.configDir
-    const configPrefix = 'luis__'
 
     const {
       endpoint,
@@ -42,7 +41,7 @@ export default class LuisApplicationCreate extends Command {
       description,
       initialVersionId,
       usageScenario
-    } = await utils.processInputs(flags, flagLabels, configDir, configPrefix)
+    } = await utils.processInputs(flags, flagLabels, configDir)
 
     const requiredProps = {endpoint, subscriptionKey, name, domain}
     utils.validateRequiredProps(requiredProps)

--- a/packages/luis/src/commands/luis/version/clone.ts
+++ b/packages/luis/src/commands/luis/version/clone.ts
@@ -25,10 +25,11 @@ export default class LuisVersionClone extends Command {
 
   async run() {
     const {flags} = this.parse(LuisVersionClone)
+    const flagLabels = Object.keys(LuisVersionClone.flags)
     const configDir = this.config.configDir
     const configPrefix = 'luis__'
 
-    const {appId, endpoint, subscriptionKey, versionId, targetVersionId} = await utils.processInputs(flags, configDir, configPrefix)
+    const {appId, endpoint, subscriptionKey, versionId, targetVersionId} = await utils.processInputs(flags, flagLabels, configDir, configPrefix)
 
     const requiredProps = {appId, endpoint, subscriptionKey, versionId, targetVersionId}
     utils.validateRequiredProps(requiredProps)

--- a/packages/luis/src/commands/luis/version/clone.ts
+++ b/packages/luis/src/commands/luis/version/clone.ts
@@ -27,9 +27,8 @@ export default class LuisVersionClone extends Command {
     const {flags} = this.parse(LuisVersionClone)
     const flagLabels = Object.keys(LuisVersionClone.flags)
     const configDir = this.config.configDir
-    const configPrefix = 'luis__'
 
-    const {appId, endpoint, subscriptionKey, versionId, targetVersionId} = await utils.processInputs(flags, flagLabels, configDir, configPrefix)
+    const {appId, endpoint, subscriptionKey, versionId, targetVersionId} = await utils.processInputs(flags, flagLabels, configDir)
 
     const requiredProps = {appId, endpoint, subscriptionKey, versionId, targetVersionId}
     utils.validateRequiredProps(requiredProps)

--- a/packages/luis/src/utils/index.ts
+++ b/packages/luis/src/utils/index.ts
@@ -50,7 +50,7 @@ const processInputs = async (flags: any, flagLabels: string[], configDir: string
   flagLabels
     .filter(flag => flag !== 'help')
     .map((flag: string) => {
-      input[flag] = flags[flag] || (config ? config[`luis__${flag}`] : null)
+      input[flag] = flags[flag] || (config ? config[prefix + flag] : null)
     })
 
   return input

--- a/packages/luis/src/utils/index.ts
+++ b/packages/luis/src/utils/index.ts
@@ -43,14 +43,15 @@ const getPropFromConfig = async (prop: string, configDir: string) => {
   }
 }
 
-const processInputs = async (flags: any, flagLabels: string[], configDir: string, prefix: string) => {
+const processInputs = async (flags: any, flagLabels: string[], configDir: string) => {
+  const configPrefix = 'luis__'
   let config = await getUserConfig(configDir)
-  config = config ? filterConfig(config, prefix) : config
+  config = config ? filterConfig(config, configPrefix) : config
   const input: any = {}
   flagLabels
     .filter(flag => flag !== 'help')
     .map((flag: string) => {
-      input[flag] = flags[flag] || (config ? config[prefix + flag] : null)
+      input[flag] = flags[flag] || (config ? config[configPrefix + flag] : null)
     })
 
   return input

--- a/packages/luis/src/utils/index.ts
+++ b/packages/luis/src/utils/index.ts
@@ -43,16 +43,16 @@ const getPropFromConfig = async (prop: string, configDir: string) => {
   }
 }
 
-const processInputs = async (flags: any, configDir: string, prefix: string) => {
+const processInputs = async (flags: any, flagLabels: string[], configDir: string, prefix: string) => {
   let config = await getUserConfig(configDir)
   config = config ? filterConfig(config, prefix) : config
-  const input = {
-    appId: flags.appId || (config ? config.luis__appId : null),
-    endpoint: flags.endpoint || (config ? config.luis__endpoint : null),
-    subscriptionKey: flags.subscriptionKey || (config ? config.luis__subscriptionKey : null),
-    versionId: flags.versionId || (config ? config.luis__versionId : null),
-    targetVersionId: flags.targetVersionId || (config ? config.luis__targetVersionId : null)
-  }
+  const input: any = {}
+  flagLabels
+    .filter(flag => flag !== 'help')
+    .map((flag: string) => {
+      input[flag] = flags[flag] || (config ? config[`luis__${flag}`] : null)
+    })
+
   return input
 }
 

--- a/packages/luis/test/commands/luis/application/create.test.ts
+++ b/packages/luis/test/commands/luis/application/create.test.ts
@@ -1,0 +1,62 @@
+import {expect, test} from '@oclif/test'
+const sinon = require('sinon')
+const uuidv1 = require('uuid/v1')
+const utils = require('../../../../src/utils/index')
+
+describe('luis:application:create', () => {
+
+  before(() => {
+    const newAppId = uuidv1()
+  })
+
+  beforeEach(() => {
+    sinon.stub(utils, 'processInputs').returnsArg(0)
+  })
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  test
+  .stdout()
+  .command(['luis:application:create', '--help'])
+  .it('should print the help contents when --help is passed as an argument', ctx => {
+    expect(ctx.stdout).to.contain('Creates a new LUIS application')
+  })
+
+  test
+  .stdout()
+  .stderr()
+  .command(['luis:application:create', '--endpoint', 'https://westus.api.cognitive.microsoft.com', '--subscriptionKey', uuidv1(), '--culture', 'en-us', '--domain', 'Comics', '--description', 'test description', '--initialVersionId', '0.04', '--usageScenario', 'For use in our test app'])
+  .it('displays an error if any required input parameters are missing', ctx => {
+    expect(ctx.stderr).to.contain(`Required input property 'name' missing.`)
+  })
+
+  test
+  .stdout()
+  .stderr()
+  .command(['luis:application:create', '--endpoint', 'https://westus.api.cognitive.microsoft.com', '--name', 'orange_app', '--culture', 'en-us', '--domain', 'Comics', '--description', 'test description', '--initialVersionId', '0.04', '--usageScenario', 'For use in our test app'])
+  .it('displays an error if any required input parameters are missing', ctx => {
+    expect(ctx.stderr).to.contain(`Required input property 'subscriptionKey' missing.`)
+  })
+
+  test
+  .nock('https://westus.api.cognitive.microsoft.com', api => api
+  .post(uri => uri.includes('apps'))
+  .reply(201, '99999')
+  )
+  .stdout()
+  .command(['luis:application:create', '--endpoint', 'https://westus.api.cognitive.microsoft.com', '--name', 'orange_app', '--subscriptionKey', uuidv1(), '--culture', 'en-us', '--domain', 'Comics', '--description', 'test description', '--initialVersionId', '0.04', '--usageScenario', 'For use in our test app'])
+  .it('creates a luis app and returns the new app\'s id', ctx => {
+    expect(ctx.stdout).to.contain('App successfully created with id 99999')
+  })
+
+  test
+  .stdout()
+  .stderr()
+  .command(['luis:application:create', '--endpoint', 'undefined', '--name', 'orange_app', '--subscriptionKey', uuidv1(), '--culture', 'en-us', '--domain', 'Comics', '--description', 'test description', '--initialVersionId', '0.04', '--usageScenario', 'For use in our test app'])
+  .it('fails to create an app and displays an error message if the endpoint is null', ctx => {
+    expect(ctx.stderr).to.contain('Access denied due to invalid subscription key or wrong API endpoint.')
+  })
+
+})

--- a/packages/luis/test/commands/luis/version/clone.test.ts
+++ b/packages/luis/test/commands/luis/version/clone.test.ts
@@ -23,7 +23,7 @@ describe('luis:version:clone', () => {
   test
   .stdout()
   .stderr()
-  .command(['luis:version:clone', '--versionId', '0.1', '--targetVersionId', '0.2', '--subscriptionKey', uuidv1(), '--endpoint', 'https://westus.api.cognitive.microsoft.com/luis/authoring/v3.0-preview/'])
+  .command(['luis:version:clone', '--versionId', '0.1', '--targetVersionId', '0.2', '--subscriptionKey', uuidv1(), '--endpoint', 'https://westus.api.cognitive.microsoft.com'])
   .it('displays an error if any required input parameters are missing', ctx => {
     expect(ctx.stderr).to.contain(`Required input property 'appId' missing.`)
   })
@@ -31,7 +31,7 @@ describe('luis:version:clone', () => {
   test
   .stdout()
   .stderr()
-  .command(['luis:version:clone', '--appId', uuidv1(), '--versionId', '0.1', '--targetVersionId', '0.2', '--endpoint', 'https://westus.api.cognitive.microsoft.com/luis/authoring/v3.0-preview/'])
+  .command(['luis:version:clone', '--appId', uuidv1(), '--versionId', '0.1', '--targetVersionId', '0.2', '--endpoint', 'https://westus.api.cognitive.microsoft.com'])
   .it('displays an error if any required input parameters are missing', ctx => {
     expect(ctx.stderr).to.contain(`Required input property 'subscriptionKey' missing.`)
   })
@@ -42,7 +42,7 @@ describe('luis:version:clone', () => {
   .reply(201, '0.2')
   )
   .stdout()
-  .command(['luis:version:clone', '--appId', uuidv1(), '--versionId', '0.1', '--targetVersionId', '0.2', '--subscriptionKey', uuidv1(), '--endpoint', 'https://westus.api.cognitive.microsoft.com/luis/authoring/v3.0-preview/'])
+  .command(['luis:version:clone', '--appId', uuidv1(), '--versionId', '0.1', '--targetVersionId', '0.2', '--subscriptionKey', uuidv1(), '--endpoint', 'https://westus.api.cognitive.microsoft.com'])
   .it('clones a luis app and returns the new version number', ctx => {
     expect(ctx.stdout).to.contain('App successfully cloned.')
   })


### PR DESCRIPTION
- create 'luis:application:create' cmd and tests
- refactor of utils to make input processing more generic
- update clone cmd to support utils refactor