### PR TITLE
fix multiturn id mismatching issue

### DIFF
--- a/packages/lu/src/parser/cross-train/crossTrainer.js
+++ b/packages/lu/src/parser/cross-train/crossTrainer.js
@@ -474,7 +474,7 @@ const qnaCrossTrainCore = function (luResource, qnaResource, fileName, interrupt
     let subDedupedUtterances = dedupedUtterances.splice(0, MAX_QUESTIONS_PER_ANSWER)
     // construct new question content for qna resource
     let utterancesContent = subDedupedUtterances.join(NEWLINE + '- ')
-    let utterancesToQuestion = `${NEWLINE}${crossTrainingComments}${NEWLINE}# ? ${utterancesContent}${NEWLINE}${NEWLINE}**Filters:**${NEWLINE}- dialogName=${fileName}${NEWLINE}${NEWLINE}\`\`\`${NEWLINE}intent=DeferToRecognizer_LUIS_${fileName}${NEWLINE}\`\`\``
+    let utterancesToQuestion = `${NEWLINE}${crossTrainingComments}${NEWLINE}> !# @qna.pair.source = crosstrained${NEWLINE}${NEWLINE}# ? ${utterancesContent}${NEWLINE}${NEWLINE}**Filters:**${NEWLINE}- dialogName=${fileName}${NEWLINE}${NEWLINE}\`\`\`${NEWLINE}intent=DeferToRecognizer_LUIS_${fileName}${NEWLINE}\`\`\``
     trainedQnaResource = new SectionOperator(trainedQnaResource).addSection(utterancesToQuestion)
   }
 

