### PR TITLE
Change luis:build naming in generated

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -158,8 +158,7 @@
                 "../libraries/**/*.schema",
                 "-o",
                 "sdk.schema",
-                "--verbose",
-                "-u"
+                "--verbose"
             ],
             "internalConsoleOptions": "openOnSessionStart",
             "cwd": "${workspaceFolder}/../botbuilder-dotnet/schemas"
@@ -177,20 +176,12 @@
             ],
             "args": [
                 "luis:build",
-                "--in",
-                ".",
                 "--authoringKey",
                 "${env:LUIS_AUTHORING_KEY}",
-                "--botName",
-                "sandwich",
-                "--dialog",
-                "--suffix",
-                "${env:USERNAME}",
-                "--out",
-                "."
+                "--luConfig", "luconfig.json"
             ],
             "internalConsoleOptions": "openOnSessionStart",
-            "cwd": "${env:TEMP}/sandwich.out/luis"
+            "cwd": "${env:TEMP}/sandwich.out/"
         },
         {
             "type": "node",

--- a/packages/lu/src/parser/lubuild/builder.ts
+++ b/packages/lu/src/parser/lubuild/builder.ts
@@ -189,7 +189,7 @@ export class Builder {
         // update settings asset
         if (settings && settings.has(path.dirname(content.path))) {
           let setting = settings.get(path.dirname(content.path)) as Settings
-          setting.luis[content.name.split('.').join('_')] = recognizer.getAppId()
+          setting.luis[content.name.replace(/\.|-/g, '_')] = recognizer.getAppId()
         }
       }))
     }

--- a/packages/lu/src/parser/lubuild/recognizer.ts
+++ b/packages/lu/src/parser/lubuild/recognizer.ts
@@ -12,7 +12,7 @@ export class Recognizer {
       let recognizer = new Recognizer(luFile, targetFileName)
       recognizer.dialogPath = dialogPath
       Object.assign(recognizer, existingRecognizer)
-      recognizer.setAppId(luisSettings.luis[path.basename(luFile).split('.').join('_')])
+      recognizer.setAppId(luisSettings.luis[path.basename(luFile).replace(/\.|-/g,  '_')])
 
       return recognizer
     }
