### PR TITLE
Fix comparing luis applications bug in lu build

### DIFF
--- a/packages/lu/src/parser/lubuild/core.ts
+++ b/packages/lu/src/parser/lubuild/core.ts
@@ -87,6 +87,15 @@ export class LuBuildCore {
 
     currentApp.name = existingApp.name
 
+    existingApp.model_features = existingApp.phraselists
+    delete existingApp.phraselists
+
+    existingApp.regex_features = existingApp.regex_features
+    delete existingApp.regex_features
+
+    existingApp.regex_entities = existingApp.regex_entities
+    delete existingApp.regex_entities
+
     return !this.isApplicationEqual(currentApp, existingApp)
   }
 
@@ -193,10 +202,10 @@ export class LuBuildCore {
     }
   }
 
-  private isApplicationEqual(appA: any, appB: any): boolean {
-    let appALu = (new Luis(JSON.stringify(appA))).parseToLuContent().toLowerCase()
-    let appBLu = (new Luis(JSON.stringify(appB))).parseToLuContent().toLowerCase()
-
+  private async isApplicationEqual(appA: any, appB: any) {
+    let appALu = (new Luis(appA)).parseToLuContent().toLowerCase()
+    let appBLu = (new Luis(appB)).parseToLuContent().toLowerCase()
+    
     return appALu === appBLu
   }
 }

--- a/packages/lu/src/parser/lubuild/core.ts
+++ b/packages/lu/src/parser/lubuild/core.ts
@@ -71,7 +71,7 @@ export class LuBuildCore {
   public compareApplications(currentApp: any, existingApp: any) {
     currentApp.desc = currentApp.desc && currentApp.desc !== '' && currentApp.desc !== existingApp.desc ? currentApp.desc : existingApp.desc
     currentApp.culture = currentApp.culture && currentApp.culture !== '' && currentApp.culture !== existingApp.culture ? currentApp.culture : existingApp.culture
-    currentApp.versionId = currentApp.versionId && currentApp.versionId !== '' && currentApp.versionId > existingApp.versionId ? currentApp.versionId : existingApp.versionId;
+    currentApp.versionId = currentApp.versionId && currentApp.versionId !== '' && currentApp.versionId > existingApp.versionId ? currentApp.versionId : existingApp.versionId
     currentApp.name = existingApp.name
 
     let currentAppToCompare = JSON.parse(JSON.stringify(currentApp));
@@ -88,10 +88,12 @@ export class LuBuildCore {
       })
     })
 
+    // skip comparison of properties that LUIS API automatically added or updated
     currentAppToCompare.luis_schema_version = existingApp.luis_schema_version
     currentAppToCompare.tokenizerVersion = existingApp.tokenizerVersion
     currentAppToCompare.settings = existingApp.settings
 
+    // align the properties between local Luis json schema and remote one
     existingApp.model_features = existingApp.phraselists
     delete existingApp.phraselists
 
@@ -101,14 +103,17 @@ export class LuBuildCore {
     existingApp.regex_entities = existingApp.regexEntities
     delete existingApp.regexEntities
 
+    // skip none intent comparison if that is automatically added by LUIS server
     if (currentAppToCompare.intents && !currentAppToCompare.intents.some((x: any) => x.name === 'None')) {
       const existingNoneIntentIndex = existingApp.intents.findIndex((x: any) => x.name === 'None')
       if (existingNoneIntentIndex > -1) existingApp.intents.splice(existingNoneIntentIndex, 1)
     }
 
+    // sort properties so that they can be converted to exact same lu content when comparing
     this.sortApplication(currentAppToCompare)
     this.sortApplication(existingApp)
 
+    // compare lu contents converted from luis josn
     const isApplicationEqual = this.isApplicationEqual(currentAppToCompare, existingApp)
 
     return !isApplicationEqual

--- a/packages/lu/src/parser/lubuild/core.ts
+++ b/packages/lu/src/parser/lubuild/core.ts
@@ -86,10 +86,21 @@ export class LuBuildCore {
     });
 
     (currentApp.entities || []).forEach((e: any) => {
-      if (e.children === undefined && existingApp.entities) {
+      if ((e.children === undefined || e.features === undefined) && existingApp.entities) {
         let matchedEntities = existingApp.entities.filter((x: any) => x.name === e.name)
-        if (matchedEntities && matchedEntities.length > 0 && matchedEntities[0].children !== undefined) {
-          e.children = []
+        if (matchedEntities && matchedEntities.length > 0) {
+          if (e.children === undefined && matchedEntities[0].children !== undefined) e.children = []
+
+          if (e.features === undefined && matchedEntities[0].features !== undefined) e.features = []
+        }
+      }
+    });
+
+    (currentApp.intents || []).forEach((i: any) => {
+      if (i.features === undefined && existingApp.intents) {
+        let matchedIntents = existingApp.intents.filter((x: any) => x.name === i.name)
+        if (matchedIntents && matchedIntents.length > 0) {
+          if (i.features === undefined && matchedIntents[0].features !== undefined) i.features = []
         }
       }
     })

--- a/packages/luis/test/commands/luis/build.test.ts
+++ b/packages/luis/test/commands/luis/build.test.ts
@@ -280,7 +280,7 @@ describe('luis:build not update application if no changes', () => {
     })
 })
 
