### PR TITLE
Fix codecov.io report URL in build tag

### DIFF
--- a/build/botframework-cli.yml
+++ b/build/botframework-cli.yml
@@ -52,7 +52,7 @@ jobs:
       displayName: 'rush coverage -v'
 
     - bash: 'bash <(curl -s https://codecov.io/bash)'
-      displayName: 'push coverage report to codecov.io - 'https://codecov.io/github/microsoft/botframework-cli'
+      displayName: 'push coverage report to codecov.io - https://codecov.io/github/microsoft/botframework-cli'
       env:
         CODECOV_TOKEN: $(TokenForCodecov)
 

--- a/build/botframework-cli.yml
+++ b/build/botframework-cli.yml
@@ -18,7 +18,7 @@ jobs:
     variables:
       buildVersion: '4.10.0-preview.$(Build.BuildId)'
       _version: ${{coalesce(variables.version, variables.buildVersion)}}
-      ThisCommit: $[ coalesce( variables['System.PullRequest.SourceCommitId'], variables['Build.SourceVersion'] ) ]
+      thisCommit: $[ coalesce( variables['System.PullRequest.SourceCommitId'], variables['Build.SourceVersion'] ) ]
 
     steps:
     - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
@@ -49,14 +49,14 @@ jobs:
       displayName: 'rush coverage -v'
 
     - bash: 'bash <(curl -s https://codecov.io/bash)'
-      displayName: 'push coverage report to codecov.io - https://codecov.io/github/microsoft/botframework-cli/commit/$(ThisCommit)'
+      displayName: 'push coverage report to codecov.io - https://codecov.io/github/microsoft/botframework-cli/commit/$(thisCommit)'
       env:
         CODECOV_TOKEN: $(TokenForCodecov)
 
     - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
       displayName: 'Tag Build with coverage url'
       inputs:
-        tags: 'https://codecov.io/github/microsoft/botframework-cli/commit/$(ThisCommit)'
+        tags: 'https://codecov.io/github/microsoft/botframework-cli/commit/$(thisCommit)'
       continueOnError: true
   
     - task: PublishCodeCoverageResults@1

--- a/build/botframework-cli.yml
+++ b/build/botframework-cli.yml
@@ -18,12 +18,24 @@ jobs:
     variables:
       buildVersion: '4.10.0-preview.$(Build.BuildId)'
       _version: ${{coalesce(variables.version, variables.buildVersion)}}
+      Commit: $[ coalesce( variables['System.PullRequest.SourceCommitId'], variables['Build.SourceVersion'] ) ]
+
 
     steps:
     - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
       displayName: 'Tag Build with version number'
       inputs:
         tags: 'Version=$(_version)'
+      continueOnError: true
+
+    steps:
+    - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
+      displayName: 'Tag Build with version number'
+      inputs:
+        tags: |
+         Build.SourceVersion=$(Build.SourceVersion)
+         System.PullRequest.SourceCommitId=$(System.PullRequest.SourceCommitId)
+         Commit=$(Commit)
       continueOnError: true
 
     - task: NodeTool@0
@@ -53,10 +65,18 @@ jobs:
         CODECOV_TOKEN: $(TokenForCodecov)
 
     - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-      displayName: 'Tag Build with coverage url'
+      displayName: 'Tag Build with coverage url (PR)'
       inputs:
-        tags: 'https://codecov.io/github/microsoft/botframework-cli/commit/$(system.pullRequest.sourceCommitId)'
+        tags: 'https://codecov.io/github/microsoft/botframework-cli/commit/$(System.PullRequest.SourceCommitId)'
       continueOnError: true
+      condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+  
+    - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
+      displayName: 'Tag Build with coverage url (non-PR)'
+      inputs:
+        tags: 'https://codecov.io/github/microsoft/botframework-cli/commit/$(Build.SourceVersion)'
+      continueOnError: true
+      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
   
     - task: PublishCodeCoverageResults@1
       displayName: 'Populate Code Coverage tab'

--- a/build/botframework-cli.yml
+++ b/build/botframework-cli.yml
@@ -27,6 +27,10 @@ jobs:
         tags: 'Version=$(_version)'
       continueOnError: true
 
+    - powershell: |
+        Get-ChildItem env:* | sort-object name | Format-Table -Autosize -Wrap | Out-String -Width 120
+      displayName: 'Get environment vars'
+
     - task: NodeTool@0
       displayName: 'Use Node 12.x'
       inputs:
@@ -49,7 +53,7 @@ jobs:
       displayName: 'rush coverage -v'
 
     - bash: 'bash <(curl -s https://codecov.io/bash)'
-      displayName: 'push coverage report to codecov.io - https://codecov.io/github/microsoft/botframework-cli/commit/$(thisCommit)'
+      displayName: 'push coverage report to codecov.io - https://codecov.io/github/microsoft/botframework-cli'
       env:
         CODECOV_TOKEN: $(TokenForCodecov)
 
@@ -58,6 +62,7 @@ jobs:
       inputs:
         tags: 'https://codecov.io/github/microsoft/botframework-cli/commit/$(thisCommit)'
       continueOnError: true
