### PR TITLE
fix activeVersion is null issue when updating application failed

### DIFF
--- a/packages/lu/src/parser/lubuild/builder.ts
+++ b/packages/lu/src/parser/lubuild/builder.ts
@@ -306,7 +306,7 @@ export class Builder {
   async updateApplication(currentApp: any, luBuildCore: LuBuildCore, recognizer: Recognizer, delayDuration: number, deleteOldVersion: boolean) {
     await delay(delayDuration)
     const appInfo = await luBuildCore.getApplicationInfo(recognizer.getAppId())
-    recognizer.versionId = appInfo.activeVersion
+    recognizer.versionId = appInfo.activeVersion || appInfo.endpoints.PRODUCTION.versionId
 
     await delay(delayDuration)
     const existingApp = await luBuildCore.exportApplication(recognizer.getAppId(), recognizer.versionId)


### PR DESCRIPTION
fix #787. The activeVersion will be null if users are trying to update an application with errors returned from luis api. After the fix, versionId will come from appInfo.endpoints.PRODUCTION.versionId if appInfo.activeVersion is null due to updating failure. Tests are added to cover the scenario. Manual E2E tests also work well for the cases reported in issue #787.