### PR TITLE
enable to configure luis publishing slot enviroment

### DIFF
--- a/packages/lu/src/parser/lubuild/builder.ts
+++ b/packages/lu/src/parser/lubuild/builder.ts
@@ -139,6 +139,7 @@ export class Builder {
     suffix: string,
     fallbackLocale: string,
     deleteOldVersion: boolean,
+    isStaging: boolean,
     multiRecognizers?: Map<string, MultiLanguageRecognizer>,
     settings?: Map<string, Settings>,
     luisAPITPS?: number,
@@ -198,7 +199,7 @@ export class Builder {
 
         if (needTrainAndPublish) {
           // train and publish application
-          await this.trainAndPublishApplication(luBuildCore, recognizer, timeBucket)
+          await this.trainAndPublishApplication(luBuildCore, recognizer, timeBucket, isStaging)
         }
 
         // update multiLanguageRecognizer asset
@@ -371,7 +372,7 @@ export class Builder {
     return true
   }
 
-  async trainAndPublishApplication(luBuildCore: LuBuildCore, recognizer: Recognizer, timeBucket: number) {
+  async trainAndPublishApplication(luBuildCore: LuBuildCore, recognizer: Recognizer, timeBucket: number, isStaging: boolean) {
     // send train application request
     this.handler(`${recognizer.getLuPath()} training version=${recognizer.versionId}\n`)
     await delay(timeBucket)
@@ -398,8 +399,8 @@ export class Builder {
     // publish applications
     this.handler(`${recognizer.getLuPath()} publishing version=${recognizer.versionId}\n`)
     await delay(timeBucket)
-    await luBuildCore.publishApplication(recognizer.getAppId(), recognizer.versionId)
-    this.handler(`${recognizer.getLuPath()} publishing finished\n`)
+    await luBuildCore.publishApplication(recognizer.getAppId(), recognizer.versionId, isStaging)
+    this.handler(`${recognizer.getLuPath()} publishing finished for ${isStaging ? 'Staging' : 'Production'} slot\n`)
   }
 
   mergeSettingsContent(settingsPath: string, contents: any[]) {

--- a/packages/lu/src/parser/lubuild/core.ts
+++ b/packages/lu/src/parser/lubuild/core.ts
@@ -345,7 +345,7 @@ export class LuBuildCore {
     return status
   }
 
-  public async publishApplication(appId: string, versionId: string) {
+  public async publishApplication(appId: string, versionId: string, isStaging: boolean) {
     let retryCount = this.retryCount + 1
     let error
     while (retryCount > 0) {
@@ -354,7 +354,7 @@ export class LuBuildCore {
           await this.client.apps.publish(appId,
             {
               versionId,
-              isStaging: false
+              isStaging
             })
           break
         } catch (e) {

--- a/packages/luis/README.md
+++ b/packages/luis/README.md
@@ -372,6 +372,8 @@ OPTIONS
 
   --schema=schema                  Defines $schema for generated .dialog files
 
+  --isStaging                      Publish luis application to staging slot if set. Default to production slot
+
 EXAMPLE
 
        $ bf luis:build --in {INPUT_FILE_OR_FOLDER} --authoringKey {AUTHORING_KEY} --botName {BOT_NAME} --dialog 

--- a/packages/luis/src/commands/luis/build.ts
+++ b/packages/luis/src/commands/luis/build.ts
@@ -42,7 +42,8 @@ export default class LuisBuild extends Command {
     deleteOldVersion: flags.boolean({description: 'Delete old version of LUIS application after building new one.'}),
     log: flags.boolean({description: 'Write out log messages to console', default: false}),
     endpoint: flags.string({description: 'Luis authoring endpoint for publishing'}),
-    schema: flags.string({description: 'Defines $schema for generated .dialog files'})
+    schema: flags.string({description: 'Defines $schema for generated .dialog files'}),
+    isStaging: flags.boolean({description: 'Publish luis application to staging slot if set. Default to production slot', default: false})
   }
 
   async run() {
@@ -70,7 +71,7 @@ export default class LuisBuild extends Command {
       // Flags override userConfig
       let luisBuildFlags = Object.keys(LuisBuild.flags)
 
-      let {inVal, authoringKey, botName, region, out, defaultCulture, fallbackLocale, suffix, dialog, force, luConfig, deleteOldVersion, log, schema, endpoint}
+      let {inVal, authoringKey, botName, region, out, defaultCulture, fallbackLocale, suffix, dialog, force, luConfig, deleteOldVersion, log, endpoint, schema, isStaging}
         = await utils.processInputs(flags, luisBuildFlags, this.config.configDir)
 
       flags.stdin = await this.readStdin()
@@ -140,7 +141,7 @@ export default class LuisBuild extends Command {
 
       // update or create and then train and publish luis applications based on loaded resources
       if (log) this.log('Handling applications...')
-      const dialogContents = await builder.build(luContents, recognizers, authoringKey, endpoint, botName, suffix, fallbackLocale, deleteOldVersion, multiRecognizers, settings)
+      const dialogContents = await builder.build(luContents, recognizers, authoringKey, endpoint, botName, suffix, fallbackLocale, deleteOldVersion, isStaging, multiRecognizers, settings)
 
       // write dialog assets based on config
       if (out) {

--- a/packages/luis/test/commands/luis/build.test.ts
+++ b/packages/luis/test/commands/luis/build.test.ts
@@ -108,21 +108,21 @@ describe('luis:build create a new application successfully', () => {
     nock('https://westus.api.cognitive.microsoft.com')
       .post(uri => uri.includes('publish'))
       .reply(201, {
-        versionId: '0.2',
+        versionId: '0.1',
         isStaging: true
       })
   })
 
   test
     .stdout()
-    .command(['luis:build', '--in', './test/fixtures/testcases/lubuild/sandwich//lufiles/sandwich.en-us.lu', '--authoringKey', uuidv1(), '--botName', 'test', '--log', '--suffix', 'development'])
+    .command(['luis:build', '--in', './test/fixtures/testcases/lubuild/sandwich//lufiles/sandwich.en-us.lu', '--authoringKey', uuidv1(), '--botName', 'test', '--log', '--suffix', 'development', '--isStaging'])
     .it('should create a new application successfully', ctx => {
       expect(ctx.stdout).to.contain('Handling applications...')
       expect(ctx.stdout).to.contain('Creating LUIS.ai application')
       expect(ctx.stdout).to.contain('training version=0.1')
       expect(ctx.stdout).to.contain('waiting for training for version=0.1')
       expect(ctx.stdout).to.contain('publishing version=0.1')
-      expect(ctx.stdout).to.contain('publishing finished')
+      expect(ctx.stdout).to.contain('publishing finished for Staging slot')
     })
 })
 
@@ -174,7 +174,7 @@ describe('luis:build update application succeed when utterances changed', () => 
       .post(uri => uri.includes('publish'))
       .reply(201, {
         versionId: '0.2',
-        isStaging: true
+        isStaging: false
       })
   })
 
@@ -239,7 +239,7 @@ describe('luis:build update application succeed when utterances added', () => {
       .post(uri => uri.includes('publish'))
       .reply(201, {
         versionId: '0.2',
-        isStaging: true
+        isStaging: false
       })
   })
 
@@ -453,14 +453,14 @@ describe('luis:build create multiple applications successfully when input is a f
       .post(uri => uri.includes('publish'))
       .reply(201, {
         versionId: '0.2',
-        isStaging: true
+        isStaging: false
       })
     
     nock('https://westus.api.cognitive.microsoft.com')
       .post(uri => uri.includes('publish'))
       .reply(201, {
         versionId: '0.2',
-        isStaging: true
+        isStaging: false
       })
 
     nock('https://westus.api.cognitive.microsoft.com')
@@ -573,7 +573,7 @@ describe('luis:build update dialog assets successfully when dialog assets exist'
       .post(uri => uri.includes('publish'))
       .reply(201, {
         versionId: '0.2',
-        isStaging: true
+        isStaging: false
       })
   })
 
@@ -713,7 +713,7 @@ describe('luis:build update application succeed with parameters set from luconfi
       .post(uri => uri.includes('publish'))
       .reply(201, {
         versionId: '0.2',
-        isStaging: true
+        isStaging: false
       })
   })
 
@@ -776,7 +776,7 @@ describe('luis:build create a new application successfully with locale set to it
       .post(uri => uri.includes('publish'))
       .reply(201, {
         versionId: '0.2',
-        isStaging: true
+        isStaging: false
       })
   })
 
@@ -847,7 +847,7 @@ describe('luis:build update application succeed when activeVersion is null', () 
       .post(uri => uri.includes('publish'))
       .reply(201, {
         versionId: '0.2',
-        isStaging: true
+        isStaging: false
       })
   })
 
@@ -901,7 +901,7 @@ describe('luis:build create a new application successfully with endpoint overrid
       .post(uri => uri.includes('publish'))
       .reply(201, {
         versionId: '0.2',
-        isStaging: true
+        isStaging: false
       })
   })
 

--- a/packages/qnamaker/src/commands/qnamaker/build.ts
+++ b/packages/qnamaker/src/commands/qnamaker/build.ts
@@ -70,7 +70,7 @@ export default class QnamakerBuild extends Command {
       // Flags override userConfig
       let qnamakerBuildFlags = Object.keys(QnamakerBuild.flags)
 
-      let {inVal, subscriptionKey, botName, region, out, defaultCulture, fallbackLocale, suffix, dialog, force, log, schema, endpoint}
+      let {inVal, subscriptionKey, botName, region, out, defaultCulture, fallbackLocale, suffix, dialog, force, log, endpoint, schema}
         = await processFlags(flags, qnamakerBuildFlags, this.config.configDir)
 
       flags.stdin = await this.readStdin()


### PR DESCRIPTION
fix #855 to enable users to configure the publishing slot enviroment. Before this change, lu build will default publish to production slot with no configuration capability. After the fix, users can specify --isStaging in lu:build to publish to staging slot. Default to production slot if not specified.