-describe('luis:build write dialog assets successfully if --dialog set', () => {
+describe.only('luis:build write dialog assets successfully if --dialog set', () => {
   const existingLuisApp = require('./../../fixtures/testcases/lubuild/sandwich/luis/test(development)-sandwich.en-us.lu.json')
   before(async function () {
     await fs.ensureDir(path.join(__dirname, './../../../results/'))
@@ -319,7 +319,7 @@ describe('luis:build write dialog assets successfully if --dialog set', () => {
     })
 })
 
-describe('luis:build create multiple applications successfully when input is a folder', () => {
+describe.only('luis:build create multiple applications successfully when input is a folder', () => {
   before(async function () {
     await fs.ensureDir(path.join(__dirname, './../../../results/'))
 
@@ -454,7 +454,7 @@ describe('luis:build create multiple applications successfully when input is a f
     })
 })
 
-describe('luis:build update dialog assets successfully when dialog assets exist', () => {
+describe.only('luis:build update dialog assets successfully when dialog assets exist', () => {
   const existingLuisApp_EN_US = require('./../../fixtures/testcases/lubuild/foo2/luis/test(development)-foo.en-us.lu.json')
   const existingLuisApp_FR_FR = require('./../../fixtures/testcases/lubuild/foo2/luis/test(development)-foo.fr-fr.lu.json')
   before(async function () {
@@ -569,7 +569,7 @@ describe('luis:build update dialog assets successfully when dialog assets exist'
     })
 })
 
-describe('luis:build not update application if only cases of utterances or patterns are changed', () => {
+describe.only('luis:build not update application if only cases of utterances or patterns are changed', () => {
   const existingLuisApp = require('./../../fixtures/testcases/lubuild/case-insensitive/luis/test(development)-case-insensitive.en-us.lu.json')
   before(function () {
     nock('https://westus.api.cognitive.microsoft.com')
@@ -601,7 +601,7 @@ describe('luis:build not update application if only cases of utterances or patte
     })
 })
 
-describe('luis:build update application succeed with parameters set from luconfig', () => {
+describe.only('luis:build update application succeed with parameters set from luconfig', () => {
   const existingLuisApp = require('./../../fixtures/testcases/lubuild/luconfig/luis/MyProject(development)-test.en-us.lu.json')
   before(async function () {
     await fs.ensureDir(path.join(__dirname, './../../../results/'))

--- a/packages/luis/test/commands/luis/build.test.ts
+++ b/packages/luis/test/commands/luis/build.test.ts
@@ -280,7 +280,7 @@ describe('luis:build not update application if no changes', () => {
     })
 })
 
-describe.only('luis:build write dialog assets successfully if --dialog set', () => {
+describe('luis:build write dialog assets successfully if --dialog set', () => {
   const existingLuisApp = require('./../../fixtures/testcases/lubuild/sandwich/luis/test(development)-sandwich.en-us.lu.json')
   before(async function () {
     await fs.ensureDir(path.join(__dirname, './../../../results/'))
@@ -319,7 +319,7 @@ describe.only('luis:build write dialog assets successfully if --dialog set', () 
     })
 })
 
-describe.only('luis:build create multiple applications successfully when input is a folder', () => {
+describe('luis:build create multiple applications successfully when input is a folder', () => {
   before(async function () {
     await fs.ensureDir(path.join(__dirname, './../../../results/'))
 
@@ -454,7 +454,7 @@ describe.only('luis:build create multiple applications successfully when input i
     })
 })
 
-describe.only('luis:build update dialog assets successfully when dialog assets exist', () => {
+describe('luis:build update dialog assets successfully when dialog assets exist', () => {
   const existingLuisApp_EN_US = require('./../../fixtures/testcases/lubuild/foo2/luis/test(development)-foo.en-us.lu.json')
   const existingLuisApp_FR_FR = require('./../../fixtures/testcases/lubuild/foo2/luis/test(development)-foo.fr-fr.lu.json')
   before(async function () {
@@ -569,7 +569,7 @@ describe.only('luis:build update dialog assets successfully when dialog assets e
     })
 })
 
-describe.only('luis:build not update application if only cases of utterances or patterns are changed', () => {
+describe('luis:build not update application if only cases of utterances or patterns are changed', () => {
   const existingLuisApp = require('./../../fixtures/testcases/lubuild/case-insensitive/luis/test(development)-case-insensitive.en-us.lu.json')
   before(function () {
     nock('https://westus.api.cognitive.microsoft.com')
@@ -601,7 +601,7 @@ describe.only('luis:build not update application if only cases of utterances or 
     })
 })
 
-describe.only('luis:build update application succeed with parameters set from luconfig', () => {
+describe('luis:build update application succeed with parameters set from luconfig', () => {
   const existingLuisApp = require('./../../fixtures/testcases/lubuild/luconfig/luis/MyProject(development)-test.en-us.lu.json')
   before(async function () {
     await fs.ensureDir(path.join(__dirname, './../../../results/'))

--- a/packages/luis/test/fixtures/testcases/lubuild/case-insensitive/lufiles/case-insensitive.lu
+++ b/packages/luis/test/fixtures/testcases/lubuild/case-insensitive/lufiles/case-insensitive.lu
@@ -15,12 +15,6 @@
 @ prebuilt age
 @ prebuilt personName
 
-> Phrase list
-@ phraselist profileDefinition(interchangeable) enabledForAllModels = 
-    - I'm 
-    - My
-    - I am
-
 > Define a list entity for user city
 @ list Cities = 
     - seattle :

--- a/packages/luis/test/fixtures/testcases/lubuild/case-insensitive/lufiles/case-insensitive.lu
+++ b/packages/luis/test/fixtures/testcases/lubuild/case-insensitive/lufiles/case-insensitive.lu
@@ -16,7 +16,7 @@
 @ prebuilt personName
 
 > Phrase list
-@ phraselist profileDefinition(interchangeable) = 
+@ phraselist profileDefinition(interchangeable) enabledForAllModels = 
     - I'm 
     - My
     - I am

--- a/packages/luis/test/fixtures/testcases/lubuild/case-insensitive/luis/test(development)-case-insensitive.en-us.lu.json
+++ b/packages/luis/test/fixtures/testcases/lubuild/case-insensitive/luis/test(development)-case-insensitive.en-us.lu.json
@@ -1,26 +1,27 @@
 {
-  "luis_schema_version": "4.0.0",
-  "versionId": "0.2",
   "name": "test(development)-case-insensitive.en-us.lu",
+  "versionId": "0.2",
   "desc": "Model for test app, targetting development",
   "culture": "en-us",
-  "tokenizerVersion": "1.0.0",
   "intents": [
     {
-      "name": "GetUserProfile"
+      "name": "GetUserProfile",
+      "features": []
     },
     {
-      "name": "Greeting"
+      "name": "Greeting",
+      "features": []
     },
     {
-      "name": "Help"
+      "name": "Help",
+      "features": []
     },
     {
-      "name": "None"
+      "name": "None",
+      "features": []
     }
   ],
   "entities": [],
-  "composites": [],
   "closedLists": [
     {
       "name": "Cities",
@@ -43,14 +44,16 @@
       "roles": []
     }
   ],
+  "composites": [],
+  "hierarchicals": [],
   "patternAnyEntities": [
     {
       "name": "Item",
-      "roles": [],
-      "explicitList": []
+      "explicitList": [],
+      "roles": []
     }
   ],
-  "regex_entities": [
+  "regexEntities": [
     {
       "name": "zipCode",
       "regexPattern": "[0-9]{5}",
@@ -67,22 +70,15 @@
       "roles": []
     }
   ],
-  "model_features": [
-    {
-      "name": "profileDefinition",
-      "mode": true,
-      "words": "I'm,My,I am",
-      "activated": true
-    }
-  ],
-  "regex_features": [],
+  "regexFeatures": [],
+  "phraselists": [],
   "patterns": [
     {
-      "pattern": "please help {Item}",
+      "pattern": "help me with {Item}",
       "intent": "Help"
     },
     {
-      "pattern": "help me with {Item}",
+      "pattern": "please help {Item}",
       "intent": "Help"
     }
   ],
@@ -113,5 +109,7 @@
       "entities": []
     }
   ],
+  "luis_schema_version": "6.0.0",
+  "tokenizerVersion": "1.0.0",
   "settings": []
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/foo2/luis/test(development)-foo.en-us.lu.json
+++ b/packages/luis/test/fixtures/testcases/lubuild/foo2/luis/test(development)-foo.en-us.lu.json
@@ -1,26 +1,27 @@
 {
-  "luis_schema_version": "4.0.0",
-  "versionId": "0.1",
   "name": "test(development)-foo.en-us.lu",
+  "versionId": "0.1",
   "desc": "Model for test app, targetting development",
   "culture": "en-us",
-  "tokenizerVersion": "1.0.0",
   "intents": [
     {
-      "name": "None"
+      "name": "None",
+      "features": []
     },
     {
-      "name": "YoCarlos"
+      "name": "YoCarlos",
+      "features": []
     }
   ],
   "entities": [],
-  "composites": [],
   "closedLists": [],
+  "composites": [],
+  "hierarchicals": [],
   "patternAnyEntities": [],
-  "regex_entities": [],
+  "regexEntities": [],
   "prebuiltEntities": [],
-  "model_features": [],
-  "regex_features": [],
+  "regexFeatures": [],
+  "phraselists": [],
   "patterns": [],
   "utterances": [
     {
@@ -44,5 +45,7 @@
       "entities": []
     }
   ],
+  "luis_schema_version": "6.0.0",
+  "tokenizerVersion": "1.0.0",
   "settings": []
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/foo2/luis/test(development)-foo.fr-fr.lu.json
+++ b/packages/luis/test/fixtures/testcases/lubuild/foo2/luis/test(development)-foo.fr-fr.lu.json
@@ -1,26 +1,27 @@
 {
-  "luis_schema_version": "4.0.0",
-  "versionId": "0.1",
   "name": "test(development)-foo.fr-fr.lu",
+  "versionId": "0.1",
   "desc": "Model for test app, targetting development",
   "culture": "fr-fr",
-  "tokenizerVersion": "1.0.0",
   "intents": [
     {
-      "name": "None"
+      "name": "None",
+      "features": []
     },
     {
-      "name": "YoCarlos"
+      "name": "YoCarlos",
+      "features": []
     }
   ],
   "entities": [],
-  "composites": [],
   "closedLists": [],
+  "composites": [],
+  "hierarchicals": [],
   "patternAnyEntities": [],
-  "regex_entities": [],
+  "regexEntities": [],
   "prebuiltEntities": [],
-  "model_features": [],
-  "regex_features": [],
+  "regexFeatures": [],
+  "phraselists": [],
   "patterns": [],
   "utterances": [
     {
@@ -29,5 +30,12 @@
       "entities": []
     }
   ],
-  "settings": []
+  "luis_schema_version": "6.0.0",
+  "tokenizerVersion": "1.0.0",
+  "settings": [
+    {
+      "name": "NormalizeDiacritics",
+      "value": "true"
+    }
+  ]
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/luconfig/lufiles/test.lu
+++ b/packages/luis/test/fixtures/testcases/lubuild/luconfig/lufiles/test.lu
@@ -1,16 +1,6 @@
 > Entity definitions 
 $ itemTitle : simple
 
-> Add a Phrase List with todo variations. Mark them as interchangeable.
-$ todoItem : PhraseList interchangeable
-   - todo
-   - todos
-   - to dos
-   - todo list
-   - todos list
-   - item list
-   - items collection
-
 > Add a list entity to detect list tye
 $ listType : todo = 
 - to do

--- a/packages/luis/test/fixtures/testcases/lubuild/luconfig/luis/MyProject(development)-test.en-us.lu.json
+++ b/packages/luis/test/fixtures/testcases/lubuild/luconfig/luis/MyProject(development)-test.en-us.lu.json
@@ -1,40 +1,46 @@
 {
-  "luis_schema_version": "4.0.0",
-  "versionId": "0.1",
   "name": "MyProject(development)-test.en-us.lu",
+  "versionId": "0.1",
   "desc": "Model for MyProject app, targetting development",
   "culture": "en-us",
-  "tokenizerVersion": "1.0.0",
   "intents": [
     {
-      "name": "AddItem"
+      "name": "AddItem",
+      "features": []
     },
     {
-      "name": "Cancel"
+      "name": "Cancel",
+      "features": []
     },
     {
-      "name": "DeleteItem"
+      "name": "DeleteItem",
+      "features": []
     },
     {
-      "name": "Greeting"
+      "name": "Greeting",
+      "features": []
     },
     {
-      "name": "Help"
+      "name": "Help",
+      "features": []
     },
     {
-      "name": "None"
+      "name": "None",
+      "features": []
     },
     {
-      "name": "ViewCollection"
+      "name": "ViewCollection",
+      "features": []
     }
   ],
   "entities": [
     {
       "name": "itemTitle",
+      "children": [],
+      "features": [],
       "roles": []
     }
   ],
-  "composites": [],
   "closedLists": [
     {
       "name": "listType",
@@ -68,93 +74,16 @@
       "roles": []
     }
   ],
+  "composites": [],
+  "hierarchicals": [],
   "patternAnyEntities": [],
-  "regex_entities": [],
+  "regexEntities": [],
   "prebuiltEntities": [],
-  "model_features": [
-    {
-      "name": "todoItem",
-      "mode": true,
-      "words": "todo,todos,to dos,todo list,todos list,item list,items collection,collection,list",
-      "activated": true
-    }
-  ],
-  "regex_features": [],
+  "regexFeatures": [],
+  "phraselists": [],
   "patterns": [
     {
-      "pattern": "create to do to {itemTitle}",
-      "intent": "AddItem"
-    },
-    {
-      "pattern": "add a to do that buy {itemTitle}",
-      "intent": "AddItem"
-    },
-    {
-      "pattern": "delete {itemTitle}",
-      "intent": "DeleteItem"
-    },
-    {
-      "pattern": "add {itemTitle} to my todo list",
-      "intent": "AddItem"
-    },
-    {
       "pattern": "add to do to {itemTitle}",
-      "intent": "AddItem"
-    },
-    {
-      "pattern": "add {itemTitle} to my to do list",
-      "intent": "AddItem"
-    },
-    {
-      "pattern": "remove {itemTitle} from my [todo] list",
-      "intent": "DeleteItem"
-    },
-    {
-      "pattern": "[please] delete {itemTitle} from the list",
-      "intent": "DeleteItem"
-    },
-    {
-      "pattern": "please remember [to] {itemTitle}",
-      "intent": "AddItem"
-    },
-    {
-      "pattern": "mark {itemTitle} as complete",
-      "intent": "DeleteItem"
-    },
-    {
-      "pattern": "add to do that {itemTitle}",
-      "intent": "AddItem"
-    },
-    {
-      "pattern": "add a to do that purchase {itemTitle}",
-      "intent": "AddItem"
-    },
-    {
-      "pattern": "add {itemTitle} to the list",
-      "intent": "AddItem"
-    },
-    {
-      "pattern": "i need you to remember [that] {itemTitle}",
-      "intent": "AddItem"
-    },
-    {
-      "pattern": "i did {itemTitle}",
-      "intent": "DeleteItem"
-    },
-    {
-      "pattern": "remind me to {itemTitle}",
-      "intent": "AddItem"
-    },
-    {
-      "pattern": "add a to do that shop {itemTitle}",
-      "intent": "AddItem"
-    },
-    {
-      "pattern": "add {itemTitle} to my todo",
-      "intent": "AddItem"
-    },
-    {
-      "pattern": "add {itemTitle} to my to dos",
       "intent": "AddItem"
     },
     {
@@ -162,11 +91,27 @@
       "intent": "AddItem"
     },
     {
-      "pattern": "add a to do to {itemTitle}",
+      "pattern": "add {itemTitle} to my to dos",
       "intent": "AddItem"
     },
     {
-      "pattern": "create a to do to {itemTitle}",
+      "pattern": "create to do to {itemTitle}",
+      "intent": "AddItem"
+    },
+    {
+      "pattern": "add a to do that shop {itemTitle}",
+      "intent": "AddItem"
+    },
+    {
+      "pattern": "i need you to remember [that] {itemTitle}",
+      "intent": "AddItem"
+    },
+    {
+      "pattern": "remove {itemTitle} from my [todo] list",
+      "intent": "DeleteItem"
+    },
+    {
+      "pattern": "add a to do that purchase {itemTitle}",
       "intent": "AddItem"
     },
     {
@@ -174,8 +119,64 @@
       "intent": "AddItem"
     },
     {
+      "pattern": "add a to do to {itemTitle}",
+      "intent": "AddItem"
+    },
+    {
+      "pattern": "i did {itemTitle}",
+      "intent": "DeleteItem"
+    },
+    {
+      "pattern": "add to do that {itemTitle}",
+      "intent": "AddItem"
+    },
+    {
+      "pattern": "[please] delete {itemTitle} from the list",
+      "intent": "DeleteItem"
+    },
+    {
+      "pattern": "add a to do that buy {itemTitle}",
+      "intent": "AddItem"
+    },
+    {
+      "pattern": "create a to do to {itemTitle}",
+      "intent": "AddItem"
+    },
+    {
+      "pattern": "mark {itemTitle} as complete",
+      "intent": "DeleteItem"
+    },
+    {
       "pattern": "i completed {itemTitle}",
       "intent": "DeleteItem"
+    },
+    {
+      "pattern": "add {itemTitle} to my todo list",
+      "intent": "AddItem"
+    },
+    {
+      "pattern": "add {itemTitle} to my to do list",
+      "intent": "AddItem"
+    },
+    {
+      "pattern": "please remember [to] {itemTitle}",
+      "intent": "AddItem"
+    },
+    {
+      "pattern": "add {itemTitle} to the list",
+      "intent": "AddItem"
+    },
+    {
+      "pattern": "add {itemTitle} to my todo",
+      "intent": "AddItem"
+    },
+    {
+      "pattern": "delete {itemTitle}",
+      "intent": "DeleteItem"
+    },
+    {
+      "pattern": "remind me to {itemTitle}",
+      "intent": "AddItem"
     }
   ],
   "utterances": [
@@ -199,9 +200,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 17,
-          "endPos": 39
+          "endPos": 39,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -210,9 +211,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 15,
-          "endPos": 23
+          "endPos": 23,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -221,9 +222,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 16,
-          "endPos": 39
+          "endPos": 39,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -232,9 +233,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 17,
-          "endPos": 45
+          "endPos": 45,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -243,9 +244,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 15,
-          "endPos": 43
+          "endPos": 43,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -259,9 +260,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 4,
-          "endPos": 17
+          "endPos": 17,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -270,9 +271,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 4,
-          "endPos": 52
+          "endPos": 52,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -281,9 +282,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 4,
-          "endPos": 19
+          "endPos": 19,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -292,9 +293,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 4,
-          "endPos": 16
+          "endPos": 16,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -303,9 +304,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 4,
-          "endPos": 13
+          "endPos": 13,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -314,9 +315,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 4,
-          "endPos": 20
+          "endPos": 20,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -325,9 +326,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 4,
-          "endPos": 10
+          "endPos": 10,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -341,9 +342,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 21,
-          "endPos": 35
+          "endPos": 35,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -352,9 +353,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 21,
-          "endPos": 61
+          "endPos": 61,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -363,9 +364,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 21,
-          "endPos": 60
+          "endPos": 60,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -379,9 +380,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 4,
-          "endPos": 15
+          "endPos": 15,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -390,9 +391,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 10,
-          "endPos": 15
+          "endPos": 15,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -401,9 +402,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 15,
-          "endPos": 19
+          "endPos": 19,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -412,9 +413,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 15,
-          "endPos": 17
+          "endPos": 17,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -473,9 +474,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 20,
-          "endPos": 32
+          "endPos": 32,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -489,9 +490,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 12,
-          "endPos": 19
+          "endPos": 19,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -505,9 +506,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 18,
-          "endPos": 36
+          "endPos": 36,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -516,9 +517,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 16,
-          "endPos": 37
+          "endPos": 37,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -532,9 +533,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 7,
-          "endPos": 10
+          "endPos": 10,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -543,9 +544,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 11,
-          "endPos": 21
+          "endPos": 21,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -554,9 +555,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 7,
-          "endPos": 13
+          "endPos": 13,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -565,9 +566,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 7,
-          "endPos": 12
+          "endPos": 12,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -576,9 +577,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 12,
-          "endPos": 21
+          "endPos": 21,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -587,9 +588,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 12,
-          "endPos": 31
+          "endPos": 31,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -598,9 +599,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 16,
-          "endPos": 24
+          "endPos": 24,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -614,9 +615,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 16,
-          "endPos": 41
+          "endPos": 41,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -625,9 +626,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 21,
-          "endPos": 45
+          "endPos": 45,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -636,9 +637,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 17,
-          "endPos": 40
+          "endPos": 40,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -647,9 +648,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 22,
-          "endPos": 41
+          "endPos": 41,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -658,9 +659,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 22,
-          "endPos": 64
+          "endPos": 64,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -669,9 +670,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 13,
-          "endPos": 20
+          "endPos": 20,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -680,9 +681,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 13,
-          "endPos": 23
+          "endPos": 23,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -691,9 +692,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 18,
-          "endPos": 35
+          "endPos": 35,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -722,9 +723,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 6,
-          "endPos": 12
+          "endPos": 12,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -733,9 +734,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 6,
-          "endPos": 12
+          "endPos": 12,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -744,9 +745,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 5,
-          "endPos": 13
+          "endPos": 13,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -835,9 +836,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 28,
-          "endPos": 56
+          "endPos": 56,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -866,9 +867,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 5,
-          "endPos": 12
+          "endPos": 12,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -892,9 +893,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 31,
-          "endPos": 38
+          "endPos": 38,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -903,9 +904,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 20,
-          "endPos": 27
+          "endPos": 27,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -934,9 +935,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 4,
-          "endPos": 8
+          "endPos": 8,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -945,9 +946,9 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 13,
-          "endPos": 32
+          "endPos": 32,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -971,9 +972,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 7,
-          "endPos": 12
+          "endPos": 12,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -982,9 +983,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 7,
-          "endPos": 17
+          "endPos": 17,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -993,9 +994,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 7,
-          "endPos": 11
+          "endPos": 11,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -1004,9 +1005,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 7,
-          "endPos": 22
+          "endPos": 22,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -1015,9 +1016,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 7,
-          "endPos": 22
+          "endPos": 22,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -1026,9 +1027,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 12,
-          "endPos": 23
+          "endPos": 23,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -1037,9 +1038,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 12,
-          "endPos": 22
+          "endPos": 22,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -1048,9 +1049,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 17,
-          "endPos": 38
+          "endPos": 38,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -1059,9 +1060,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 17,
-          "endPos": 27
+          "endPos": 27,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -1075,9 +1076,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 16,
-          "endPos": 20
+          "endPos": 20,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -1086,9 +1087,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 21,
-          "endPos": 44
+          "endPos": 44,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -1097,9 +1098,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 17,
-          "endPos": 36
+          "endPos": 36,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -1108,9 +1109,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 22,
-          "endPos": 44
+          "endPos": 44,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -1119,9 +1120,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 13,
-          "endPos": 25
+          "endPos": 25,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -1130,9 +1131,9 @@
       "intent": "DeleteItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 18,
-          "endPos": 51
+          "endPos": 51,
+          "entity": "itemTitle"
         }
       ]
     },
@@ -1207,7 +1208,7 @@
       "entities": []
     },
     {
-      "text": "who are you?",
+      "text": "who am I?",
       "intent": "Help",
       "entities": []
     },
@@ -1216,12 +1217,14 @@
       "intent": "AddItem",
       "entities": [
         {
-          "entity": "itemTitle",
           "startPos": 14,
-          "endPos": 24
+          "endPos": 24,
+          "entity": "itemTitle"
         }
       ]
     }
   ],
+  "luis_schema_version": "6.0.0",
+  "tokenizerVersion": "1.0.0",
   "settings": []
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/sandwich/luis/test(development)-sandwich.en-us.lu.json
+++ b/packages/luis/test/fixtures/testcases/lubuild/sandwich/luis/test(development)-sandwich.en-us.lu.json
@@ -1,31 +1,34 @@
 {
-  "luis_schema_version": "4.0.0",
-  "versionId": "0.1",
   "name": "test(development)-sandwich.en-us.lu",
+  "versionId": "0.1",
   "desc": "Model for test app, targetting development",
   "culture": "en-us",
-  "tokenizerVersion": "1.0.0",
   "intents": [
     {
-      "name": "Cancel"
+      "name": "Cancel",
+      "features": []
     },
     {
-      "name": "Help"
+      "name": "Help",
+      "features": []
     },
     {
-      "name": "None"
+      "name": "None",
+      "features": []
     },
     {
-      "name": "sandwich"
+      "name": "sandwich",
+      "features": []
     }
   ],
   "entities": [
     {
       "name": "NameEntity",
+      "children": [],
+      "features": [],
       "roles": []
     }
   ],
-  "composites": [],
   "closedLists": [
     {
       "name": "BreadEntity",
@@ -218,8 +221,10 @@
       "roles": []
     }
   ],
+  "composites": [],
+  "hierarchicals": [],
   "patternAnyEntities": [],
-  "regex_entities": [],
+  "regexEntities": [],
   "prebuiltEntities": [
     {
       "name": "dimension",
@@ -236,31 +241,15 @@
       ]
     }
   ],
-  "model_features": [],
-  "regex_features": [],
+  "regexFeatures": [],
+  "phraselists": [],
   "patterns": [
-    {
-      "pattern": "{BreadEntity}",
-      "intent": "sandwich"
-    },
     {
       "pattern": "help with {PROPERTYName}",
       "intent": "Help"
     },
     {
-      "pattern": "{money}",
-      "intent": "sandwich"
-    },
-    {
-      "pattern": "{PROPERTYName}",
-      "intent": "sandwich"
-    },
-    {
-      "pattern": "{CheeseEntity}",
-      "intent": "sandwich"
-    },
-    {
-      "pattern": "{Confirmation}",
+      "pattern": "{NameEntity}",
       "intent": "sandwich"
     },
     {
@@ -268,7 +257,11 @@
       "intent": "sandwich"
     },
     {
-      "pattern": "{NameEntity}",
+      "pattern": "{Confirmation}",
+      "intent": "sandwich"
+    },
+    {
+      "pattern": "{PROPERTYName}",
       "intent": "sandwich"
     },
     {
@@ -276,12 +269,24 @@
       "intent": "sandwich"
     },
     {
-      "pattern": "{MeatEntity}",
+      "pattern": "help {PROPERTYName}",
+      "intent": "Help"
+    },
+    {
+      "pattern": "{BreadEntity}",
       "intent": "sandwich"
     },
     {
-      "pattern": "help {PROPERTYName}",
-      "intent": "Help"
+      "pattern": "{CheeseEntity}",
+      "intent": "sandwich"
+    },
+    {
+      "pattern": "{money}",
+      "intent": "sandwich"
+    },
+    {
+      "pattern": "{MeatEntity}",
+      "intent": "sandwich"
     }
   ],
   "utterances": [
@@ -341,5 +346,7 @@
       "entities": []
     }
   ],
+  "luis_schema_version": "6.0.0",
+  "tokenizerVersion": "1.0.0",
   "settings": []
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/sandwich/luis/test(development)-sandwich.utteranceAdded.en-us.lu.json
+++ b/packages/luis/test/fixtures/testcases/lubuild/sandwich/luis/test(development)-sandwich.utteranceAdded.en-us.lu.json
@@ -1,31 +1,34 @@
 {
-  "luis_schema_version": "4.0.0",
-  "versionId": "0.1",
   "name": "test(development)-sandwich.en-us.lu",
+  "versionId": "0.1",
   "desc": "Model for test app, targetting development",
   "culture": "en-us",
-  "tokenizerVersion": "1.0.0",
   "intents": [
     {
-      "name": "Cancel"
+      "name": "Cancel",
+      "features": []
     },
     {
-      "name": "Help"
+      "name": "Help",
+      "features": []
     },
     {
-      "name": "None"
+      "name": "None",
+      "features": []
     },
     {
-      "name": "sandwich"
+      "name": "sandwich",
+      "features": []
     }
   ],
   "entities": [
     {
       "name": "NameEntity",
+      "children": [],
+      "features": [],
       "roles": []
     }
   ],
-  "composites": [],
   "closedLists": [
     {
       "name": "BreadEntity",
@@ -218,8 +221,10 @@
       "roles": []
     }
   ],
+  "composites": [],
+  "hierarchicals": [],
   "patternAnyEntities": [],
-  "regex_entities": [],
+  "regexEntities": [],
   "prebuiltEntities": [
     {
       "name": "dimension",
@@ -236,31 +241,15 @@
       ]
     }
   ],
-  "model_features": [],
-  "regex_features": [],
+  "regexFeatures": [],
+  "phraselists": [],
   "patterns": [
-    {
-      "pattern": "{BreadEntity}",
-      "intent": "sandwich"
-    },
     {
       "pattern": "help with {PROPERTYName}",
       "intent": "Help"
     },
     {
-      "pattern": "{money}",
-      "intent": "sandwich"
-    },
-    {
-      "pattern": "{PROPERTYName}",
-      "intent": "sandwich"
-    },
-    {
-      "pattern": "{CheeseEntity}",
-      "intent": "sandwich"
-    },
-    {
-      "pattern": "{Confirmation}",
+      "pattern": "{NameEntity}",
       "intent": "sandwich"
     },
     {
@@ -268,7 +257,11 @@
       "intent": "sandwich"
     },
     {
-      "pattern": "{NameEntity}",
+      "pattern": "{Confirmation}",
+      "intent": "sandwich"
+    },
+    {
+      "pattern": "{PROPERTYName}",
       "intent": "sandwich"
     },
     {
@@ -276,12 +269,24 @@
       "intent": "sandwich"
     },
     {
-      "pattern": "{MeatEntity}",
+      "pattern": "help {PROPERTYName}",
+      "intent": "Help"
+    },
+    {
+      "pattern": "{BreadEntity}",
       "intent": "sandwich"
     },
     {
-      "pattern": "help {PROPERTYName}",
-      "intent": "Help"
+      "pattern": "{CheeseEntity}",
+      "intent": "sandwich"
+    },
+    {
+      "pattern": "{money}",
+      "intent": "sandwich"
+    },
+    {
+      "pattern": "{MeatEntity}",
+      "intent": "sandwich"
     }
   ],
   "utterances": [
@@ -316,6 +321,11 @@
       "entities": []
     },
     {
+      "text": "how can i do for you?",
+      "intent": "Help",
+      "entities": []
+    },
+    {
       "text": "i don't understand",
       "intent": "Help",
       "entities": []
@@ -339,12 +349,9 @@
       "text": "what can i do?",
       "intent": "Help",
       "entities": []
-    },
-    {
-      "text": "how can i do for you?",
-      "intent": "Help",
-      "entities": []
     }
   ],
+  "luis_schema_version": "6.0.0",
+  "tokenizerVersion": "1.0.0",
   "settings": []
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/sandwich/luis/test(development)-sandwich.utteranceChanged.en-us.lu.json
+++ b/packages/luis/test/fixtures/testcases/lubuild/sandwich/luis/test(development)-sandwich.utteranceChanged.en-us.lu.json
@@ -1,31 +1,34 @@
 {
-  "luis_schema_version": "4.0.0",
-  "versionId": "0.1",
   "name": "test(development)-sandwich.en-us.lu",
+  "versionId": "0.1",
   "desc": "Model for test app, targetting development",
   "culture": "en-us",
-  "tokenizerVersion": "1.0.0",
   "intents": [
     {
-      "name": "Cancel"
+      "name": "Cancel",
+      "features": []
     },
     {
-      "name": "Help"
+      "name": "Help",
+      "features": []
     },
     {
-      "name": "None"
+      "name": "None",
+      "features": []
     },
     {
-      "name": "sandwich"
+      "name": "sandwich",
+      "features": []
     }
   ],
   "entities": [
     {
       "name": "NameEntity",
+      "children": [],
+      "features": [],
       "roles": []
     }
   ],
-  "composites": [],
   "closedLists": [
     {
       "name": "BreadEntity",
@@ -218,8 +221,10 @@
       "roles": []
     }
   ],
+  "composites": [],
+  "hierarchicals": [],
   "patternAnyEntities": [],
-  "regex_entities": [],
+  "regexEntities": [],
   "prebuiltEntities": [
     {
       "name": "dimension",
@@ -236,31 +241,15 @@
       ]
     }
   ],
-  "model_features": [],
-  "regex_features": [],
+  "regexFeatures": [],
+  "phraselists": [],
   "patterns": [
-    {
-      "pattern": "{BreadEntity}",
-      "intent": "sandwich"
-    },
     {
       "pattern": "help with {PROPERTYName}",
       "intent": "Help"
     },
     {
-      "pattern": "{money}",
-      "intent": "sandwich"
-    },
-    {
-      "pattern": "{PROPERTYName}",
-      "intent": "sandwich"
-    },
-    {
-      "pattern": "{CheeseEntity}",
-      "intent": "sandwich"
-    },
-    {
-      "pattern": "{Confirmation}",
+      "pattern": "{NameEntity}",
       "intent": "sandwich"
     },
     {
@@ -268,7 +257,11 @@
       "intent": "sandwich"
     },
     {
-      "pattern": "{NameEntity}",
+      "pattern": "{Confirmation}",
+      "intent": "sandwich"
+    },
+    {
+      "pattern": "{PROPERTYName}",
       "intent": "sandwich"
     },
     {
@@ -276,12 +269,24 @@
       "intent": "sandwich"
     },
     {
-      "pattern": "{MeatEntity}",
+      "pattern": "help {PROPERTYName}",
+      "intent": "Help"
+    },
+    {
+      "pattern": "{BreadEntity}",
       "intent": "sandwich"
     },
     {
-      "pattern": "help {PROPERTYName}",
-      "intent": "Help"
+      "pattern": "{CheeseEntity}",
+      "intent": "sandwich"
+    },
+    {
+      "pattern": "{money}",
+      "intent": "sandwich"
+    },
+    {
+      "pattern": "{MeatEntity}",
+      "intent": "sandwich"
     }
   ],
   "utterances": [
@@ -316,6 +321,11 @@
       "entities": []
     },
     {
+      "text": "how can i do for you?",
+      "intent": "Help",
+      "entities": []
+    },
+    {
       "text": "i don't understand",
       "intent": "Help",
       "entities": []
@@ -334,12 +344,9 @@
       "text": "shisls",
       "intent": "None",
       "entities": []
-    },
-    {
-      "text": "how can i do for you?",
-      "intent": "Help",
-      "entities": []
     }
   ],
+  "luis_schema_version": "6.0.0",
+  "tokenizerVersion": "1.0.0",
   "settings": []
 }


### PR DESCRIPTION
fix a bug in lu build when comparing apps to decide update app or not. The bug is caused due to the returning application structure of luis exportApplication api changes in version 3.0-preview that I switched recently. The reason why unit tests cannot hit this case is that the returning json from luis portal doesn't change in new API version but the object from luis api changed, so it's hard to detect it by unit tests. **_Hope this can catch R8 release_**, otherwise lu build may hit issues when users run lu build for lu files which don't have changes(That's saying lu build will always update luis application to a new version even though the lu files don't change actually). @vishwasena, @munozemilio could you help?