### PR TITLE
fix lu build bug when training empty intents

### DIFF
--- a/packages/lu/src/parser/lubuild/builder.ts
+++ b/packages/lu/src/parser/lubuild/builder.ts
@@ -366,7 +366,7 @@ export class Builder {
 
     if (emptyIntents && emptyIntents.length > 0) {
       const filteredIntents = intents.filter((intent: any) => !emptyIntents.some((emptyIntent: any) => emptyIntent.name === intent.name))
-      this.handler(`[WARN]: empty intent(s) ${emptyIntents.map((intent: any) => '# ' + intent.name).join(', ')} are filtered when training and publishing`)
+      this.handler(`[WARN]: empty intent(s) ${emptyIntents.map((intent: any) => '# ' + intent.name).join(', ')} are filtered when handling luis application`)
       app.intents = filteredIntents
     }
   }

--- a/packages/lu/src/parser/lubuild/builder.ts
+++ b/packages/lu/src/parser/lubuild/builder.ts
@@ -258,6 +258,9 @@ export class Builder {
       currentApp.name = `${botName}(${suffix})-${content.name}`
     }
 
+    // remove empty intents from current app to avoid fewLabels error when training
+    this.filterEmptyIntents(currentApp)
+
     return currentApp
   }
 
@@ -351,5 +354,20 @@ export class Builder {
     }
 
     return new Content(settings.save(), new LUOptions(path.basename(settings.getSettingsPath()), true, '', settings.getSettingsPath()))
+  }
+
+  filterEmptyIntents(app: any) {
+    const intents = app.intents
+    const utterances = app.utterances
+    const patterns = app.patterns
+
+    const emptyIntents = intents.filter((intent: any) => !utterances.some((utterance: any) => utterance.intent === intent.name)
+      && !patterns.some((pattern: any) => pattern.intent === intent.name))
+
+    if (emptyIntents && emptyIntents.length > 0) {
+      const filteredIntents = intents.filter((intent: any) => !emptyIntents.some((emptyIntent: any) => emptyIntent.name === intent.name))
+      this.handler(`[WARN]: empty intent(s) ${emptyIntents.map((intent: any) => '# ' + intent.name).join(', ')} are filtered when training and publishing`)
+      app.intents = filteredIntents
+    }
   }
 }

--- a/packages/lu/src/parser/lufile/parseFileContents.js
+++ b/packages/lu/src/parser/lufile/parseFileContents.js
@@ -1800,7 +1800,11 @@ const parseAndHandleModelInfoSection = function (parsedContent, luResource, log)
     if (modelInfos && modelInfos.length > 0) {
         for (const modelInfo of modelInfos) {
             let line = modelInfo.ModelInfo
-            let kvPair = line.split(/@(app|kb|intent|entity|enableMergeIntents|patternAnyEntity).(.*)=/g).map(item => item.trim());
+            let kvPair = line.split(/@(app|kb|intent|entity|enableSections|enableMergeIntents|patternAnyEntity).(.*)=/g).map(item => item.trim());
+            
+            // avoid to throw invalid model info when meeting enableSections info which is handled in luParser.js
+            if (kvPair[1] === 'enableSections') continue
+
             if (kvPair.length === 4) {
                 if (kvPair[1] === 'enableMergeIntents' && kvPair[3] === 'false') {
                     enableMergeIntents = false;

--- a/packages/luis/test/commands/luis/build.test.ts
+++ b/packages/luis/test/commands/luis/build.test.ts
@@ -549,6 +549,8 @@ describe('luis:build update dialog assets successfully when dialog assets exist'
       expect(ctx.stdout).to.contain('foo.en-us.lu.dialog loaded')
       expect(ctx.stdout).to.contain('foo.fr-fr.lu.dialog loaded')
 
+      expect(ctx.stdout).to.contain('[WARN]: empty intent(s) # emptyIntent are filtered when training and publishing')
+
       expect(ctx.stdout).to.contain('Creating LUIS.ai application')
       expect(ctx.stdout).to.contain('training version=0.1')
       expect(ctx.stdout).to.contain('waiting for training for version=0.1')

--- a/packages/luis/test/commands/luis/build.test.ts
+++ b/packages/luis/test/commands/luis/build.test.ts
@@ -549,7 +549,7 @@ describe('luis:build update dialog assets successfully when dialog assets exist'
       expect(ctx.stdout).to.contain('foo.en-us.lu.dialog loaded')
       expect(ctx.stdout).to.contain('foo.fr-fr.lu.dialog loaded')
 
-      expect(ctx.stdout).to.contain('[WARN]: empty intent(s) # emptyIntent are filtered when training and publishing')
+      expect(ctx.stdout).to.contain('[WARN]: empty intent(s) # emptyIntent are filtered when handling luis application')
 
       expect(ctx.stdout).to.contain('Creating LUIS.ai application')
       expect(ctx.stdout).to.contain('training version=0.1')

--- a/packages/luis/test/fixtures/testcases/lubuild/foo2/lufiles-and-dialog-assets/foo.lu
+++ b/packages/luis/test/fixtures/testcases/lubuild/foo2/lufiles-and-dialog-assets/foo.lu
@@ -3,3 +3,5 @@
 - yo carlos!
 - hello
 - hi
+
+# emptyIntent


### PR DESCRIPTION
Fix two bugs:
1. fix bug https://github.com/microsoft/BotFramework-Composer/issues/2195. Luis API will throw exception when training lu file with empty intents(with no utterances and patterns). This PR removes the empty intents before creating and training/publishing lu models. Meanwhile, it will log out a messages such as `[WARN]: empty intent(s) # A, # B are filtered when handling luis application`
2. fix invalid model info error message `[WARN]: Invalid model info found. Skipping "> !# @enableSections = true`  which was false error. `enableSections` is used in luParser.js. The fix here is to avoid the error message.