--- a/packages/lu/src/parser/qna/qnamaker/kbCollate.js
+++ b/packages/lu/src/parser/qna/qnamaker/kbCollate.js
@@ -85,7 +85,7 @@ const resolveMultiTurnReferences = function(qnaList) {
             let qnaId = qnaList.find(x => x.id === prompt.qnaId || x.id === parseInt(prompt.qnaId));
             if (!qnaId) {
                 // find by question match
-                qnaId = qnaList.find(x => x.questions.includes(prompt.qnaId) || x.questions.includes(prompt.qnaId.replace(/-/g, ' ').trim()))
+                qnaId = qnaList.find(x => x.source.trim() !== 'crosstrained' && (x.questions.includes(prompt.qnaId) || x.questions.includes(prompt.qnaId.replace(/-/g, ' ').trim())))
             }
             if (qnaId === undefined) {
                 throw (new exception(retCode.INVALID_INPUT, `[ERROR]: Cannot find follow up prompt definition for '- [${prompt.displayText}](#?${prompt.qnaId}).`));

--- a/packages/lu/src/parser/qnabuild/builder.ts
+++ b/packages/lu/src/parser/qnabuild/builder.ts
@@ -20,7 +20,6 @@ const qnaMakerBuilder = require('./../qna/qnamaker/qnaMakerBuilder')
 const qnaOptions = require('./../lu/qnaOptions')
 const Content = require('./../lu/qna')
 const KB = require('./../qna/qnamaker/kb')
-const NEWLINE = require('os').EOL
 const recognizerType = require('./../utils/enums/recognizertypes')
 
 export class Builder {
@@ -40,7 +39,8 @@ export class Builder {
     let multiRecognizer: any
     let settings: any
     let recognizers = new Map<string, Recognizer>()
-    let qnaContents = new Map<string, string>()
+    let qnaContents = new Map<string, any>()
+    let qnaObjects = new Map<string, any[]>()
 
     for (const file of files) {
       let fileCulture: string
@@ -51,22 +51,7 @@ export class Builder {
         fileCulture = culture
       }
 
-      let fileContent = ''
-      let result
       const qnaFiles = await fileHelper.getLuObjects(undefined, file, true, fileExtEnum.QnAFile)
-      try {
-        result = await qnaBuilderVerbose.build(qnaFiles, true)
-
-        // construct qna content without file and url references
-        fileContent = result.parseToQnAContent()
-      } catch (err) {
-        if (err.source) {
-          err.text = `Invalid QnA file ${err.source}: ${err.text}`
-        } else {
-          err.text = `Invalid QnA file ${file}: ${err.text}`
-        }
-        throw (new exception(retCode.errorCode.INVALID_INPUT_FILE, err.text))
-      }
 
       this.handler(`${file} loaded\n`)
 
@@ -96,7 +81,7 @@ export class Builder {
         settings = new Settings(settingsPath, settingsContent)
       }
 
-      const content = new Content(fileContent, new qnaOptions(botName, true, fileCulture, file))
+      const content = new Content('', new qnaOptions(botName, true, fileCulture, file))
 
       if (!recognizers.has(content.name)) {
         const dialogFile = path.join(fileFolder, `${content.name}.dialog`)
@@ -113,13 +98,14 @@ export class Builder {
         let recognizer = Recognizer.load(content.path, content.name, dialogFile, settings, existingDialogObj, schema)
         recognizers.set(content.name, recognizer)
         qnaContents.set(content.name, content)
+        qnaObjects.set(content.name, qnaFiles)
       } else {
         // merge contents of qna files with same name
-        let existingContent: any = qnaContents.get(content.name)
-        existingContent.content = `${existingContent.content}${NEWLINE}${NEWLINE}${content.content}`
-        qnaContents.set(content.name, existingContent)
+        qnaObjects.get(content.name)?.push(...qnaFiles)
       }
     }
+
+    await this.resolveMergedQnAContentIds(qnaContents, qnaObjects)
 
     return {qnaContents: [...qnaContents.values()], recognizers, multiRecognizer, settings}
   }
@@ -512,6 +498,25 @@ export class Builder {
         }
 
         await fs.writeFile(crossTrainedFilePath, content, 'utf-8')
+      }
+    }
+  }
+
+  async resolveMergedQnAContentIds(contents: Map<string, any>, objects: Map<string, any[]>) {
+    for (const [name, content] of contents) {
+      let qnaObjects = objects.get(name)
+      try {
+        let result = await qnaBuilderVerbose.build(qnaObjects, true)
+        let mergedContent = result.parseToQnAContent()
+        content.content = mergedContent
+        contents.set(name, content)
+      } catch (err) {
+        if (err.source) {
+          err.text = `Invalid QnA file ${err.source}: ${err.text}`
+        } else {
+          err.text = `Invalid QnA file ${content.path}: ${err.text}`
+        }
+        throw (new exception(retCode.errorCode.INVALID_INPUT_FILE, err.text))
       }
     }
   }

--- a/packages/lu/test/parser/qna/qnaMakerBuilder.test.js
+++ b/packages/lu/test/parser/qna/qnaMakerBuilder.test.js
@@ -1,5 +1,6 @@
 const QnAMakerBuilder = require('./../../../src/parser/qna/qnamaker/qnaMakerBuilder')
 const QnA = require('./../../../src/parser/lu/qna')
+const qnaOptions = require('./../../../src/parser/lu/qnaOptions')
 var chai = require('chai');
 var assert = chai.assert;
 
@@ -23,6 +24,39 @@ describe('QnAMakerBuilder', function() {
         const qna = new QnA(qnaContent, '')
         const qnaMakerObject = await QnAMakerBuilder.fromQna([qna])
         assert.equal(qnaMakerObject.kb.name, 'my test kb');
+    });
+
+    it('Build QnaMaker app from multiple instances that have prompts', async () => {
+        let qnaContent1 =
+        `> !# @qna.pair.source = crosstrained
+        # ? hi
+        \`\`\`markdown
+        hi from crosstrained
+        \`\`\``;
+
+        let qnaContent2 =
+        `# ? greeting
+        \`\`\`markdown
+        how to greeting
+        \`\`\`
+        
+        **Prompts:**
+        - [hi greeting](#hi)`;
+
+        let qnaContent3 =
+        `# ? hi
+        \`\`\`markdown
+        say hi
+        \`\`\``;
+        const qna1 = new QnA(qnaContent1, new qnaOptions())
+        const qna2 = new QnA(qnaContent2, new qnaOptions())
+        const qna3 = new QnA(qnaContent3, new qnaOptions())
+        const qnaMakerObject = await QnAMakerBuilder.fromQna([qna1, qna2, qna3])
+
+        assert.equal(qnaMakerObject.kb.qnaList[0].id, 2);
+        assert.equal(qnaMakerObject.kb.qnaList[1].id, 3);
+        assert.equal(qnaMakerObject.kb.qnaList[2].id, 1);
+        assert.equal(qnaMakerObject.kb.qnaList[1].context.prompts[0].qnaId, 1);
     });
 
 });

