### PR TITLE
Fix LU parser to handle pattern.any any definitions added by prebuilt domain import

### DIFF
--- a/packages/lu/src/parser/lufile/parseFileContents.js
+++ b/packages/lu/src/parser/lufile/parseFileContents.js
@@ -1267,7 +1267,7 @@ const RemoveDuplicatePatternAnyEntity = function(parsedContent, pEntityName, ent
             return false;
         }
     });
-    if (PAEntityFound !== undefined && PAIdx !== -1) {
+    if (PAEntityFound !== undefined && PAIdx !== -1 && entityType != EntityTypeEnum.PATTERNANY) {
         if (entityType.toLowerCase().trim().includes('phraselist')) {
             let errorMsg = `Phrase lists cannot be used as an entity in a pattern "${pEntityName}"`;
             let error = BuildDiagnostic({
@@ -1762,7 +1762,7 @@ const parseAndHandleModelInfoSection = function (parsedContent, luResource, log)
     if (modelInfos && modelInfos.length > 0) {
         for (const modelInfo of modelInfos) {
             let line = modelInfo.ModelInfo
-            let kvPair = line.split(/@(app|kb|intent|entity|enableMergeIntents).(.*)=/g).map(item => item.trim());
+            let kvPair = line.split(/@(app|kb|intent|entity|enableMergeIntents|patternAnyEntity).(.*)=/g).map(item => item.trim());
             if (kvPair.length === 4) {
                 if (kvPair[1] === 'enableMergeIntents' && kvPair[3] === 'false') {
                     enableMergeIntents = false;
@@ -1831,6 +1831,31 @@ const parseAndHandleModelInfoSection = function (parsedContent, luResource, log)
                                 newEntity['inherits'][inheritsProperties[2]] = inheritsProperties[3];
                                 newEntity['inherits'][inheritsProperties[4]] = inheritsProperties[5];
                                 parsedContent.LUISJsonStructure.entities.push(newEntity);
+                            } else {
+                                if (entity['inherits'] === undefined) entity['inherits'] = {};
+                                entity['inherits'][inheritsProperties[2]] = inheritsProperties[3];
+                                entity['inherits'][inheritsProperties[4]] = inheritsProperties[5];
+                            }
+                        }
+                    } else {
+                        if (log) {
+                            process.stdout.write(chalk.default.yellowBright('[WARN]: Invalid entity inherits information found. Skipping "' + line + '"\n'));
+                        }
+                    }
+                } else if (kvPair[1].toLowerCase() === 'patternanyentity') {
+                    if (kvPair[2].toLowerCase() === 'inherits') {
+                        let inheritsProperties = kvPair[3].split(/[:;]/g).map(item => item.trim());
+                        if (inheritsProperties.length !== 6) {
+                            process.stdout.write(chalk.default.yellowBright('[WARN]: Invalid Pattern.Any inherits information found. Skipping "' + line + '"\n'));
+                        } else {
+                            // find the intent
+                            let entity = parsedContent.LUISJsonStructure.patternAnyEntities.find(item => item.name == inheritsProperties[1]);
+                            if (entity === undefined) {
+                                let newEntity = new helperClass.patternAnyEntity(inheritsProperties[1]);
+                                newEntity.inherits = {};
+                                newEntity['inherits'][inheritsProperties[2]] = inheritsProperties[3];
+                                newEntity['inherits'][inheritsProperties[4]] = inheritsProperties[5];
+                                parsedContent.LUISJsonStructure.patternAnyEntities.push(newEntity);
                             } else {
                                 if (entity['inherits'] === undefined) entity['inherits'] = {};
                                 entity['inherits'][inheritsProperties[2]] = inheritsProperties[3];

--- a/packages/lu/src/parser/luis/luConverter.js
+++ b/packages/lu/src/parser/luis/luConverter.js
@@ -28,6 +28,7 @@ const luisToLuContent = function(luisJSON){
     fileContent += parseToLuClosedLists(luisJSON)
     fileContent += parseRegExEntitiesToLu(luisJSON)
     fileContent += parseCompositesToLu(luisJSON)
+    fileContent += parsePatternAnyEntitiesToLu(luisJSON)
     return fileContent
 }
 
@@ -211,6 +212,33 @@ const parseCompositesToLu = function(luisJson){
         fileContent += NEWLINE;
     })
     return fileContent
+}
+
+const parsePatternAnyEntitiesToLu = function(luisJson){
+    let fileContent = ''
+    if(!luisJson.patternAnyEntities || luisJson.patternAnyEntities.length <= 0) {
+        return fileContent;
+    }
+    luisJson.patternAnyEntities.forEach(patternAnyEntity => {
+        // Add inherits information if any
+        if (patternAnyEntity.inherits !== undefined) {
+            fileContent += '> # Pattern.Any entities' + NEWLINE + NEWLINE;
+            // > !# @intent.inherits = {name = Web.WebSearch; domain_name = Web; model_name = WebSearch}
+            fileContent += '> !# @patternAnyEntity.inherits = name : ' + patternAnyEntity.name;
+            if (patternAnyEntity.inherits.domain_name !== undefined) {
+                fileContent += '; domain_name : ' + patternAnyEntity.inherits.domain_name;
+            }
+            if (patternAnyEntity.inherits.model_name !== undefined) {
+                fileContent += '; model_name : ' + patternAnyEntity.inherits.model_name;
+            }
+            fileContent += NEWLINE + NEWLINE;
+            // For back compat we will only write this if the pattern.any has inherits information.
+            fileContent += `@ patternany ${patternAnyEntity.name}`;
+            fileContent += addRolesAndFeatures(patternAnyEntity);
+            fileContent += NEWLINE;
+        }
+    })
+    return fileContent;
 }
 
 /**

--- a/packages/lu/test/commands/luis/convert.test.ts
+++ b/packages/lu/test/commands/luis/convert.test.ts
@@ -615,6 +615,30 @@ describe('luis:convert new entity format', () => {
   })
 })
 
+describe('luis:convert with pattern.any inherits information', () => {
+  before(async function(){
+    await fs.mkdirp(path.join(__dirname, './../../../results/'))
+  })
+
+  after(async function(){
+    await fs.remove(path.join(__dirname, './../../../results/'))
+  })
+
+  test
+  .stdout()
+  .command(['luis:convert', '--in', `${path.join(__dirname, './../../fixtures/verified/LUISAppWithPAInherits.lu')}`, '--out', './results/LUISAppWithPAInherits.lu.json'])
+  .it('luis:convert with pattern.any inherits information correctly produces a LUIS app', async () => {
+    expect(await compareLuFiles('./../../../results/LUISAppWithPAInherits.lu.json', './../../fixtures/verified/LUISAppWithPAInherits.lu.json')).to.be.true
+  })
+
+  test
+    .stdout()
+    .command(['luis:convert', '--in', `${path.join(__dirname, './../../fixtures/testcases/LUISAppWithPAInherits.json')}`, '--out', './results/root2_a.lu'])
+    .it('luis:convert successfully reconstructs a markdown file from a LUIS input file with pattern.any inherits information', async () => {
+      expect(await compareLuFiles('./../../../results/root2_a.lu', './../../fixtures/verified/LUISAppWithPAInherits.lu')).to.be.true
+    })
+})
+
 describe('luis:convert file creation', () => {
   test
   .stderr()

--- a/packages/lu/test/fixtures/testcases/LUISAppWithPAInherits.json
+++ b/packages/lu/test/fixtures/testcases/LUISAppWithPAInherits.json
@@ -1,0 +1,1840 @@
+{
+  "luis_schema_version": "4.0.0",
+  "versionId": "0.1",
+  "name": "testPrebuiltImport",
+  "desc": "",
+  "culture": "en-us",
+  "tokenizerVersion": "1.0.0",
+  "intents": [
+    {
+      "name": "None"
+    },
+    {
+      "name": "ToDo.AddToDo",
+      "inherits": {
+        "domain_name": "ToDo",
+        "model_name": "AddToDo"
+      }
+    }
+  ],
+  "entities": [
+    {
+      "name": "ToDo.TaskContent",
+      "inherits": {
+        "domain_name": "ToDo",
+        "model_name": "TaskContent"
+      },
+      "roles": []
+    }
+  ],
+  "composites": [],
+  "closedLists": [],
+  "patternAnyEntities": [
+    {
+      "name": "ToDo.TaskContent.Any",
+      "inherits": {
+        "domain_name": "ToDo",
+        "model_name": "TaskContent.Any"
+      },
+      "roles": [],
+      "explicitList": []
+    }
+  ],
+  "regex_entities": [],
+  "prebuiltEntities": [],
+  "model_features": [],
+  "regex_features": [],
+  "patterns": [
+    {
+      "pattern": "^(add|create|append) an item [(called|about|of)] \"{ToDo.TaskContent.Any}\" [as (next|first|last) task][(in|on|to) my (to do|to-do|todos) list]",
+      "intent": "ToDo.AddToDo"
+    },
+    {
+      "pattern": "^[(can you|could you|would you)] [please] (put|add|append) {ToDo.TaskContent} [and] [{ToDo.TaskContent}] (on|to)[my][(to do|todos|todo)]list",
+      "intent": "ToDo.AddToDo"
+    }
+  ],
+  "utterances": [
+    {
+      "text": "add a few items to the grocery list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add a grocery item to buy fish",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 22,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "add a grocery item to buy fruit and vegetables",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 22,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "add a grocery item to buy vegetables",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 22,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "add a new shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add a shopping item to buy dancing dresses",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 23,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "add a shopping item to buy orange juice",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 23,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "add a task for anna west to bring my swimsuit for my vacation",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 60
+        }
+      ]
+    },
+    {
+      "text": "add a task for jimmy to play xbox games with me after work",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "add a task for li lei to bring my coat from home",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "add a task for raghu to bring my chocolates from germany",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 55
+        }
+      ]
+    },
+    {
+      "text": "add a task of chores to do around the house",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "add a task to finish driving test this week",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "add a task to pick mary up after work",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "add a task to purchase fruit and vegetables",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "add a task to shop at gnc after work",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "add a to do to buy shoes",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "add a to do to purchase a nice sweater",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "add a todo item to vacuum by october 3rd",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 16,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "add action item for khalifa to pack my school supplies in my list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 20,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "add an item to buy some snacks",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "add bronwnies to the grocery list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "add buy gum",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 10
+        }
+      ]
+    },
+    {
+      "text": "add buy milk to my shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "add call my mother to my todo list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "add go running to my to dos",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "add go to whole foods in my to do list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "add grocery add spinach my groceries list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 16,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "add grocery items cream cheese and raisin to the list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 18,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "add grocery items dinners and storage bag to the shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 18,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "add have a haircut to my tasks",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "add items as i speak",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add juicer groceries list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 9
+        }
+      ]
+    },
+    {
+      "text": "add melon and sugars and brown sugar to shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "add more to grocery list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add peanuts the grocery list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 10
+        }
+      ]
+    },
+    {
+      "text": "add purchase a cinema ticket to my list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "add purchasing food and drinks to my shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "add reading to my to do list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 10
+        }
+      ]
+    },
+    {
+      "text": "add shoes to the shopping lists",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 8
+        }
+      ]
+    },
+    {
+      "text": "add some items to that shopping notes",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add some items to the grocery list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add some jeans on our shopping lists",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 9,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "add something in this grocery list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add something to my list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add tapioca starch on my shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "add tapioca starch on our shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "add task to buy a coat",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 12,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "add task to set up dining room table",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 12,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "add this on our shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add this stuff on my shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add this thing in to do list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add to my grocery list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add to my to do list pick up clothes",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 21,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "add to my to do list print papers for 10 copies this afternoon",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 21,
+          "endPos": 61
+        }
+      ]
+    },
+    {
+      "text": "add to my todos list mail the insurance forms out by saturday",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 21,
+          "endPos": 60
+        }
+      ]
+    },
+    {
+      "text": "add to note shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add to shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add to the grocery note buy milk",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 24,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "append a summer reading in my list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 9,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "append an task of guest to invite at the party",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 18,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "append this item onto my notes",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "ask a task for kim to bring my coat from home",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "can i add shirts on the todos list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 10,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "can i put on caramel cheese popcorn on my grocery list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 13,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "can you delete abc item",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "can you delete todo1",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "cancel apples from shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 7,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "check off apples from list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 10,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "check off bananas from my grocery list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 10,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "check off garbage from grocery list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 10,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "check off meet john at 8 am from to do list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 10,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "check off shampoo from shopping list as done",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 10,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "check the box shampoo in my shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "complete pick up black shoes in my to-do list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 9,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "complete task go shopping",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "could i add medicine to the todos list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 12,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "create a task to meet my friends",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 17,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "create task to cyber shop on nov. 11",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "create task to go to the mall",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "create task to meet john after 5:00 p.m.",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "create to do to go running in the park",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 16,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "create to do to read a book tonight",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 18,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "delete eggs from list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 7,
+          "endPos": 10
+        }
+      ]
+    },
+    {
+      "text": "delete off pancake mix on the shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 11,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "delete shampoo from shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 7,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "delete shirts from list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 7,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "delete task go fishing",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 12,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "delete task go to cinema tonight",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 12,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "delete the item buy socks from my to-do list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 16,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "delete the task house cleanup this weekend",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 16,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "delete the task to hit the gym every morning",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 19,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "delete the to do meet my friends tomorrow",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 17,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "delete the to do to meet john when he come here the next friday",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 20,
+          "endPos": 62
+        }
+      ]
+    },
+    {
+      "text": "delete the to do to practice piano daily",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 20,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "delete to do buy milk",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 13,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "delete to do go shopping",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 13,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "delete to do that go hiking tomorrow",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 18,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "done with the task abc in our shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 19,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "done with the task shopping",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 19,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "done with the task tapioca starch in our shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 19,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "erase bananas from shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 6,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "erase peanuts on the shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 6,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "finish hikes on my to do list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 7,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "finish peanuts on the shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 7,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "mark buy fish as completed",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "mark fish as complete",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 8
+        }
+      ]
+    },
+    {
+      "text": "mark happy on to dos list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 9
+        }
+      ]
+    },
+    {
+      "text": "mark lemons and onions in grocery list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "mark pancake mix on my grocery shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "mark peanuts on my grocery list as done",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "mark peanuts on my grocery shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "mark pick mary up as finished",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "mark pick up milk on my to-do list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "mark play badminton with tom as finished",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "mark salad on my grocery shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 9
+        }
+      ]
+    },
+    {
+      "text": "mark salad on the groceries list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 9
+        }
+      ]
+    },
+    {
+      "text": "mark task buy a bottle of vinegar as finished",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 10,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "mark task go running as finished",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 10,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "mark task read a book as done",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 10,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "mark the item garbage from grocery list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "mark the task buy milk as done",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "mark the task get some food as complete",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "mark the task reserve a restaurant for tomorrow's dinner as finished",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 55
+        }
+      ]
+    },
+    {
+      "text": "mark the task visit my grandma as completed",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "need go to library this week, add this todo item",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 0,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "no need to buy milk in grocery list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 11,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "omit the milk in the grocery list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 9,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "put cheese on list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 9
+        }
+      ]
+    },
+    {
+      "text": "put ham on my shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 6
+        }
+      ]
+    },
+    {
+      "text": "put hikes on my to do list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 8
+        }
+      ]
+    },
+    {
+      "text": "put ice cream on the groceries list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "put milk on my grocery list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 7
+        }
+      ]
+    },
+    {
+      "text": "put on caramel cheese popcorn on my grocery shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "remind me to attend the meeting tomorrow",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 13,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "remind me to buy first aid creams and berries",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 13,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "remind me to buy milk",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 13,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "remind me to meet my teacher",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 13,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "remind me to shop for a new carpet",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 22,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "remove asprin from shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 7,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "remove black shoes from shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 7,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "remove class from todo list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 7,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "remove salad vegetables from grocery list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 7,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "remove task buy dog food",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 12,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "remove task go shopping",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 12,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "remove task go shopping with john this saturday",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 12,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "remove task that go hiking this weekend",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 17,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "remove task that lawn mowing",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 17,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "remove the item paris from my list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 16,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "remove the task that go to library after work",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 21,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "remove the to do physical examination",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 17,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "remove the to do that pick tom up at six p.m.",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 22,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "remove to do go to the gym",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 13,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "remove to do that go to the dentist tomorrow morning",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 18,
+          "endPos": 51
+        }
+      ]
+    },
+    {
+      "text": "shopping list delete a",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 21,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "shopping list delete dog food",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 21,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "shopping list delete eggs",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 21,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "shopping list delete milk",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 21,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "take coffee off my groceries list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 10
+        }
+      ]
+    },
+    {
+      "text": "take lemons and onions off my shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "take milk off grocery list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 8
+        }
+      ]
+    },
+    {
+      "text": "take socks and shoes off my shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "task completed buy gum",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "task train has been done",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 9
+        }
+      ]
+    },
+    {
+      "text": "to grocery list add milk",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 20,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "to my shopping list add paper towels",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 24,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "to my vacation to do list add buy sunblock",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 30,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "todo list delete paris vacation",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 17,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "would you add heavy cream to the todos list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "would you please add todo item of all hands meeting next monday",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 34,
+          "endPos": 62
+        }
+      ]
+    }
+  ],
+  "settings": []
+}

--- a/packages/lu/test/fixtures/verified/LUISAppWithPAInherits.lu
+++ b/packages/lu/test/fixtures/verified/LUISAppWithPAInherits.lu
@@ -1,0 +1,213 @@
+
+> LUIS application information
+> !# @app.name = testPrebuiltImport
+> !# @app.versionId = 0.1
+> !# @app.culture = en-us
+> !# @app.luis_schema_version = 4.0.0
+
+
+> # Intent definitions
+
+## None
+- can you delete {@ToDo.TaskContent=abc} item
+- can you delete {@ToDo.TaskContent=todo1}
+- cancel {@ToDo.TaskContent=apples} from shopping list
+- check off {@ToDo.TaskContent=apples} from list
+- check off {@ToDo.TaskContent=bananas} from my grocery list
+- check off {@ToDo.TaskContent=garbage} from grocery list
+- check off {@ToDo.TaskContent=meet john at 8 am} from to do list
+- check off {@ToDo.TaskContent=shampoo} from shopping list as done
+- check the box {@ToDo.TaskContent=shampoo} in my shopping list
+- complete {@ToDo.TaskContent=pick up black shoes} in my to-do list
+- complete task {@ToDo.TaskContent=go shopping}
+- delete {@ToDo.TaskContent=eggs} from list
+- delete off {@ToDo.TaskContent=pancake mix} on the shopping list
+- delete {@ToDo.TaskContent=shampoo} from shopping list
+- delete {@ToDo.TaskContent=shirts} from list
+- delete task {@ToDo.TaskContent=go fishing}
+- delete task {@ToDo.TaskContent=go to cinema tonight}
+- delete the item {@ToDo.TaskContent=buy socks} from my to-do list
+- delete the task {@ToDo.TaskContent=house cleanup this weekend}
+- delete the task to {@ToDo.TaskContent=hit the gym every morning}
+- delete the to do {@ToDo.TaskContent=meet my friends tomorrow}
+- delete the to do to {@ToDo.TaskContent=meet john when he come here the next friday}
+- delete the to do to {@ToDo.TaskContent=practice piano daily}
+- delete to do {@ToDo.TaskContent=buy milk}
+- delete to do {@ToDo.TaskContent=go shopping}
+- delete to do that {@ToDo.TaskContent=go hiking tomorrow}
+- done with the task {@ToDo.TaskContent=abc} in our shopping list
+- done with the task {@ToDo.TaskContent=shopping}
+- done with the task {@ToDo.TaskContent=tapioca starch} in our shopping list
+- erase {@ToDo.TaskContent=bananas} from shopping list
+- erase {@ToDo.TaskContent=peanuts} on the shopping list
+- finish {@ToDo.TaskContent=hikes} on my to do list
+- finish {@ToDo.TaskContent=peanuts} on the shopping list
+- mark {@ToDo.TaskContent=buy fish} as completed
+- mark {@ToDo.TaskContent=fish} as complete
+- mark {@ToDo.TaskContent=happy} on to dos list
+- mark {@ToDo.TaskContent=lemons and onions} in grocery list
+- mark {@ToDo.TaskContent=pancake mix} on my grocery shopping list
+- mark {@ToDo.TaskContent=peanuts} on my grocery list as done
+- mark {@ToDo.TaskContent=peanuts} on my grocery shopping list
+- mark {@ToDo.TaskContent=pick mary up} as finished
+- mark {@ToDo.TaskContent=pick up milk} on my to-do list
+- mark {@ToDo.TaskContent=play badminton with tom} as finished
+- mark {@ToDo.TaskContent=salad} on my grocery shopping list
+- mark {@ToDo.TaskContent=salad} on the groceries list
+- mark task {@ToDo.TaskContent=buy a bottle of vinegar} as finished
+- mark task {@ToDo.TaskContent=go running} as finished
+- mark task {@ToDo.TaskContent=read a book} as done
+- mark the item {@ToDo.TaskContent=garbage} from grocery list
+- mark the task {@ToDo.TaskContent=buy milk} as done
+- mark the task {@ToDo.TaskContent=get some food} as complete
+- mark the task {@ToDo.TaskContent=reserve a restaurant for tomorrow's dinner} as finished
+- mark the task {@ToDo.TaskContent=visit my grandma} as completed
+- no need to {@ToDo.TaskContent=buy milk} in grocery list
+- omit the {@ToDo.TaskContent=milk} in the grocery list
+- remove {@ToDo.TaskContent=asprin} from shopping list
+- remove {@ToDo.TaskContent=black shoes} from shopping list
+- remove {@ToDo.TaskContent=class} from todo list
+- remove {@ToDo.TaskContent=salad vegetables} from grocery list
+- remove task {@ToDo.TaskContent=buy dog food}
+- remove task {@ToDo.TaskContent=go shopping}
+- remove task {@ToDo.TaskContent=go shopping with john this saturday}
+- remove task that {@ToDo.TaskContent=go hiking this weekend}
+- remove task that {@ToDo.TaskContent=lawn mowing}
+- remove the item {@ToDo.TaskContent=paris} from my list
+- remove the task that {@ToDo.TaskContent=go to library after work}
+- remove the to do {@ToDo.TaskContent=physical examination}
+- remove the to do that {@ToDo.TaskContent=pick tom up at six p.m.}
+- remove to do {@ToDo.TaskContent=go to the gym}
+- remove to do that {@ToDo.TaskContent=go to the dentist tomorrow morning}
+- shopping list delete {@ToDo.TaskContent=a}
+- shopping list delete {@ToDo.TaskContent=dog food}
+- shopping list delete {@ToDo.TaskContent=eggs}
+- shopping list delete {@ToDo.TaskContent=milk}
+- take {@ToDo.TaskContent=coffee} off my groceries list
+- take {@ToDo.TaskContent=lemons and onions} off my shopping list
+- take {@ToDo.TaskContent=milk} off grocery list
+- take {@ToDo.TaskContent=socks and shoes} off my shopping list
+- task completed {@ToDo.TaskContent=buy gum}
+- task {@ToDo.TaskContent=train} has been done
+- todo list delete {@ToDo.TaskContent=paris vacation}
+
+
+> !# @intent.inherits = name : ToDo.AddToDo; domain_name : ToDo; model_name : AddToDo
+
+## ToDo.AddToDo
+- add a few items to the grocery list
+- add a grocery item to {@ToDo.TaskContent=buy fish}
+- add a grocery item to {@ToDo.TaskContent=buy fruit and vegetables}
+- add a grocery item to {@ToDo.TaskContent=buy vegetables}
+- add a new shopping list
+- add a shopping item to {@ToDo.TaskContent=buy dancing dresses}
+- add a shopping item to {@ToDo.TaskContent=buy orange juice}
+- add a task for {@ToDo.TaskContent=anna west to bring my swimsuit for my vacation}
+- add a task for {@ToDo.TaskContent=jimmy to play xbox games with me after work}
+- add a task for {@ToDo.TaskContent=li lei to bring my coat from home}
+- add a task for {@ToDo.TaskContent=raghu to bring my chocolates from germany}
+- add a task of {@ToDo.TaskContent=chores to do around the house}
+- add a task to {@ToDo.TaskContent=finish driving test this week}
+- add a task to {@ToDo.TaskContent=pick mary up after work}
+- add a task to {@ToDo.TaskContent=purchase fruit and vegetables}
+- add a task to {@ToDo.TaskContent=shop at gnc after work}
+- add a to do to {@ToDo.TaskContent=buy shoes}
+- add a to do to {@ToDo.TaskContent=purchase a nice sweater}
+- add a todo item {@ToDo.TaskContent=to vacuum by october 3rd}
+- add action item for {@ToDo.TaskContent=khalifa to pack my school supplies} in my list
+- add an item to {@ToDo.TaskContent=buy some snacks}
+- add {@ToDo.TaskContent=bronwnies} to the grocery list
+- add {@ToDo.TaskContent=buy gum}
+- add {@ToDo.TaskContent=buy milk} to my shopping list
+- add {@ToDo.TaskContent=call my mother} to my todo list
+- add {@ToDo.TaskContent=go running} to my to dos
+- add {@ToDo.TaskContent=go to whole foods} in my to do list
+- add grocery add {@ToDo.TaskContent=spinach} my groceries list
+- add grocery items {@ToDo.TaskContent=cream cheese and raisin} to the list
+- add grocery items {@ToDo.TaskContent=dinners and storage bag} to the shopping list
+- add {@ToDo.TaskContent=have a haircut} to my tasks
+- add items as i speak
+- add {@ToDo.TaskContent=juicer} groceries list
+- add {@ToDo.TaskContent=melon and sugars and brown sugar} to shopping list
+- add more to grocery list
+- add {@ToDo.TaskContent=peanuts} the grocery list
+- add {@ToDo.TaskContent=purchase a cinema ticket} to my list
+- add {@ToDo.TaskContent=purchasing food and drinks} to my shopping list
+- add {@ToDo.TaskContent=reading} to my to do list
+- add {@ToDo.TaskContent=shoes} to the shopping lists
+- add some items to that shopping notes
+- add some items to the grocery list
+- add some {@ToDo.TaskContent=jeans} on our shopping lists
+- add something in this grocery list
+- add something to my list
+- add {@ToDo.TaskContent=tapioca starch} on my shopping list
+- add {@ToDo.TaskContent=tapioca starch} on our shopping list
+- add task to {@ToDo.TaskContent=buy a coat}
+- add task to {@ToDo.TaskContent=set up dining room table}
+- add this on our shopping list
+- add this stuff on my shopping list
+- add this thing in to do list
+- add to my grocery list
+- add to my to do list {@ToDo.TaskContent=pick up clothes}
+- add to my to do list {@ToDo.TaskContent=print papers for 10 copies this afternoon}
+- add to my todos list {@ToDo.TaskContent=mail the insurance forms out by saturday}
+- add to note shopping list
+- add to shopping list
+- add to the grocery note {@ToDo.TaskContent=buy milk}
+- append a {@ToDo.TaskContent=summer reading} in my list
+- append an task of {@ToDo.TaskContent=guest to invite at the party}
+- append this item onto my notes
+- ask a task for {@ToDo.TaskContent=kim to bring my coat from home}
+- can i add {@ToDo.TaskContent=shirts} on the todos list
+- can i put on {@ToDo.TaskContent=caramel cheese popcorn} on my grocery list
+- could i add {@ToDo.TaskContent=medicine} to the todos list
+- create a task to {@ToDo.TaskContent=meet my friends}
+- create task to {@ToDo.TaskContent=cyber shop on nov. 11}
+- create task to {@ToDo.TaskContent=go to the mall}
+- create task to {@ToDo.TaskContent=meet john after 5:00 p.m.}
+- create to do to {@ToDo.TaskContent=go running in the park}
+- create to do to re{@ToDo.TaskContent=ad a book tonight}
+- {@ToDo.TaskContent=need go to library this week}, add this todo item
+- put {@ToDo.TaskContent=cheese} on list
+- put {@ToDo.TaskContent=ham} on my shopping list
+- put {@ToDo.TaskContent=hikes} on my to do list
+- put {@ToDo.TaskContent=ice cream} on the groceries list
+- put {@ToDo.TaskContent=milk} on my grocery list
+- put {@ToDo.TaskContent=on caramel cheese popcorn} on my grocery shopping list
+- remind me to {@ToDo.TaskContent=attend the meeting tomorrow}
+- remind me to {@ToDo.TaskContent=buy first aid creams and berries}
+- remind me to {@ToDo.TaskContent=buy milk}
+- remind me to {@ToDo.TaskContent=meet my teacher}
+- remind me to shop for {@ToDo.TaskContent=a new carpet}
+- to grocery list add {@ToDo.TaskContent=milk}
+- to my shopping list add {@ToDo.TaskContent=paper towels}
+- to my vacation to do list add {@ToDo.TaskContent=buy sunblock}
+- would you add {@ToDo.TaskContent=heavy cream} to the todos list
+- would you please add todo item of {@ToDo.TaskContent=all hands meeting next monday}
+- ^(add|create|append) an item [(called|about|of)] "{@ToDo.TaskContent.Any}" [as (next|first|last) task][(in|on|to) my (to do|to-do|todos) list]
+- ^[(can you|could you|would you)] [please] (put|add|append) {@ToDo.TaskContent} [and] [{ToDo.TaskContent}] (on|to)[my][(to do|todos|todo)]list
+
+
+> # Entity definitions
+
+> !# @entity.inherits = name : ToDo.TaskContent; domain_name : ToDo; model_name : TaskContent
+
+@ ml ToDo.TaskContent
+
+
+> # PREBUILT Entity definitions
+
+
+> # Phrase list definitions
+
+
+> # List entities
+
+> # RegEx entities
+
+
+> # Pattern.Any entities
+
+> !# @patternAnyEntity.inherits = name : ToDo.TaskContent.Any; domain_name : ToDo; model_name : TaskContent.Any
+
+@ patternany ToDo.TaskContent.Any

--- a/packages/lu/test/fixtures/verified/LUISAppWithPAInherits.lu.json
+++ b/packages/lu/test/fixtures/verified/LUISAppWithPAInherits.lu.json
@@ -1,0 +1,1838 @@
+{
+  "intents": [
+    {
+      "name": "ToDo.AddToDo",
+      "inherits": {
+        "domain_name": "ToDo",
+        "model_name": "AddToDo"
+      }
+    },
+    {
+      "name": "None"
+    }
+  ],
+  "entities": [
+    {
+      "name": "ToDo.TaskContent",
+      "inherits": {
+        "domain_name": "ToDo",
+        "model_name": "TaskContent"
+      },
+      "roles": []
+    }
+  ],
+  "composites": [],
+  "closedLists": [],
+  "regex_entities": [],
+  "model_features": [],
+  "regex_features": [],
+  "utterances": [
+    {
+      "text": "can you delete abc item",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "can you delete todo1",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "cancel apples from shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 7,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "check off apples from list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 10,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "check off bananas from my grocery list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 10,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "check off garbage from grocery list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 10,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "check off meet john at 8 am from to do list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 10,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "check off shampoo from shopping list as done",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 10,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "check the box shampoo in my shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "complete pick up black shoes in my to-do list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 9,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "complete task go shopping",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "delete eggs from list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 7,
+          "endPos": 10
+        }
+      ]
+    },
+    {
+      "text": "delete off pancake mix on the shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 11,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "delete shampoo from shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 7,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "delete shirts from list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 7,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "delete task go fishing",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 12,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "delete task go to cinema tonight",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 12,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "delete the item buy socks from my to-do list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 16,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "delete the task house cleanup this weekend",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 16,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "delete the task to hit the gym every morning",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 19,
+          "endPos": 43
+        }
+      ]
+    },
+    {
+      "text": "delete the to do meet my friends tomorrow",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 17,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "delete the to do to meet john when he come here the next friday",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 20,
+          "endPos": 62
+        }
+      ]
+    },
+    {
+      "text": "delete the to do to practice piano daily",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 20,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "delete to do buy milk",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 13,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "delete to do go shopping",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 13,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "delete to do that go hiking tomorrow",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 18,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "done with the task abc in our shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 19,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "done with the task shopping",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 19,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "done with the task tapioca starch in our shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 19,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "erase bananas from shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 6,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "erase peanuts on the shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 6,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "finish hikes on my to do list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 7,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "finish peanuts on the shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 7,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "mark buy fish as completed",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "mark fish as complete",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 8
+        }
+      ]
+    },
+    {
+      "text": "mark happy on to dos list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 9
+        }
+      ]
+    },
+    {
+      "text": "mark lemons and onions in grocery list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "mark pancake mix on my grocery shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "mark peanuts on my grocery list as done",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "mark peanuts on my grocery shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "mark pick mary up as finished",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "mark pick up milk on my to-do list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 16
+        }
+      ]
+    },
+    {
+      "text": "mark play badminton with tom as finished",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "mark salad on my grocery shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 9
+        }
+      ]
+    },
+    {
+      "text": "mark salad on the groceries list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 9
+        }
+      ]
+    },
+    {
+      "text": "mark task buy a bottle of vinegar as finished",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 10,
+          "endPos": 32
+        }
+      ]
+    },
+    {
+      "text": "mark task go running as finished",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 10,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "mark task read a book as done",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 10,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "mark the item garbage from grocery list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "mark the task buy milk as done",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "mark the task get some food as complete",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 26
+        }
+      ]
+    },
+    {
+      "text": "mark the task reserve a restaurant for tomorrow's dinner as finished",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 55
+        }
+      ]
+    },
+    {
+      "text": "mark the task visit my grandma as completed",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "no need to buy milk in grocery list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 11,
+          "endPos": 18
+        }
+      ]
+    },
+    {
+      "text": "omit the milk in the grocery list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 9,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "remove asprin from shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 7,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "remove black shoes from shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 7,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "remove class from todo list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 7,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "remove salad vegetables from grocery list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 7,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "remove task buy dog food",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 12,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "remove task go shopping",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 12,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "remove task go shopping with john this saturday",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 12,
+          "endPos": 46
+        }
+      ]
+    },
+    {
+      "text": "remove task that go hiking this weekend",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 17,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "remove task that lawn mowing",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 17,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "remove the item paris from my list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 16,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "remove the task that go to library after work",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 21,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "remove the to do physical examination",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 17,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "remove the to do that pick tom up at six p.m.",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 22,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "remove to do go to the gym",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 13,
+          "endPos": 25
+        }
+      ]
+    },
+    {
+      "text": "remove to do that go to the dentist tomorrow morning",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 18,
+          "endPos": 51
+        }
+      ]
+    },
+    {
+      "text": "shopping list delete a",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 21,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "shopping list delete dog food",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 21,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "shopping list delete eggs",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 21,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "shopping list delete milk",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 21,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "take coffee off my groceries list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 10
+        }
+      ]
+    },
+    {
+      "text": "take lemons and onions off my shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "take milk off grocery list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 8
+        }
+      ]
+    },
+    {
+      "text": "take socks and shoes off my shopping list",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "task completed buy gum",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "task train has been done",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 5,
+          "endPos": 9
+        }
+      ]
+    },
+    {
+      "text": "todo list delete paris vacation",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 17,
+          "endPos": 30
+        }
+      ]
+    },
+    {
+      "text": "add a few items to the grocery list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add a grocery item to buy fish",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 22,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "add a grocery item to buy fruit and vegetables",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 22,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "add a grocery item to buy vegetables",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 22,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "add a new shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add a shopping item to buy dancing dresses",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 23,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "add a shopping item to buy orange juice",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 23,
+          "endPos": 38
+        }
+      ]
+    },
+    {
+      "text": "add a task for anna west to bring my swimsuit for my vacation",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 60
+        }
+      ]
+    },
+    {
+      "text": "add a task for jimmy to play xbox games with me after work",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 57
+        }
+      ]
+    },
+    {
+      "text": "add a task for li lei to bring my coat from home",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 47
+        }
+      ]
+    },
+    {
+      "text": "add a task for raghu to bring my chocolates from germany",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 55
+        }
+      ]
+    },
+    {
+      "text": "add a task of chores to do around the house",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "add a task to finish driving test this week",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "add a task to pick mary up after work",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 36
+        }
+      ]
+    },
+    {
+      "text": "add a task to purchase fruit and vegetables",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 42
+        }
+      ]
+    },
+    {
+      "text": "add a task to shop at gnc after work",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "add a to do to buy shoes",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "add a to do to purchase a nice sweater",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "add a todo item to vacuum by october 3rd",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 16,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "add action item for khalifa to pack my school supplies in my list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 20,
+          "endPos": 53
+        }
+      ]
+    },
+    {
+      "text": "add an item to buy some snacks",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "add bronwnies to the grocery list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "add buy gum",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 10
+        }
+      ]
+    },
+    {
+      "text": "add buy milk to my shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 11
+        }
+      ]
+    },
+    {
+      "text": "add call my mother to my todo list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "add go running to my to dos",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "add go to whole foods in my to do list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "add grocery add spinach my groceries list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 16,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "add grocery items cream cheese and raisin to the list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 18,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "add grocery items dinners and storage bag to the shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 18,
+          "endPos": 40
+        }
+      ]
+    },
+    {
+      "text": "add have a haircut to my tasks",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "add items as i speak",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add juicer groceries list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 9
+        }
+      ]
+    },
+    {
+      "text": "add melon and sugars and brown sugar to shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "add more to grocery list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add peanuts the grocery list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 10
+        }
+      ]
+    },
+    {
+      "text": "add purchase a cinema ticket to my list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "add purchasing food and drinks to my shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 29
+        }
+      ]
+    },
+    {
+      "text": "add reading to my to do list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 10
+        }
+      ]
+    },
+    {
+      "text": "add shoes to the shopping lists",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 8
+        }
+      ]
+    },
+    {
+      "text": "add some items to that shopping notes",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add some items to the grocery list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add some jeans on our shopping lists",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 9,
+          "endPos": 13
+        }
+      ]
+    },
+    {
+      "text": "add something in this grocery list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add something to my list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add tapioca starch on my shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "add tapioca starch on our shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "add task to buy a coat",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 12,
+          "endPos": 21
+        }
+      ]
+    },
+    {
+      "text": "add task to set up dining room table",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 12,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "add this on our shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add this stuff on my shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add this thing in to do list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add to my grocery list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add to my to do list pick up clothes",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 21,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "add to my to do list print papers for 10 copies this afternoon",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 21,
+          "endPos": 61
+        }
+      ]
+    },
+    {
+      "text": "add to my todos list mail the insurance forms out by saturday",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 21,
+          "endPos": 60
+        }
+      ]
+    },
+    {
+      "text": "add to note shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add to shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "add to the grocery note buy milk",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 24,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "append a summer reading in my list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 9,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "append an task of guest to invite at the party",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 18,
+          "endPos": 45
+        }
+      ]
+    },
+    {
+      "text": "append this item onto my notes",
+      "intent": "ToDo.AddToDo",
+      "entities": []
+    },
+    {
+      "text": "ask a task for kim to bring my coat from home",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "can i add shirts on the todos list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 10,
+          "endPos": 15
+        }
+      ]
+    },
+    {
+      "text": "can i put on caramel cheese popcorn on my grocery list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 13,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "could i add medicine to the todos list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 12,
+          "endPos": 19
+        }
+      ]
+    },
+    {
+      "text": "create a task to meet my friends",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 17,
+          "endPos": 31
+        }
+      ]
+    },
+    {
+      "text": "create task to cyber shop on nov. 11",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "create task to go to the mall",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "create task to meet john after 5:00 p.m.",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 15,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "create to do to go running in the park",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 16,
+          "endPos": 37
+        }
+      ]
+    },
+    {
+      "text": "create to do to read a book tonight",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 18,
+          "endPos": 34
+        }
+      ]
+    },
+    {
+      "text": "need go to library this week, add this todo item",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 0,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "put cheese on list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 9
+        }
+      ]
+    },
+    {
+      "text": "put ham on my shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 6
+        }
+      ]
+    },
+    {
+      "text": "put hikes on my to do list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 8
+        }
+      ]
+    },
+    {
+      "text": "put ice cream on the groceries list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 12
+        }
+      ]
+    },
+    {
+      "text": "put milk on my grocery list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 7
+        }
+      ]
+    },
+    {
+      "text": "put on caramel cheese popcorn on my grocery shopping list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 4,
+          "endPos": 28
+        }
+      ]
+    },
+    {
+      "text": "remind me to attend the meeting tomorrow",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 13,
+          "endPos": 39
+        }
+      ]
+    },
+    {
+      "text": "remind me to buy first aid creams and berries",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 13,
+          "endPos": 44
+        }
+      ]
+    },
+    {
+      "text": "remind me to buy milk",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 13,
+          "endPos": 20
+        }
+      ]
+    },
+    {
+      "text": "remind me to meet my teacher",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 13,
+          "endPos": 27
+        }
+      ]
+    },
+    {
+      "text": "remind me to shop for a new carpet",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 22,
+          "endPos": 33
+        }
+      ]
+    },
+    {
+      "text": "to grocery list add milk",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 20,
+          "endPos": 23
+        }
+      ]
+    },
+    {
+      "text": "to my shopping list add paper towels",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 24,
+          "endPos": 35
+        }
+      ]
+    },
+    {
+      "text": "to my vacation to do list add buy sunblock",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 30,
+          "endPos": 41
+        }
+      ]
+    },
+    {
+      "text": "would you add heavy cream to the todos list",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 14,
+          "endPos": 24
+        }
+      ]
+    },
+    {
+      "text": "would you please add todo item of all hands meeting next monday",
+      "intent": "ToDo.AddToDo",
+      "entities": [
+        {
+          "entity": "ToDo.TaskContent",
+          "startPos": 34,
+          "endPos": 62
+        }
+      ]
+    }
+  ],
+  "patterns": [
+    {
+      "pattern": "^(add|create|append) an item [(called|about|of)] \"{ToDo.TaskContent.Any}\" [as (next|first|last) task][(in|on|to) my (to do|to-do|todos) list]",
+      "intent": "ToDo.AddToDo"
+    },
+    {
+      "pattern": "^[(can you|could you|would you)] [please] (put|add|append) {ToDo.TaskContent} [and] [{ToDo.TaskContent}] (on|to)[my][(to do|todos|todo)]list",
+      "intent": "ToDo.AddToDo"
+    }
+  ],
+  "patternAnyEntities": [
+    {
+      "name": "ToDo.TaskContent.Any",
+      "explicitList": [],
+      "roles": [],
+      "inherits": {
+        "domain_name": "ToDo",
+        "model_name": "TaskContent.Any"
+      }
+    }
+  ],
+  "prebuiltEntities": [],
+  "name": "testPrebuiltImport",
+  "versionId": "0.1",
+  "culture": "en-us",
+  "luis_schema_version": "4.0.0",
+  "desc": ""
+}


### PR DESCRIPTION
Fixes #444 

Current implementation did not expect nor handle pattern.any entities to be added via prebuilt domain import. This PR adds support for pattern.any entities to have `inherits` information. 

Verified existing tests pass
Added new tests.