### PR TITLE
[luis build] change string format in setting and luis recognizer

### DIFF
--- a/packages/lu/src/parser/lubuild/builder.ts
+++ b/packages/lu/src/parser/lubuild/builder.ts
@@ -189,7 +189,7 @@ export class Builder {
         // update settings asset
         if (settings && settings.has(path.dirname(content.path))) {
           let setting = settings.get(path.dirname(content.path)) as Settings
-          setting.luis[content.name.split('.').join('_')] = recognizer.getAppId()
+          setting.luis[content.name.split('.').join('_').replace(/-/g, '_')] = recognizer.getAppId()
         }
       }))
     }

--- a/packages/lu/src/parser/lubuild/recognizer.ts
+++ b/packages/lu/src/parser/lubuild/recognizer.ts
@@ -33,7 +33,7 @@ export class Recognizer {
 
   constructor(private readonly luFile: string, targetFileName: string) {
     this.appId = ''
-    this.applicationId = `=settings.luis.${targetFileName.split('.').join('_')}`.replace(/-/g, '_')
+    this.applicationId = `=settings.luis.${targetFileName.split('.').join('_').replace(/-/g, '_')}`
     this.endpoint = '=settings.luis.endpoint'
     this.endpointKey = '=settings.luis.endpointKey'
     this.versionId = '0.1'

--- a/packages/lu/src/parser/lubuild/recognizer.ts
+++ b/packages/lu/src/parser/lubuild/recognizer.ts
@@ -33,7 +33,7 @@ export class Recognizer {
 
   constructor(private readonly luFile: string, targetFileName: string) {
     this.appId = ''
-    this.applicationId = `=settings.luis.${targetFileName.split('.').join('_')}`
+    this.applicationId = `=settings.luis.${targetFileName.split('.').join('_')}`.replace(/-/g, '_')
     this.endpoint = '=settings.luis.endpoint'
     this.endpointKey = '=settings.luis.endpointKey'
     this.versionId = '0.1'

--- a/packages/lu/test/fixtures/testcases/lubuild/foo/config/luis.settings.development.westus.json
+++ b/packages/lu/test/fixtures/testcases/lubuild/foo/config/luis.settings.development.westus.json
@@ -1,7 +1,7 @@
 {
     "luis": {
-        "foo_fr-fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5",
-        "foo_en-us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
-        "foo_zh-cn_lu": "f8c64e2a-3333-3a09-8f78-39d7adc76ec5"
+        "foo_fr_fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5",
+        "foo_en_us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
+        "foo_zh_cn_lu": "f8c64e2a-3333-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/lu/test/fixtures/testcases/lubuild/foo/dialogs/foo.en-us.lu.dialog
+++ b/packages/lu/test/fixtures/testcases/lubuild/foo/dialogs/foo.en-us.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.foo_en-us_lu",
+    "applicationId": "=settings.luis.foo_en_us_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/lu/test/fixtures/testcases/lubuild/foo/dialogs/foo.fr-fr.lu.dialog
+++ b/packages/lu/test/fixtures/testcases/lubuild/foo/dialogs/foo.fr-fr.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.foo_fr-fr_lu",
+    "applicationId": "=settings.luis.foo_fr_fr_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/lu/test/fixtures/testcases/lubuild/foo/dialogs/foo.zh-cn.lu.dialog
+++ b/packages/lu/test/fixtures/testcases/lubuild/foo/dialogs/foo.zh-cn.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.foo_zh-cn_lu",
+    "applicationId": "=settings.luis.foo_zh_cn_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/lu/test/fixtures/testcases/lubuild/foo2/config/luis.settings.development.westus.json
+++ b/packages/lu/test/fixtures/testcases/lubuild/foo2/config/luis.settings.development.westus.json
@@ -1,7 +1,7 @@
 {
     "luis": {
-        "foo_en-us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
-        "foo_fr-fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5",
-        "foo_zh-cn_lu": "f8c64e2a-3333-3a09-8f78-39d7adc76ec5"
+        "foo_en_us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
+        "foo_fr_fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5",
+        "foo_zh_cn_lu": "f8c64e2a-3333-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/lu/test/fixtures/testcases/lubuild/foo2/dialogs/foo.zh-cn.lu.dialog
+++ b/packages/lu/test/fixtures/testcases/lubuild/foo2/dialogs/foo.zh-cn.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.foo_zh-cn_lu",
+    "applicationId": "=settings.luis.foo_zh_cn_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/lu/test/fixtures/testcases/lubuild/foo2/lufiles-and-dialog-assets/luis.settings.development.westus.json
+++ b/packages/lu/test/fixtures/testcases/lubuild/foo2/lufiles-and-dialog-assets/luis.settings.development.westus.json
@@ -1,6 +1,6 @@
 {
     "luis": {
-        "foo_en-us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
-        "foo_fr-fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5"
+        "foo_en_us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
+        "foo_fr_fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/lu/test/fixtures/testcases/lubuild/sandwich/config/luis.settings.development.westus.json
+++ b/packages/lu/test/fixtures/testcases/lubuild/sandwich/config/luis.settings.development.westus.json
@@ -1,5 +1,5 @@
 {
     "luis": {
-        "sandwich_en-us_lu": "f8c64e2a-8635-3a09-8f78-39d7adc76ec5"
+        "sandwich_en_us_lu": "f8c64e2a-8635-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/lu/test/fixtures/testcases/lubuild/sandwich/dialogs/sandwich.en-us.lu.dialog
+++ b/packages/lu/test/fixtures/testcases/lubuild/sandwich/dialogs/sandwich.en-us.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.sandwich_en-us_lu",
+    "applicationId": "=settings.luis.sandwich_en_us_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/foo/config/luis.settings.development.westus.json
+++ b/packages/luis/test/fixtures/testcases/lubuild/foo/config/luis.settings.development.westus.json
@@ -1,7 +1,7 @@
 {
     "luis": {
-        "foo_fr-fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5",
-        "foo_en-us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
-        "foo_zh-cn_lu": "f8c64e2a-3333-3a09-8f78-39d7adc76ec5"
+        "foo_fr_fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5",
+        "foo_en_us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
+        "foo_zh_cn_lu": "f8c64e2a-3333-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/foo/dialogs/foo.en-us.lu.dialog
+++ b/packages/luis/test/fixtures/testcases/lubuild/foo/dialogs/foo.en-us.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.foo_en-us_lu",
+    "applicationId": "=settings.luis.foo_en_us_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/foo/dialogs/foo.fr-fr.lu.dialog
+++ b/packages/luis/test/fixtures/testcases/lubuild/foo/dialogs/foo.fr-fr.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.foo_fr-fr_lu",
+    "applicationId": "=settings.luis.foo_fr_fr_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/foo/dialogs/foo.zh-cn.lu.dialog
+++ b/packages/luis/test/fixtures/testcases/lubuild/foo/dialogs/foo.zh-cn.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.foo_zh-cn_lu",
+    "applicationId": "=settings.luis.foo_zh_cn_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/foo2/config/luis.settings.development.westus.json
+++ b/packages/luis/test/fixtures/testcases/lubuild/foo2/config/luis.settings.development.westus.json
@@ -1,7 +1,7 @@
 {
     "luis": {
-        "foo_en-us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
-        "foo_fr-fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5",
-        "foo_zh-cn_lu": "f8c64e2a-3333-3a09-8f78-39d7adc76ec5"
+        "foo_en_us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
+        "foo_fr_fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5",
+        "foo_zh_cn_lu": "f8c64e2a-3333-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/foo2/dialogs/foo.zh-cn.lu.dialog
+++ b/packages/luis/test/fixtures/testcases/lubuild/foo2/dialogs/foo.zh-cn.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.foo_zh-cn_lu",
+    "applicationId": "=settings.luis.foo_zh_cn_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/foo2/lufiles-and-dialog-assets/luis.settings.development.westus.json
+++ b/packages/luis/test/fixtures/testcases/lubuild/foo2/lufiles-and-dialog-assets/luis.settings.development.westus.json
@@ -1,6 +1,6 @@
 {
     "luis": {
-        "foo_en-us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
-        "foo_fr-fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5"
+        "foo_en_us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
+        "foo_fr_fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/luconfig/config/luis.settings.development.westus.json
+++ b/packages/luis/test/fixtures/testcases/lubuild/luconfig/config/luis.settings.development.westus.json
@@ -1,5 +1,5 @@
 {
     "luis": {
-        "test_en-us_lu": "f8c64e2a-8635-3a09-8f78-39d7adc76ec5"
+        "test_en_us_lu": "f8c64e2a-8635-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/luconfig/dialogs/test.en-us.lu.dialog
+++ b/packages/luis/test/fixtures/testcases/lubuild/luconfig/dialogs/test.en-us.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.test_en-us_lu",
+    "applicationId": "=settings.luis.test_en_us_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/sandwich/config/luis.settings.development.westus.json
+++ b/packages/luis/test/fixtures/testcases/lubuild/sandwich/config/luis.settings.development.westus.json
@@ -1,5 +1,5 @@
 {
     "luis": {
-        "sandwich_en-us_lu": "f8c64e2a-8635-3a09-8f78-39d7adc76ec5"
+        "sandwich_en_us_lu": "f8c64e2a-8635-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/sandwich/dialogs/sandwich.en-us.lu.dialog
+++ b/packages/luis/test/fixtures/testcases/lubuild/sandwich/dialogs/sandwich.en-us.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.sandwich_en-us_lu",
+    "applicationId": "=settings.luis.sandwich_en_us_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }


### PR DESCRIPTION
Background: SDK side, expression syntax no longer support "-" in the middle of the name, so we change to "_" instead.

change string format in settings and luis recognizer from 'a-1.en-us.lu' to 'a_1.en_us.lu' as string with '-' will be treated as invalid expression string in expression engine