### PR TITLE
support multi trigger intents point to same lu file

### DIFF
--- a/packages/lu/src/parser/cross-train/crossTrainer.js
+++ b/packages/lu/src/parser/cross-train/crossTrainer.js
@@ -122,9 +122,9 @@ const constructResoureTree = function (fileIdToLuResourceMap, triggerRules) {
 
       resources.push(resource)
     }
-
-    return resources
   }
+
+  return resources
 }
 
 /**

--- a/packages/lu/src/parser/cross-train/crossTrainer.js
+++ b/packages/lu/src/parser/cross-train/crossTrainer.js
@@ -119,9 +119,9 @@ const constructResoureTree = function (fileIdToLuResourceMap, triggerRules) {
           intent: triggerIntent
         })
       }
-
-      resources.push(resource)
     }
+
+    resources.push(resource)
   }
 
   return resources

--- a/packages/lu/src/parser/cross-train/crossTrainer.js
+++ b/packages/lu/src/parser/cross-train/crossTrainer.js
@@ -93,36 +93,38 @@ const constructResoureTree = function (fileIdToLuResourceMap, triggerRules) {
       }
     }
 
-    const destLuFileToIntents = triggerRules[fileId]
-    for (const destLuFile of Object.keys(destLuFileToIntents)) {
-      if (destLuFile !== '' && !fileIdsFromInput.includes(destLuFile)) continue
+    const intentToDestLuFiles = triggerRules[fileId]
+    for (const triggerIntent of Object.keys(intentToDestLuFiles)) {
+      if (triggerIntent !== '' && !intents.some(i => i.Name === triggerIntent)) {
+        throw (new exception(retCode.errorCode.INVALID_INPUT, `Sorry, trigger intent '${triggerIntent}' is not found in lu file: ${fileId}`))
+      }
 
-      let triggerIntentNames = destLuFileToIntents[destLuFile]
-      if (typeof triggerIntentNames === 'string') triggerIntentNames = [triggerIntentNames]
-      
-      if (triggerIntentNames.length > 0) {
-        triggerIntentNames.forEach(triggerIntentName => {
-          if (triggerIntentName !== '' && !intents.some(i => i.Name === triggerIntentName)) {
-            throw (new exception(retCode.errorCode.INVALID_INPUT, `Sorry, trigger intent '${triggerIntentNames}' is not found in lu file: ${fileId}`))
+      let destLuFiles = intentToDestLuFiles[triggerIntent]
+      if (typeof destLuFiles === 'string') destLuFiles = [destLuFiles]
+
+      if (destLuFiles.length > 0) {
+        destLuFiles.forEach(destLuFile => {
+          if (destLuFile !== '' && !fileIdsFromInput.includes(destLuFile)) {
+            throw (new exception(retCode.errorCode.INVALID_INPUT, `Sorry, lu file '${destLuFile}' is not found`))
           } else {
             resource.children.push({
               target: destLuFile,
-              intent: triggerIntentName
+              intent: triggerIntent
             })
           }
         })
       } else {
         resource.children.push({
-          target: destLuFile,
-          intent: ''
+          target: '',
+          intent: triggerIntent
         })
       }
+
+      resources.push(resource)
     }
 
-    resources.push(resource)
+    return resources
   }
-
-  return resources
 }
 
 /**

--- a/packages/lu/src/utils/filehelper.ts
+++ b/packages/lu/src/utils/filehelper.ts
@@ -239,7 +239,7 @@ export function getConfigObject(configContent: any, intentName: string) {
             for (const triggerKey of Object.keys(triggers)) {
               const destLuFiles = triggers[triggerKey] instanceof Array ? triggers[triggerKey] : [triggers[triggerKey]]
               for (const destLuFile of destLuFiles) {
-                const destLuFileFullPath = destLuFile !== '' ? path.resolve(configFileDir, destLuFile) : destLuFile
+                const destLuFileFullPath = destLuFile && destLuFile !== '' ? path.resolve(configFileDir, destLuFile) : destLuFile
                 if (rootLuFileFullPath in finalLuConfigObj) {
                   const finalIntentToDestLuFiles = finalLuConfigObj[rootLuFileFullPath]
                   if (finalIntentToDestLuFiles[triggerKey]) {

--- a/packages/lu/src/utils/filehelper.ts
+++ b/packages/lu/src/utils/filehelper.ts
@@ -239,14 +239,18 @@ export function getConfigObject(configContent: any, intentName: string) {
             for (const triggerKey of Object.keys(triggers)) {
               const destLuFiles = triggers[triggerKey] instanceof Array ? triggers[triggerKey] : [triggers[triggerKey]]
               for (const destLuFile of destLuFiles) {
-                const destLuFileFullPath = path.resolve(configFileDir, destLuFile)
+                const destLuFileFullPath = destLuFile !== '' ? path.resolve(configFileDir, destLuFile) : destLuFile
                 if (rootLuFileFullPath in finalLuConfigObj) {
-                  const finalDestLuFileToIntent = finalLuConfigObj[rootLuFileFullPath]
-                  finalDestLuFileToIntent[destLuFileFullPath] = triggerKey
+                  const finalIntentToDestLuFiles = finalLuConfigObj[rootLuFileFullPath]
+                  if (finalIntentToDestLuFiles[triggerKey]) {
+                    finalIntentToDestLuFiles[triggerKey].push(destLuFileFullPath)
+                  } else {
+                    finalIntentToDestLuFiles[triggerKey] = [destLuFileFullPath]
+                  }
                 } else {
-                  let finalDestLuFileToIntent = Object.create(null)
-                  finalDestLuFileToIntent[destLuFileFullPath] = triggerKey
-                  finalLuConfigObj[rootLuFileFullPath] = finalDestLuFileToIntent
+                  let finalIntentToDestLuFiles = Object.create(null)
+                  finalIntentToDestLuFiles[triggerKey] = [destLuFileFullPath]
+                  finalLuConfigObj[rootLuFileFullPath] = finalIntentToDestLuFiles
                 }
               }
             }

--- a/packages/lu/test/parser/cross-train/crossTrainer.test.js
+++ b/packages/lu/test/parser/cross-train/crossTrainer.test.js
@@ -170,15 +170,15 @@ describe('luis:cross training tests among lu and qna contents', () => {
       ],
       triggerRules: {
         'main.lu': {
-          'dia1.lu': 'dia1_trigger',
-          'dia2.lu': 'dia2_trigger'
+          'dia1_trigger': 'dia1.lu',
+          'dia2_trigger': 'dia2.lu'
         },
         'dia2.lu': {
-          'dia3.lu': 'dia3_trigger',
-          'dia4.lu': 'dia4_trigger'
+          'dia3_trigger': 'dia3.lu',
+          'dia4_trigger': 'dia4.lu'
         },
         'main.fr-fr.lu': {
-          'dia1.fr-fr.lu': 'dia1_trigger'
+          'dia1_trigger': 'dia1.fr-fr.lu'
         }
       },
       intentName: '_Interruption',
@@ -284,8 +284,8 @@ describe('luis:cross training tests among lu and qna contents', () => {
       ],
       triggerRules: {
         './main/main.lu': {
-          './dia1/dia1.lu': 'dia1_trigger',
-          './dia2/dia2.lu': 'dia2_trigger'
+          'dia1_trigger': './dia1/dia1.lu',
+          'dia2_trigger': './dia2/dia2.lu'
         }
       },
       intentName: '_Interruption',
@@ -339,9 +339,8 @@ describe('luis:cross training tests among lu and qna contents', () => {
       ],
       triggerRules: {
         './main/main.lu': {
-          './dia1/dia1.lu': 'dia1_trigger',
-          './dia2/dia2.lu': 'dia1_trigger',
-          './dia3/dia3.lu': 'dia2_trigger'
+          'dia1_trigger': ['./dia1/dia1.lu', './dia2/dia2.lu'],
+          'dia2_trigger': './dia3/dia3.lu'
         }
       },
       intentName: '_Interruption',
@@ -398,8 +397,8 @@ describe('luis:cross training tests among lu and qna contents', () => {
       ],
       triggerRules: {
         './main/main.lu': {
-          './dia1/dia1.lu': 'dia1_trigger',
-          './dia2/dia2.lu': 'dia2_trigger'
+          'dia1_trigger': './dia1/dia1.lu',
+          'dia2_trigger': './dia2/dia2.lu'
         }
       },
       intentName: '_Interruption',
@@ -460,10 +459,10 @@ describe('luis:cross training tests among lu and qna contents', () => {
       ],
       triggerRules: {
         './main/main.lu': {
-          './dia1/dia1.lu': 'dia1_trigger',
-          './dia2/dia2.lu': 'dia2_trigger',
-          '': 'dia3_trigger',
-          './dia3/dia3.lu': ''
+          'dia1_trigger': './dia1/dia1.lu',
+          'dia2_trigger': './dia2/dia2.lu',
+          'dia3_trigger': '',
+          '': './dia3/dia3.lu'
         }
       },
       intentName: '_Interruption',
@@ -523,8 +522,10 @@ describe('luis:cross training tests among lu and qna contents', () => {
       ],
       triggerRules: {
         './main/main.lu': {
-          './dia1/dia1.lu': ['dia1_trigger', 'dia2_trigger'],
-          './dia2/dia2.lu': ['dia3_trigger', '']
+          'dia1_trigger': './dia1/dia1.lu',
+          'dia2_trigger': './dia1/dia1.lu',
+          'dia3_trigger': './dia2/dia2.lu',
+          '': './dia2/dia2.lu'
         }
       },
       intentName: '_Interruption',

--- a/packages/lu/test/utils/filehelper.test.js
+++ b/packages/lu/test/utils/filehelper.test.js
@@ -1,5 +1,6 @@
 import {readTextFile} from './../../src/utils/textfilereader'
 const expect = require('chai').expect;   
+const assert = require('chai').assert
 const fileHelper = require('./../../src/utils/filehelper')
 const luObject = require('./../../src/parser/lu/lu')
 const luOptions = require('./../../src/parser/lu/luOptions')
@@ -27,5 +28,48 @@ describe('utils/filehelper test', () => {
             let expected = []
             expected.push(new luObject(content, new luOptions('stdin')))
             expect(luObjArray).to.deep.equal(expected)
+    })
+
+    it('File helper correctly build cross train config object', function () {
+        const configContent = {
+            "./main/main.lu": {
+                "rootDialog": true,
+                "triggers": {
+                    "dia1_trigger": ["./dia1/dia1.lu", "./dia2/dia2.lu"]
+                }
+            },
+            "./dia2/dia2.lu": {
+                "triggers": {
+                    "dia3_trigger": "",
+                    "": "./dia4/dia4.lu"
+                }
+            },
+            "./main/main.fr-fr.lu": {
+                "rootDialog": true,
+                "triggers": {
+                    "dia1_trigger": "./dia1/dia1.fr-fr.lu"
+                }
+            }
+        }
+
+        let configObject = fileHelper.getConfigObject({ id: path.join(__dirname, 'config.json'), content: JSON.stringify(configContent) }, '_Interruption')
+        assert.equal(configObject.rootIds[0].includes('main.lu'), true)
+        assert.equal(configObject.rootIds[1].includes('main.fr-fr.lu'), true)
+
+        const triggerRuleKeys = [...Object.keys(configObject.triggerRules)]
+        assert.equal(triggerRuleKeys[0].includes('main.lu'), true)
+        assert.equal(triggerRuleKeys[1].includes('dia2.lu'), true)
+        assert.equal(triggerRuleKeys[2].includes('main.fr-fr.lu'), true)
+
+        const triggerRuleValues = [...Object.values(configObject.triggerRules)]
+        assert.equal(triggerRuleValues[0]['dia1_trigger'][0].includes('dia1.lu'), true)
+        assert.equal(triggerRuleValues[0]['dia1_trigger'][1].includes('dia2.lu'), true)
+        assert.equal(triggerRuleValues[1]['dia3_trigger'][0], '')
+        assert.equal(triggerRuleValues[1][''][0].includes('dia4.lu'), true)
+        assert.equal(triggerRuleValues[2]['dia1_trigger'][0].includes('dia1.fr-fr.lu'), true)
+
+        assert.equal(configObject.intentName, '_Interruption')
+
+        assert.equal(configObject.verbose, true)
     })
 })


### PR DESCRIPTION
fix issue #713 from composer. Main changes are supporting multi trigger intents mapping to same lu file in config and logic. Also added tests to cover the scenario. Considering such cases,

triggerIntentA -> a.lu
triggerIntentB -> a.lu
triggerIntentC -> b.lu

After cross train, interruption intent in a.lu will only include utterances under triggerIntentC.