--- a/packages/luis/test/fixtures/verified/interruption/Main.qna
+++ b/packages/luis/test/fixtures/verified/interruption/Main.qna
@@ -28,6 +28,8 @@ I can help book flight, book hotel and book train ticket
 ```
 
 > Source: cross training. Please do not edit these directly!
+> !# @qna.pair.source = crosstrained
+
 # ? book a hotel for me
 - book a flight for me
 - book a train ticket for me

--- a/packages/luis/test/fixtures/verified/interruption/dia1.fr-fr.qna
+++ b/packages/luis/test/fixtures/verified/interruption/dia1.fr-fr.qna
@@ -8,6 +8,8 @@ ha ha ha
 ```
 
 > Source: cross training. Please do not edit these directly!
+> !# @qna.pair.source = crosstrained
+
 # ? J'ai besoin d'un hôtel quatre étoiles
 - puis-je réserver un hôtel près de l'aiguille spatiale
 - guide de l'utilisateur

--- a/packages/luis/test/fixtures/verified/interruption/dia1.qna
+++ b/packages/luis/test/fixtures/verified/interruption/dia1.qna
@@ -50,6 +50,8 @@ I can help book flight, book hotel and book train ticket
 ```
 
 > Source: cross training. Please do not edit these directly!
+> !# @qna.pair.source = crosstrained
+
 # ? I need a four star hotel
 - book a flight for me
 - book a train ticket for me

--- a/packages/luis/test/fixtures/verified/interruption/dia2.qna
+++ b/packages/luis/test/fixtures/verified/interruption/dia2.qna
@@ -17,6 +17,8 @@ ha ha ha
 ```
 
 > Source: cross training. Please do not edit these directly!
+> !# @qna.pair.source = crosstrained
+
 # ? book a flight from Seattle to Beijing
 - book a train ticket from Seattle to Portland
 - book a hotel for me

--- a/packages/luis/test/fixtures/verified/interruption/dia3.qna
+++ b/packages/luis/test/fixtures/verified/interruption/dia3.qna
@@ -1,5 +1,7 @@
 
 > Source: cross training. Please do not edit these directly!
+> !# @qna.pair.source = crosstrained
+
 # ? book a flight to Beijing
 - book a train ticket from Seattle to Portland
 - book a hotel for me

