### PR TITLE
Add lg as BF-CLI core plugin

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,8 @@
       "@microsoft/bf-cli-config",
       "@microsoft/bf-qnamaker",
       "@microsoft/bf-luis-cli",
-      "@microsoft/bf-cli-plugins"
+      "@microsoft/bf-cli-plugins",
+      "@microsoft/bf-lg-cli"
     ],
     "hooks": {
       "init": "./lib/hooks/init/inithook"
@@ -59,6 +60,7 @@
     "@microsoft/bf-luis-cli": "1.0.0",
     "@microsoft/bf-qnamaker": "1.0.0",
     "@microsoft/bf-cli-plugins": "1.0.0",
+    "@microsoft/bf-lg-cli": "1.0.0",
     "@oclif/command": "~1.5.19",
     "@oclif/config": "~1.13.3",
     "@oclif/errors": "~1.2.2",


### PR DESCRIPTION
Verified manually that node packages/cli/bin/run now lists `lg` as a top level command group.