### PR TITLE
optimize error msg text when error comes from imported files

### DIFF
--- a/packages/lu/src/parser/lu/luMerger.js
+++ b/packages/lu/src/parser/lu/luMerger.js
@@ -517,6 +517,7 @@ const parseLuFile = async function(luOb, log, luis_culture) {
     try {
         parsedContent = await parseFileContents.parseFile(luOb.content, log, luis_culture);
     } catch (err) {
+        err.text = `Invalid file ${luOb.id}: ${err.text}`
         throw(err);
     }
     if (!parsedContent) {

--- a/packages/lu/src/parser/lu/luMerger.js
+++ b/packages/lu/src/parser/lu/luMerger.js
@@ -517,7 +517,7 @@ const parseLuFile = async function(luOb, log, luis_culture) {
     try {
         parsedContent = await parseFileContents.parseFile(luOb.content, log, luis_culture);
     } catch (err) {
-        err.text = `Invalid file ${luOb.id}: ${err.text}`
+        err.source = luOb.id;
         throw(err);
     }
     if (!parsedContent) {

--- a/packages/lu/src/parser/lubuild/builder.ts
+++ b/packages/lu/src/parser/lubuild/builder.ts
@@ -47,6 +47,11 @@ export class Builder {
         result = await LuisBuilderVerbose.build(luFiles, true, culture)
         fileContent = result.parseToLuContent()
       } catch (err) {
+        if (err.source) {
+          err.text = `Invalid LU file ${err.source}: ${err.text}`
+        } else {
+          err.text = `Invalid LU file ${file}: ${err.text}`
+        }
         throw(new exception(retCode.errorCode.INVALID_INPUT_FILE, err.text))
       }
 

--- a/packages/lu/src/parser/lubuild/builder.ts
+++ b/packages/lu/src/parser/lubuild/builder.ts
@@ -47,7 +47,6 @@ export class Builder {
         result = await LuisBuilderVerbose.build(luFiles, true, culture)
         fileContent = result.parseToLuContent()
       } catch (err) {
-        err.text = `Invalid LU file ${file}: ${err.text}`
         throw(new exception(retCode.errorCode.INVALID_INPUT_FILE, err.text))
       }
 

--- a/packages/luis/test/commands/luis/build.test.ts
+++ b/packages/luis/test/commands/luis/build.test.ts
@@ -58,7 +58,7 @@ describe('luis:build cli parameters test', () => {
     .stderr()
     .command(['luis:build', '--authoringKey', uuidv1(), '--in', `${path.join(__dirname, './../../fixtures/testcases/invalid_import_file.lu')}`, '--botName', 'Contoso'])
     .it('displays an error if error occurs in parsing lu content', ctx => {
-      expect(ctx.stderr).to.contain('Invalid file')
+      expect(ctx.stderr).to.contain('Invalid LU file')
       expect(ctx.stderr).to.contain('bad3.lu')
       expect(ctx.stderr).to.contain('[ERROR] line 4:0 - line 4:16: Invalid intent body line, did you miss \'-\' at line begin')
     })

--- a/packages/luis/test/commands/luis/build.test.ts
+++ b/packages/luis/test/commands/luis/build.test.ts
@@ -56,9 +56,10 @@ describe('luis:build cli parameters test', () => {
   test
     .stdout()
     .stderr()
-    .command(['luis:build', '--authoringKey', uuidv1(), '--in', `${path.join(__dirname, './../../fixtures/testcases/bad3.lu')}`, '--botName', 'Contoso'])
+    .command(['luis:build', '--authoringKey', uuidv1(), '--in', `${path.join(__dirname, './../../fixtures/testcases/invalid_import_file.lu')}`, '--botName', 'Contoso'])
     .it('displays an error if error occurs in parsing lu content', ctx => {
-      expect(ctx.stderr).to.contain('Invalid LU file')
+      expect(ctx.stderr).to.contain('Invalid file')
+      expect(ctx.stderr).to.contain('bad3.lu')
       expect(ctx.stderr).to.contain('[ERROR] line 4:0 - line 4:16: Invalid intent body line, did you miss \'-\' at line begin')
     })
 })

--- a/packages/luis/test/fixtures/testcases/invalid_import_file.lu
+++ b/packages/luis/test/fixtures/testcases/invalid_import_file.lu
@@ -1,0 +1,5 @@
+# greeting
+- hi
+- hello
+
+[import lu file with error](bad3.lu)


### PR DESCRIPTION
fix #647. After fix, error messages will point to imported lu file when errors come from imported file