+      condition: and(succeeded(), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI'))
   
     - task: PublishCodeCoverageResults@1
       displayName: 'Populate Code Coverage tab'

--- a/build/botframework-cli.yml
+++ b/build/botframework-cli.yml
@@ -2,7 +2,7 @@
 # Build Botframework-CLI on Windows agent
 #
 
-# "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber).
+# "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
 name: $(Build.BuildId)
 
 pool:
@@ -68,7 +68,7 @@ jobs:
       inputs:
         tags: 'https://codecov.io/github/microsoft/botframework-cli/commit/$(thisCommit)'
       continueOnError: true
-      condition: and(succeeded(), eq(variables['CommitExists'], "true"))
+      condition: and(succeeded(), eq(variables['CommitExists'], 'true'))
   
     - task: PublishCodeCoverageResults@1
       displayName: 'Populate Code Coverage tab'

--- a/build/botframework-cli.yml
+++ b/build/botframework-cli.yml
@@ -20,7 +20,6 @@ jobs:
       _version: ${{coalesce(variables.version, variables.buildVersion)}}
       Commit: $[ coalesce( variables['System.PullRequest.SourceCommitId'], variables['Build.SourceVersion'] ) ]
 
-
     steps:
     - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
       displayName: 'Tag Build with version number'
@@ -28,7 +27,6 @@ jobs:
         tags: 'Version=$(_version)'
       continueOnError: true
 
-    steps:
     - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
       displayName: 'Tag Build with version number'
       inputs:

--- a/build/botframework-cli.yml
+++ b/build/botframework-cli.yml
@@ -55,7 +55,7 @@ jobs:
     - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
       displayName: 'Tag Build with coverage url'
       inputs:
-        tags: 'https://codecov.io/gh/microsoft/botframework-cli/tree/$(Build.SourceVersion)/packages'
+        tags: 'https://codecov.io/github/microsoft/botframework-cli/commit/$(system.pullRequest.sourceCommitId)'
       continueOnError: true
   
     - task: PublishCodeCoverageResults@1

--- a/build/botframework-cli.yml
+++ b/build/botframework-cli.yml
@@ -2,7 +2,7 @@
 # Build Botframework-CLI on Windows agent
 #
 
-# "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber)
+# "name" here defines the build number format. Build number is accessed via $(Build.BuildNumber).
 name: $(Build.BuildId)
 
 pool:

--- a/build/botframework-cli.yml
+++ b/build/botframework-cli.yml
@@ -18,7 +18,6 @@ jobs:
     variables:
       buildVersion: '4.10.0-preview.$(Build.BuildId)'
       _version: ${{coalesce(variables.version, variables.buildVersion)}}
-      thisCommit: $[ coalesce( variables['System.PullRequest.SourceCommitId'], variables['Build.SourceVersion'] ) ]
 
     steps:
     - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
@@ -26,12 +25,6 @@ jobs:
       inputs:
         tags: 'Version=$(_version)'
       continueOnError: true
-
-    - powershell: |
-        $result = $(git rev-list HEAD..$(Build.SourceVersion) 2>&1);
-        if ($result -like "*fatal*") {Write-Host "##vso[task.setvariable variable=CommitExists;]$false"}
-        else {Write-Host "##vso[task.setvariable variable=CommitExists;]$true"};
-      displayName: 'Verify commit exists'
 
     - powershell: |
         Get-ChildItem env:* | sort-object name | Format-Table -Autosize -Wrap | Out-String -Width 120
@@ -59,14 +52,22 @@ jobs:
       displayName: 'rush coverage -v'
 
     - bash: 'bash <(curl -s https://codecov.io/bash)'
-      displayName: 'push coverage report to codecov.io - https://codecov.io/github/microsoft/botframework-cli'
+      displayName: 'push coverage report to codecov.io - 'https://codecov.io/github/microsoft/botframework-cli'
       env:
         CODECOV_TOKEN: $(TokenForCodecov)
+
+    - powershell: |
+        # Check if Build.SourceVersion exists in Github
+        $result = $(git rev-list HEAD..$(Build.SourceVersion) 2>&1);
+        if ($result -like "*fatal*") { $Url = "https://codecov.io/github/microsoft/botframework-cli" }
+        else { $Url = "https://codecov.io/github/microsoft/botframework-cli/commit/$(Build.SourceVersion)" };
+        Write-Host "##vso[task.setvariable variable=CodecovUrl;]$Url"
+      displayName: 'Set CodecovUrl'
 
     - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
       displayName: 'Tag Build with coverage url'
       inputs:
-        tags: 'https://codecov.io/github/microsoft/botframework-cli/commit/$(thisCommit)'
+        tags: '$(CodecovUrl)'
       continueOnError: true
       condition: and(succeeded(), eq(variables['CommitExists'], 'true'))
   

--- a/build/botframework-cli.yml
+++ b/build/botframework-cli.yml
@@ -18,22 +18,13 @@ jobs:
     variables:
       buildVersion: '4.10.0-preview.$(Build.BuildId)'
       _version: ${{coalesce(variables.version, variables.buildVersion)}}
-      Commit: $[ coalesce( variables['System.PullRequest.SourceCommitId'], variables['Build.SourceVersion'] ) ]
+      ThisCommit: $[ coalesce( variables['System.PullRequest.SourceCommitId'], variables['Build.SourceVersion'] ) ]
 
     steps:
     - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
       displayName: 'Tag Build with version number'
       inputs:
         tags: 'Version=$(_version)'
-      continueOnError: true
-
-    - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-      displayName: 'Tag Build with version number'
-      inputs:
-        tags: |
-         Build.SourceVersion=$(Build.SourceVersion)
-         System.PullRequest.SourceCommitId=$(System.PullRequest.SourceCommitId)
-         Commit=$(Commit)
       continueOnError: true
 
     - task: NodeTool@0
@@ -58,23 +49,15 @@ jobs:
       displayName: 'rush coverage -v'
 
     - bash: 'bash <(curl -s https://codecov.io/bash)'
-      displayName: 'push coverage report to codecov.io - https://codecov.io/github/microsoft/botframework-cli/commit/$(Build.SourceVersion)'
+      displayName: 'push coverage report to codecov.io - https://codecov.io/github/microsoft/botframework-cli/commit/$(ThisCommit)'
       env:
         CODECOV_TOKEN: $(TokenForCodecov)
 
     - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-      displayName: 'Tag Build with coverage url (PR)'
+      displayName: 'Tag Build with coverage url'
       inputs:
-        tags: 'https://codecov.io/github/microsoft/botframework-cli/commit/$(System.PullRequest.SourceCommitId)'
+        tags: 'https://codecov.io/github/microsoft/botframework-cli/commit/$(ThisCommit)'
       continueOnError: true
-      condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
-  
-    - task: colinsalmcorner.colinsalmcorner-buildtasks.tag-build-task.tagBuildOrRelease@0
-      displayName: 'Tag Build with coverage url (non-PR)'
-      inputs:
-        tags: 'https://codecov.io/github/microsoft/botframework-cli/commit/$(Build.SourceVersion)'
-      continueOnError: true
-      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
   
     - task: PublishCodeCoverageResults@1
       displayName: 'Populate Code Coverage tab'

--- a/build/botframework-cli.yml
+++ b/build/botframework-cli.yml
@@ -28,6 +28,12 @@ jobs:
       continueOnError: true
 
     - powershell: |
+        $result = $(git rev-list HEAD..$(Build.SourceVersion) 2>&1);
+        if ($result -like "*fatal*") {Write-Host "##vso[task.setvariable variable=CommitExists;]$false"}
+        else {Write-Host "##vso[task.setvariable variable=CommitExists;]$true"};
+      displayName: 'Verify commit exists'
+
+    - powershell: |
         Get-ChildItem env:* | sort-object name | Format-Table -Autosize -Wrap | Out-String -Width 120
       displayName: 'Get environment vars'
 
@@ -62,7 +68,7 @@ jobs:
       inputs:
         tags: 'https://codecov.io/github/microsoft/botframework-cli/commit/$(thisCommit)'
       continueOnError: true
-      condition: and(succeeded(), in(variables['Build.Reason'], 'PullRequest', 'IndividualCI', 'BatchedCI'))
+      condition: and(succeeded(), eq(variables['CommitExists'], "true"))
   
     - task: PublishCodeCoverageResults@1
       displayName: 'Populate Code Coverage tab'

--- a/build/botframework-cli.yml
+++ b/build/botframework-cli.yml
@@ -26,10 +26,6 @@ jobs:
         tags: 'Version=$(_version)'
       continueOnError: true
 
-    - powershell: |
-        Get-ChildItem env:* | sort-object name | Format-Table -Autosize -Wrap | Out-String -Width 120
-      displayName: 'Get environment vars'
-
     - task: NodeTool@0
       displayName: 'Use Node 12.x'
       inputs:

--- a/build/botframework-cli.yml
+++ b/build/botframework-cli.yml
@@ -57,7 +57,7 @@ jobs:
         CODECOV_TOKEN: $(TokenForCodecov)
 
     - powershell: |
-        # Check if Build.SourceVersion exists in Github
+        # If commit Build.SourceVersion exists in Github, we can show a nicer codecov.io URL
         $result = $(git rev-list HEAD..$(Build.SourceVersion) 2>&1);
         if ($result -like "*fatal*") { $Url = "https://codecov.io/github/microsoft/botframework-cli" }
         else { $Url = "https://codecov.io/github/microsoft/botframework-cli/commit/$(Build.SourceVersion)" };
@@ -69,7 +69,6 @@ jobs:
       inputs:
         tags: '$(CodecovUrl)'
       continueOnError: true
-      condition: and(succeeded(), eq(variables['CommitExists'], 'true'))
   
     - task: PublishCodeCoverageResults@1
       displayName: 'Populate Code Coverage tab'


### PR DESCRIPTION
URL in build tag is sometimes a 404. This fixes it. You can see a build tag URL [here](https://fuselabs.visualstudio.com/SDK_Public/_build/results?buildId=142542&view=results)