### PR TITLE
Opt out of type checking for "config"

### DIFF
--- a/packages/plugins/src/commands/plugins/install.ts
+++ b/packages/plugins/src/commands/plugins/install.ts
@@ -25,8 +25,9 @@ This is useful if a user needs to update core plugin functionality in the CLI wi
 
   static aliases = ['plugins:add']
 
+  config: any
   plugins = new Plugins(this.config)
-
+  
   // In this case we want these operations to happen
   // sequentially so the `no-await-in-loop` rule is ugnored
   /* eslint-disable no-await-in-loop */


### PR DESCRIPTION
This evidently fixed the error in [build 120912](https://fuselabs.visualstudio.com/SDK_v4/_build/results?buildId=120912&view=logs&j=80f76d13-0c40-5212-ec8e-38178015f064&t=9fbb9c62-5746-506b-3720-d9dbd3070c2a).

However, other errors of the same type remain, as shown in [build 120919](https://fuselabs.visualstudio.com/SDK_v4/_build/results?buildId=120919&view=logs&j=80f76d13-0c40-5212-ec8e-38178015f064&t=9fbb9c62-5746-506b-3720-d9dbd3070c2a)