@@ -33,7 +33,8 @@ export class Recognizer {
 
   constructor(private readonly luFile: string, targetFileName: string) {
     this.appId = ''
-    this.applicationId = `=settings.luis.${targetFileName.split('.').join('_')}`
+    // . is part of hierarchy and - is treated as subtraction by expressions so turn them into _
+    this.applicationId = `=settings.luis.${targetFileName.replace(/\.|-/g, '_')}`
     this.endpoint = '=settings.luis.endpoint'
     this.endpointKey = '=settings.luis.endpointKey'
     this.versionId = '0.1'

--- a/packages/lu/test/fixtures/testcases/lubuild/foo/config/luis.settings.development.westus.json
+++ b/packages/lu/test/fixtures/testcases/lubuild/foo/config/luis.settings.development.westus.json
@@ -1,7 +1,7 @@
 {
     "luis": {
-        "foo_fr-fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5",
-        "foo_en-us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
-        "foo_zh-cn_lu": "f8c64e2a-3333-3a09-8f78-39d7adc76ec5"
+        "foo_fr_fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5",
+        "foo_en_us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
+        "foo_zh_cn_lu": "f8c64e2a-3333-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/lu/test/fixtures/testcases/lubuild/foo/dialogs/foo.en-us.lu.dialog
+++ b/packages/lu/test/fixtures/testcases/lubuild/foo/dialogs/foo.en-us.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.foo_en-us_lu",
+    "applicationId": "=settings.luis.foo_en_us_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/lu/test/fixtures/testcases/lubuild/foo/dialogs/foo.fr-fr.lu.dialog
+++ b/packages/lu/test/fixtures/testcases/lubuild/foo/dialogs/foo.fr-fr.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.foo_fr-fr_lu",
+    "applicationId": "=settings.luis.foo_fr_fr_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/lu/test/fixtures/testcases/lubuild/foo/dialogs/foo.zh-cn.lu.dialog
+++ b/packages/lu/test/fixtures/testcases/lubuild/foo/dialogs/foo.zh-cn.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.foo_zh-cn_lu",
+    "applicationId": "=settings.luis.foo_zh_cn_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/lu/test/fixtures/testcases/lubuild/foo2/config/luis.settings.development.westus.json
+++ b/packages/lu/test/fixtures/testcases/lubuild/foo2/config/luis.settings.development.westus.json
@@ -1,7 +1,7 @@
 {
     "luis": {
-        "foo_en-us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
-        "foo_fr-fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5",
-        "foo_zh-cn_lu": "f8c64e2a-3333-3a09-8f78-39d7adc76ec5"
+        "foo_en_us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
+        "foo_fr_fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5",
+        "foo_zh_cn_lu": "f8c64e2a-3333-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/lu/test/fixtures/testcases/lubuild/foo2/dialogs/foo.zh-cn.lu.dialog
+++ b/packages/lu/test/fixtures/testcases/lubuild/foo2/dialogs/foo.zh-cn.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.foo_zh-cn_lu",
+    "applicationId": "=settings.luis.foo_zh_cn_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/lu/test/fixtures/testcases/lubuild/foo2/lufiles-and-dialog-assets/luis.settings.development.westus.json
+++ b/packages/lu/test/fixtures/testcases/lubuild/foo2/lufiles-and-dialog-assets/luis.settings.development.westus.json
@@ -1,6 +1,6 @@
 {
     "luis": {
-        "foo_en-us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
-        "foo_fr-fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5"
+        "foo_en_us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
+        "foo_fr_fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/lu/test/fixtures/testcases/lubuild/sandwich/config/luis.settings.development.westus.json
+++ b/packages/lu/test/fixtures/testcases/lubuild/sandwich/config/luis.settings.development.westus.json
@@ -1,5 +1,5 @@
 {
     "luis": {
-        "sandwich_en-us_lu": "f8c64e2a-8635-3a09-8f78-39d7adc76ec5"
+        "sandwich_en_us_lu": "f8c64e2a-8635-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/lu/test/fixtures/testcases/lubuild/sandwich/dialogs/sandwich.en-us.lu.dialog
+++ b/packages/lu/test/fixtures/testcases/lubuild/sandwich/dialogs/sandwich.en-us.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.sandwich_en-us_lu",
+    "applicationId": "=settings.luis.sandwich_en_us_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/luis/docs/using-luis-build.md
+++ b/packages/luis/docs/using-luis-build.md
@@ -106,8 +106,8 @@ Example for user **vishwac** targeting authoring region **westus**
 ```json
 {
     "luis": {
-        "RootDialog_en-us_lu": "66976439-3197-4937-88bb-7b95aea2f462",
-        "TodoPhraseList_en-us_lu": "5e8d3f95-619a-4fbb-b6f6-6fad3050e286"
+        "RootDialog_en_us_lu": "66976439-3197-4937-88bb-7b95aea2f462",
+        "TodoPhraseList_en_us_lu": "5e8d3f95-619a-4fbb-b6f6-6fad3050e286"
     }
 }
 ```
@@ -148,13 +148,13 @@ generates the following files
 {
     "luis": {
         // LUIS application IDs for every application created/ updated
-        "root_en-us_lu": "c571f17e-7f10-4211-a21e-17ebb1f7f89b",
-        "root_fr-fr_lu": "d71ae2fe-d3e0-49e6-80a3-68a22fa666dc",
-        "add_en-us_lu": "f3674ea3-0ae5-4c06-af57-49d76fb86fba",
-        "add_es-es_lu": "53dc2dd2-8435-47ac-a080-b26249a57c6c",
-        "add_fr-fr_lu": "06f7ba22-41dd-4df0-b0f8-17608afa2aec",
-        "del_en-us_lu": "ecb34067-7917-45a5-821f-b0aace36df68",
-        "del_it-it_lu": "5299ca26-ec4f-4270-9221-196fcf834f84"
+        "root_en_us_lu": "c571f17e-7f10-4211-a21e-17ebb1f7f89b",
+        "root_fr_fr_lu": "d71ae2fe-d3e0-49e6-80a3-68a22fa666dc",
+        "add_en_us_lu": "f3674ea3-0ae5-4c06-af57-49d76fb86fba",
+        "add_es_es_lu": "53dc2dd2-8435-47ac-a080-b26249a57c6c",
+        "add_fr_fr_lu": "06f7ba22-41dd-4df0-b0f8-17608afa2aec",
+        "del_en_us_lu": "ecb34067-7917-45a5-821f-b0aace36df68",
+        "del_it_it_lu": "5299ca26-ec4f-4270-9221-196fcf834f84"
     }
 }
 ```
@@ -175,7 +175,7 @@ generates the following files
 ```jsonc
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.root_en-us_lu",
+    "applicationId": "=settings.luis.root_en_us_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/foo/config/luis.settings.development.westus.json
+++ b/packages/luis/test/fixtures/testcases/lubuild/foo/config/luis.settings.development.westus.json
@@ -1,7 +1,7 @@
 {
     "luis": {
-        "foo_fr-fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5",
-        "foo_en-us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
-        "foo_zh-cn_lu": "f8c64e2a-3333-3a09-8f78-39d7adc76ec5"
+        "foo_fr_fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5",
+        "foo_en_us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
+        "foo_zh_cn_lu": "f8c64e2a-3333-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/foo/dialogs/foo.en-us.lu.dialog
+++ b/packages/luis/test/fixtures/testcases/lubuild/foo/dialogs/foo.en-us.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.foo_en-us_lu",
+    "applicationId": "=settings.luis.foo_en_us_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/foo/dialogs/foo.fr-fr.lu.dialog
+++ b/packages/luis/test/fixtures/testcases/lubuild/foo/dialogs/foo.fr-fr.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.foo_fr-fr_lu",
+    "applicationId": "=settings.luis.foo_fr_fr_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/foo/dialogs/foo.zh-cn.lu.dialog
+++ b/packages/luis/test/fixtures/testcases/lubuild/foo/dialogs/foo.zh-cn.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.foo_zh-cn_lu",
+    "applicationId": "=settings.luis.foo_zh_cn_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/foo2/config/luis.settings.development.westus.json
+++ b/packages/luis/test/fixtures/testcases/lubuild/foo2/config/luis.settings.development.westus.json
@@ -1,7 +1,7 @@
 {
     "luis": {
-        "foo_en-us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
-        "foo_fr-fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5",
-        "foo_zh-cn_lu": "f8c64e2a-3333-3a09-8f78-39d7adc76ec5"
+        "foo_en_us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
+        "foo_fr_fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5",
+        "foo_zh_cn_lu": "f8c64e2a-3333-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/foo2/dialogs/foo.zh-cn.lu.dialog
+++ b/packages/luis/test/fixtures/testcases/lubuild/foo2/dialogs/foo.zh-cn.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.foo_zh-cn_lu",
+    "applicationId": "=settings.luis.foo_zh_cn_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/foo2/lufiles-and-dialog-assets/luis.settings.development.westus.json
+++ b/packages/luis/test/fixtures/testcases/lubuild/foo2/lufiles-and-dialog-assets/luis.settings.development.westus.json
@@ -1,6 +1,6 @@
 {
     "luis": {
-        "foo_en-us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
-        "foo_fr-fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5"
+        "foo_en_us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
+        "foo_fr_fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/luconfig/config/luis.settings.development.westus.json
+++ b/packages/luis/test/fixtures/testcases/lubuild/luconfig/config/luis.settings.development.westus.json
@@ -1,5 +1,5 @@
 {
     "luis": {
-        "test_en-us_lu": "f8c64e2a-8635-3a09-8f78-39d7adc76ec5"
+        "test_en_us_lu": "f8c64e2a-8635-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/luconfig/dialogs/test.en-us.lu.dialog
+++ b/packages/luis/test/fixtures/testcases/lubuild/luconfig/dialogs/test.en-us.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.test_en-us_lu",
+    "applicationId": "=settings.luis.test_en_us_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/sandwich/config/luis.settings.development.westus.json
+++ b/packages/luis/test/fixtures/testcases/lubuild/sandwich/config/luis.settings.development.westus.json
@@ -1,5 +1,5 @@
 {
     "luis": {
-        "sandwich_en-us_lu": "f8c64e2a-8635-3a09-8f78-39d7adc76ec5"
+        "sandwich_en_us_lu": "f8c64e2a-8635-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/luis/test/fixtures/testcases/lubuild/sandwich/dialogs/sandwich.en-us.lu.dialog
+++ b/packages/luis/test/fixtures/testcases/lubuild/sandwich/dialogs/sandwich.en-us.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.sandwich_en-us_lu",
+    "applicationId": "=settings.luis.sandwich_en_us_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/qnamaker/test/fixtures/testcases/lubuild/foo/config/luis.settings.development.westus.json
+++ b/packages/qnamaker/test/fixtures/testcases/lubuild/foo/config/luis.settings.development.westus.json
@@ -1,7 +1,7 @@
 {
     "luis": {
-        "foo_fr-fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5",
-        "foo_en-us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
-        "foo_zh-cn_lu": "f8c64e2a-3333-3a09-8f78-39d7adc76ec5"
+        "foo_fr_fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5",
+        "foo_en_us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
+        "foo_zh_cn_lu": "f8c64e2a-3333-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/qnamaker/test/fixtures/testcases/lubuild/foo/dialogs/foo.en-us.lu.dialog
+++ b/packages/qnamaker/test/fixtures/testcases/lubuild/foo/dialogs/foo.en-us.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.foo_en-us_lu",
+    "applicationId": "=settings.luis.foo_en_us_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/qnamaker/test/fixtures/testcases/lubuild/foo/dialogs/foo.fr-fr.lu.dialog
+++ b/packages/qnamaker/test/fixtures/testcases/lubuild/foo/dialogs/foo.fr-fr.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.foo_fr-fr_lu",
+    "applicationId": "=settings.luis.foo_fr_fr_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/qnamaker/test/fixtures/testcases/lubuild/foo/dialogs/foo.zh-cn.lu.dialog
+++ b/packages/qnamaker/test/fixtures/testcases/lubuild/foo/dialogs/foo.zh-cn.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.foo_zh-cn_lu",
+    "applicationId": "=settings.luis.foo_zh_cn_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/qnamaker/test/fixtures/testcases/lubuild/foo2/config/luis.settings.development.westus.json
+++ b/packages/qnamaker/test/fixtures/testcases/lubuild/foo2/config/luis.settings.development.westus.json
@@ -1,7 +1,7 @@
 {
     "luis": {
-        "foo_en-us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
-        "foo_fr-fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5",
-        "foo_zh-cn_lu": "f8c64e2a-3333-3a09-8f78-39d7adc76ec5"
+        "foo_en_us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
+        "foo_fr_fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5",
+        "foo_zh_cn_lu": "f8c64e2a-3333-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/qnamaker/test/fixtures/testcases/lubuild/foo2/dialogs/foo.zh-cn.lu.dialog
+++ b/packages/qnamaker/test/fixtures/testcases/lubuild/foo2/dialogs/foo.zh-cn.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.foo_zh-cn_lu",
+    "applicationId": "=settings.luis.foo_zh_cn_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/packages/qnamaker/test/fixtures/testcases/lubuild/foo2/lufiles-and-dialog-assets/luis.settings.development.westus.json
+++ b/packages/qnamaker/test/fixtures/testcases/lubuild/foo2/lufiles-and-dialog-assets/luis.settings.development.westus.json
@@ -1,6 +1,6 @@
 {
     "luis": {
-        "foo_en-us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
-        "foo_fr-fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5"
+        "foo_en_us_lu": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
+        "foo_fr_fr_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/qnamaker/test/fixtures/testcases/lubuild/sandwich/config/luis.settings.development.westus.json
+++ b/packages/qnamaker/test/fixtures/testcases/lubuild/sandwich/config/luis.settings.development.westus.json
@@ -1,5 +1,5 @@
 {
     "luis": {
-        "sandwich_en-us_lu": "f8c64e2a-8635-3a09-8f78-39d7adc76ec5"
+        "sandwich_en_us_lu": "f8c64e2a-8635-3a09-8f78-39d7adc76ec5"
     }
 }

--- a/packages/qnamaker/test/fixtures/testcases/lubuild/sandwich/dialogs/sandwich.en-us.lu.dialog
+++ b/packages/qnamaker/test/fixtures/testcases/lubuild/sandwich/dialogs/sandwich.en-us.lu.dialog
@@ -1,6 +1,6 @@
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.sandwich_en-us_lu",
+    "applicationId": "=settings.luis.sandwich_en_us_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }

--- a/specs/LUIS-MAKE.md
+++ b/specs/LUIS-MAKE.md
@@ -81,7 +81,7 @@ For each LU file:
 ```json
 {
     "$kind": "Microsoft.LuisRecognizer",
-    "applicationId": "=settings.luis.Main_en-us_lu",
+    "applicationId": "=settings.luis.Main_en_us_lu",
     "endpoint": "=settings.luis.endpoint",
     "endpointKey": "=settings.luis.endpointKey"
 }


### PR DESCRIPTION
Fixes #716
We need to rename - and . to _ in order to not interpret them as
operators in expressions.