### PR TITLE
verbose build tests

### DIFF
--- a/build/botframework-cli-mac.yml
+++ b/build/botframework-cli-mac.yml
@@ -55,7 +55,7 @@ jobs:
     - script: 'rush build'
       displayName: 'rush build'
 
-    - script: 'rush test'
+    - script: 'rush test -v'
       displayName: 'rush test'
     
     - script: 'rush posttest'

--- a/build/botframework-cli.yml
+++ b/build/botframework-cli.yml
@@ -55,7 +55,7 @@ jobs:
     - script: 'rush build -p 2'
       displayName: 'rush build'
 
-    - script: 'rush test -p 2'
+    - script: 'rush test -p 2 -v'
       displayName: 'rush test'
     
     - script: 'rush posttest'


### PR DESCRIPTION
Currently, during a build where the tests fail, the console output isn't terribly helpful. It will look something like this:

![image](https://user-images.githubusercontent.com/40401643/75381523-be073d80-588d-11ea-9066-cf125f4a1967.png)

...and has no indication of which tests failed.

By adding `-v` to `rush test`, this will show success/failure of every test as well as the error message.