### PR TITLE
ludown content is not supported in import command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -350,7 +350,7 @@ _See code: [@microsoft/bf-luis-cli](https://github.com/microsoft/botframework-cl
 
 ## `bf luis:application:import`
 
-Imports LUIS application from JSON or LU content.
+Imports LUIS application from JSON.
 
 ```
 USAGE


### PR DESCRIPTION
` bf luis:application:import --endpoint https://{region}.api.cognitive.microsoft.com/ --subscriptionKey yourKey --name AppName --in ./ludown.lu ` from the code it looks like it wasn't intended to work with ludown files