--- a/packages/luis/test/fixtures/verified/interruption/main.fr-fr.qna
+++ b/packages/luis/test/fixtures/verified/interruption/main.fr-fr.qna
@@ -9,6 +9,8 @@ Voici le [guide de l'utilisateur] (http://contoso.com/userguide.pdf)
 ```
 
 > Source: cross training. Please do not edit these directly!
+> !# @qna.pair.source = crosstrained
+
 # ? réserver un hôtel
 
 **Filters:**

--- a/packages/luis/test/fixtures/verified/interruption5/dia1.qna
+++ b/packages/luis/test/fixtures/verified/interruption5/dia1.qna
@@ -8,6 +8,8 @@ ha ha ha
 ```
 
 > Source: cross training. Please do not edit these directly!
+> !# @qna.pair.source = crosstrained
+
 # ? can I book a hotel near space needle
 - user guide
 - Can I add multiple items?
@@ -1017,6 +1019,8 @@ intent=DeferToRecognizer_LUIS_dia1
 ```
 
 > Source: cross training. Please do not edit these directly!
+> !# @qna.pair.source = crosstrained
+
 # ? Feeling chipper?
 - Somebody's cheerful.
 - Feeling cheerful?

--- a/packages/luis/test/fixtures/verified/interruption5/main.qna
+++ b/packages/luis/test/fixtures/verified/interruption5/main.qna
@@ -1038,6 +1038,8 @@ Thank you
 ```
 
 > Source: cross training. Please do not edit these directly!
+> !# @qna.pair.source = crosstrained
+
 # ? book a hotel for me
 
 **Filters:**

--- a/packages/qnamaker/test/fixtures/verified/interruption/dia1.fr-fr.qna
+++ b/packages/qnamaker/test/fixtures/verified/interruption/dia1.fr-fr.qna
@@ -8,6 +8,8 @@ ha ha ha
 ```
 
 > Source: cross training. Please do not edit these directly!
+> !# @qna.pair.source = crosstrained
+
 # ? J'ai besoin d'un hôtel quatre étoiles
 - puis-je réserver un hôtel près de l'aiguille spatiale
 - guide de l'utilisateur

--- a/packages/qnamaker/test/fixtures/verified/interruption/dia1.qna
+++ b/packages/qnamaker/test/fixtures/verified/interruption/dia1.qna
@@ -38,6 +38,8 @@ I can book flight for you
 ```
 
 > Source: cross training. Please do not edit these directly!
+> !# @qna.pair.source = crosstrained
+
 # ? I need a four star hotel
 - book a flight for me
 - book a train ticket for me

--- a/packages/qnamaker/test/fixtures/verified/interruption/dia2.qna
+++ b/packages/qnamaker/test/fixtures/verified/interruption/dia2.qna
@@ -17,6 +17,8 @@ ha ha ha
 ```
 
 > Source: cross training. Please do not edit these directly!
+> !# @qna.pair.source = crosstrained
+
 # ? book a flight from Seattle to Beijing
 - book a train ticket from Seattle to Portland
 - book a hotel for me

--- a/packages/qnamaker/test/fixtures/verified/interruption/dia3.qna
+++ b/packages/qnamaker/test/fixtures/verified/interruption/dia3.qna
@@ -1,5 +1,7 @@
 
 > Source: cross training. Please do not edit these directly!
+> !# @qna.pair.source = crosstrained
+
 # ? book a flight to Beijing
 - book a train ticket from Seattle to Portland
 - book a hotel for me

--- a/packages/qnamaker/test/fixtures/verified/interruption/main.fr-fr.qna
+++ b/packages/qnamaker/test/fixtures/verified/interruption/main.fr-fr.qna
@@ -9,6 +9,8 @@ Voici le [guide de l'utilisateur] (http://contoso.com/userguide.pdf)
 ```
 
 > Source: cross training. Please do not edit these directly!
+> !# @qna.pair.source = crosstrained
+
 # ? réserver un hôtel
 
 **Filters:**

--- a/packages/qnamaker/test/fixtures/verified/interruption/main.qna
+++ b/packages/qnamaker/test/fixtures/verified/interruption/main.qna
@@ -18,6 +18,8 @@ Tell a funny joke
 ```
 
 > Source: cross training. Please do not edit these directly!
+> !# @qna.pair.source = crosstrained
+
 # ? book a hotel for me
 - book a flight for me
 - book a train ticket for me


### PR DESCRIPTION
fix #886 to resolve the issue that id mismatched in multi turn prompts when merging multiple qna files. The fix is to use lu/qna merger to merge multiple qna files and resolve the follow up ids as a whole instead of resolving each file first and then directly merging them. It also fixed an issue in crosstrain that will have negetive impact for the id matching flow, that means I added the source `> !# @qna.pair.source = crosstrained` for all crosstrained DeferToRecognizer_LUIS_{dialogName} QA pair. Then I filtered out such pairs when resolving the multi turn prompt ids to make sure the follow up turns always point to the right original QA pairs. The reason I did this is that, some orginial questions will be added to crosstrained DeferToRecognizer_LUIS_{dialogName}, when resolving the follow up prompt ids, it may point to crosstrained DeferToRecognizer_LUIS_{dialogName} QA pair. This is unreasonable. 

Unit test is added [here](https://github.com/microsoft/botframework-cli/pull/902/files#diff-2293ebbe63649de49c104048c728b765R29)