### PR TITLE
Add support for URI reference in LU

### DIFF
--- a/packages/lu/src/parser/lu/luMerger.js
+++ b/packages/lu/src/parser/lu/luMerger.js
@@ -481,14 +481,6 @@ const isUrl = function(path) {
         return false;
     }
 }
-const findLuFilesInDir = async function(srcId, idsToFind){
-    let luObjects = []
-    let parentFilePath = srcId === 'stdin' ? process.cwd() : path.parse(path.resolve(srcId)).dir
-    for(let idx = 0; idx < idsToFind.length; idx++ ) {
-        resolveLuFileContent(idsToFind[idx], luObjects, parentFilePath);
-    }
-    return luObjects
-}
 
 const updateParsedFiles = function(allParsedLUISContent, allParsedQnAContent, allParsedAlterationsContent, luobject) {
     // find the instance and ensure includeInCollate property is set correctly 

--- a/packages/lu/src/parser/lufile/parseFileContents.js
+++ b/packages/lu/src/parser/lufile/parseFileContents.js
@@ -659,7 +659,11 @@ const parseAndHandleImportSection = async function (parsedContent, luResource) {
 
                 let contentType = response.headers.get('content-type');
                 if (!contentType.includes('text/html')) {
-                    parsedContent.qnaJsonStructure.files.push(new qnaFile(linkValue, linkValueText));
+                    if (parseUrl.pathname.toLowerCase().endsWith('.lu') || parseUrl.pathname.toLowerCase().endsWith('.qna')) {
+                        parsedContent.additionalFilesToParse.push(new fileToParse(linkValue));
+                    } else {
+                        parsedContent.qnaJsonStructure.files.push(new qnaFile(linkValue, linkValueText));
+                    }
                 } else {
                     parsedContent.qnaJsonStructure.urls.push(linkValue);
                 }

--- a/packages/lu/src/parser/utils/helpers.js
+++ b/packages/lu/src/parser/utils/helpers.js
@@ -75,8 +75,6 @@ const helpers = {
         let linkValueList = utterance.trim().match(new RegExp(/\(.*?\)/g));
         let linkValue = linkValueList[0].replace('(', '').replace(')', '');
         if (linkValue === '') throw (new exception(retCode.errorCode.INVALID_LU_FILE_REF, `[ERROR]: Invalid LU File Ref: "${utterance}"`));
-        let parseUrl = url.parse(linkValue);
-        if (parseUrl.host || parseUrl.hostname) throw (new exception(retCode.errorCode.INVALID_LU_FILE_REF, `[ERROR]: Invalid LU File Ref: "${utterance}". \n Reference cannot be a URI`));
         // reference can either be #<Intent-Name> or #? or /*#? or /**#? or #*utterance* or #<Intent-Name>*patterns*
         let splitRegExp = new RegExp(/^(?<fileName>.*?)(?<segment>#|\*+)(?<path>.*?)$/gim);
         let splitReference = splitRegExp.exec(linkValue);
@@ -170,7 +168,36 @@ const helpers = {
         (finalLUISJSON.entities || []).forEach(e => {
             if (e.explicitlyAdded !== undefined) delete e.explicitlyAdded;
         })
-    }
+    },
+    fixBuffer : function(fileBuffer) {
+        if (fileBuffer) {
+          // If the data starts with BOM, we know it is UTF
+          if (fileBuffer[0] === 0xEF && fileBuffer[1] === 0xBB && fileBuffer[2] === 0xBF) {
+            // EF BB BF  UTF-8 with BOM
+            fileBuffer = fileBuffer.slice(3)
+          } else if (fileBuffer[0] === 0xFF && fileBuffer[1] === 0xFE && fileBuffer[2] === 0x00 && fileBuffer[3] === 0x00) {
+            // FF FE 00 00  UTF-32, little-endian BOM
+            fileBuffer = fileBuffer.slice(4)
+          } else if (fileBuffer[0] === 0x00 && fileBuffer[1] === 0x00 && fileBuffer[2] === 0xFE && fileBuffer[3] === 0xFF) {
+            // 00 00 FE FF  UTF-32, big-endian BOM
+            fileBuffer = fileBuffer.slice(4)
+          } else if (fileBuffer[0] === 0xFE && fileBuffer[1] === 0xFF && fileBuffer[2] === 0x00 && fileBuffer[3] === 0x00) {
+            // FE FF 00 00  UCS-4, unusual octet order BOM (3412)
+            fileBuffer = fileBuffer.slice(4)
+          } else if (fileBuffer[0] === 0x00 && fileBuffer[1] === 0x00 && fileBuffer[2] === 0xFF && fileBuffer[3] === 0xFE) {
+            // 00 00 FF FE  UCS-4, unusual octet order BOM (2143)
+            fileBuffer = fileBuffer.slice(4)
+          } else if (fileBuffer[0] === 0xFF && fileBuffer[1] === 0xFE) {
+            // FF FE  UTF-16, little endian BOM
+            fileBuffer = fileBuffer.slice(2)
+          } else if (fileBuffer[0] === 0xFE && fileBuffer[1] === 0xFF) {
+            // FE FF  UTF-16, big endian BOM
+            fileBuffer = fileBuffer.slice(2)
+          }
+        }
+        return fileBuffer.toString('utf8').replace(/\0/g, '');
+      }
+      
 };
 
 module.exports = helpers;

--- a/packages/lu/src/utils/textfilereader.ts
+++ b/packages/lu/src/utils/textfilereader.ts
@@ -6,7 +6,7 @@
 const fs = require('fs-extra')
 const error = require('./../parser/utils/exception')
 const retCode = require('./../parser/utils/enums/CLI-errors')
-const helpers = require('./../parser/utils/helpers');
+const helpers = require('./../parser/utils/helpers')
 
 export async function readTextFile(file: any): Promise<string> {
   return new Promise(async (resolve, reject) => {
@@ -15,7 +15,7 @@ export async function readTextFile(file: any): Promise<string> {
         return reject('ENOENT: no such file or directory, ' + file)
       }
       let fileBuffer = await fs.readFile(file)
-      return resolve(helpers.fixBuffer(fileBuffer));
+      return resolve(helpers.fixBuffer(fileBuffer))
     } catch (err) {
       if (err.message.match(/ENOENT: no such file or directory/)) {
         return reject(new error(retCode.errorCode.INVALID_INPUT_FILE, err.message))
@@ -25,4 +25,3 @@ export async function readTextFile(file: any): Promise<string> {
     }
   })
 }
-

--- a/packages/lu/src/utils/textfilereader.ts
+++ b/packages/lu/src/utils/textfilereader.ts
@@ -6,6 +6,7 @@
 const fs = require('fs-extra')
 const error = require('./../parser/utils/exception')
 const retCode = require('./../parser/utils/enums/CLI-errors')
+const helpers = require('./../parser/utils/helpers');
 
 export async function readTextFile(file: any): Promise<string> {
   return new Promise(async (resolve, reject) => {
@@ -14,32 +15,7 @@ export async function readTextFile(file: any): Promise<string> {
         return reject('ENOENT: no such file or directory, ' + file)
       }
       let fileBuffer = await fs.readFile(file)
-      if (fileBuffer) {
-        // If the data starts with BOM, we know it is UTF
-        if (fileBuffer[0] === 0xEF && fileBuffer[1] === 0xBB && fileBuffer[2] === 0xBF) {
-          // EF BB BF  UTF-8 with BOM
-          fileBuffer = fileBuffer.slice(3)
-        } else if (fileBuffer[0] === 0xFF && fileBuffer[1] === 0xFE && fileBuffer[2] === 0x00 && fileBuffer[3] === 0x00) {
-          // FF FE 00 00  UTF-32, little-endian BOM
-          fileBuffer = fileBuffer.slice(4)
-        } else if (fileBuffer[0] === 0x00 && fileBuffer[1] === 0x00 && fileBuffer[2] === 0xFE && fileBuffer[3] === 0xFF) {
-          // 00 00 FE FF  UTF-32, big-endian BOM
-          fileBuffer = fileBuffer.slice(4)
-        } else if (fileBuffer[0] === 0xFE && fileBuffer[1] === 0xFF && fileBuffer[2] === 0x00 && fileBuffer[3] === 0x00) {
-          // FE FF 00 00  UCS-4, unusual octet order BOM (3412)
-          fileBuffer = fileBuffer.slice(4)
-        } else if (fileBuffer[0] === 0x00 && fileBuffer[1] === 0x00 && fileBuffer[2] === 0xFF && fileBuffer[3] === 0xFE) {
-          // 00 00 FF FE  UCS-4, unusual octet order BOM (2143)
-          fileBuffer = fileBuffer.slice(4)
-        } else if (fileBuffer[0] === 0xFF && fileBuffer[1] === 0xFE) {
-          // FF FE  UTF-16, little endian BOM
-          fileBuffer = fileBuffer.slice(2)
-        } else if (fileBuffer[0] === 0xFE && fileBuffer[1] === 0xFF) {
-          // FE FF  UTF-16, big endian BOM
-          fileBuffer = fileBuffer.slice(2)
-        }
-      }
-      return resolve(fileBuffer.toString('utf8').replace(/\0/g, ''))
+      return resolve(helpers.fixBuffer(fileBuffer));
     } catch (err) {
       if (err.message.match(/ENOENT: no such file or directory/)) {
         return reject(new error(retCode.errorCode.INVALID_INPUT_FILE, err.message))
@@ -49,3 +25,4 @@ export async function readTextFile(file: any): Promise<string> {
     }
   })
 }
+

--- a/packages/lu/test/fixtures/verified/importUrl.json
+++ b/packages/lu/test/fixtures/verified/importUrl.json
@@ -1,0 +1,91 @@
+{
+  "intents": [
+    {
+      "name": "None"
+    }
+  ],
+  "entities": [
+    {
+      "name": "add",
+      "roles": [],
+      "children": [
+        {
+          "name": "count",
+          "children": [],
+          "features": [
+            {
+              "modelName": "globalCount",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "globalCount",
+      "roles": [],
+      "children": [
+        {
+          "name": "countNumber",
+          "children": [],
+          "features": [
+            {
+              "modelName": "number",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "composites": [],
+  "closedLists": [],
+  "regex_entities": [],
+  "regex_features": [],
+  "utterances": [
+    {
+      "text": "add two apples",
+      "intent": "None",
+      "entities": [
+        {
+          "entity": "add",
+          "startPos": 0,
+          "endPos": 13,
+          "children": [
+            {
+              "entity": "count",
+              "startPos": 4,
+              "endPos": 13
+            }
+          ]
+        },
+        {
+          "entity": "globalCount",
+          "startPos": 4,
+          "endPos": 13,
+          "children": [
+            {
+              "entity": "countNumber",
+              "startPos": 4,
+              "endPos": 6
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "patterns": [],
+  "patternAnyEntities": [],
+  "prebuiltEntities": [
+    {
+      "name": "number",
+      "roles": []
+    }
+  ],
+  "luis_schema_version": "7.0.0",
+  "versionId": "0.1",
+  "name": "",
+  "desc": "",
+  "culture": "en-us",
+  "phraselists": []
+}

--- a/packages/lu/test/fixtures/verified/referenceUrl.json
+++ b/packages/lu/test/fixtures/verified/referenceUrl.json
@@ -1,0 +1,28 @@
+{
+  "intents": [
+    {
+      "name": "test"
+    }
+  ],
+  "entities": [],
+  "composites": [],
+  "closedLists": [],
+  "regex_entities": [],
+  "model_features": [],
+  "regex_features": [],
+  "utterances": [
+    {
+      "text": "add two apples",
+      "intent": "test",
+      "entities": []
+    }
+  ],
+  "patterns": [],
+  "patternAnyEntities": [],
+  "prebuiltEntities": [],
+  "luis_schema_version": "3.2.0",
+  "versionId": "0.1",
+  "name": "",
+  "desc": "",
+  "culture": "en-us"
+}

--- a/packages/lu/test/fixtures/verified/referenceUrlWithWildCard.json
+++ b/packages/lu/test/fixtures/verified/referenceUrlWithWildCard.json
@@ -1,0 +1,49 @@
+{
+  "intents": [
+    {
+      "name": "test"
+    }
+  ],
+  "entities": [],
+  "composites": [],
+  "closedLists": [],
+  "regex_entities": [],
+  "model_features": [],
+  "regex_features": [],
+  "utterances": [
+    {
+      "text": "add two apples",
+      "intent": "test",
+      "entities": []
+    },
+    {
+      "text": "one",
+      "intent": "test",
+      "entities": []
+    },
+    {
+      "text": "two",
+      "intent": "test",
+      "entities": []
+    }
+  ],
+  "patterns": [
+    {
+      "pattern": "another {entity}",
+      "intent": "test"
+    }
+  ],
+  "patternAnyEntities": [
+    {
+      "name": "entity",
+      "explicitList": [],
+      "roles": []
+    }
+  ],
+  "prebuiltEntities": [],
+  "luis_schema_version": "3.2.0",
+  "versionId": "0.1",
+  "name": "",
+  "desc": "",
+  "culture": "en-us"
+}

--- a/packages/lu/test/parser/lufile/urlReference.test.js
+++ b/packages/lu/test/parser/lufile/urlReference.test.js
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+const chai = require('chai');
+const assert = chai.assert;
+const luisBuild = require('./../../../src/parser/luis/luisBuilder');
+const luMerger = require('./../../../src/parser/lu/luMerger');
+const luObj = require('../../../src/parser/lu/lu');
+const luOptions = require('./../../../src/parser/lu/luOptions')
+const nock = require('nock');
+
+describe('luis:convert with URL imports', () => {
+    before(function () {
+      nock('https://vkstoragetest.blob.core.windows.net')
+        .head(/.*/)
+        .reply(200, { status: 'OK' })
+      
+      nock('https://vkstoragetest.blob.core.windows.net')
+        .get(/.*/)
+        .reply(200, `## None
+        - {@add=add {@globalCount={@count={@countNumber=two} apples}}}
+        
+        @ ml add
+            - @ globalCount count
+        
+        @ ml globalCount
+            - @ number countNumber
+        
+        @ prebuilt number`)
+      })
+  
+    it('luis:convert [LUIS] with import statements to LU URLs is parsed correctly', (done) => {
+        let luContent = `[import](https://vkstoragetest.blob.core.windows.net/testlu/Expected.lu)`;
+        const expectedOutput = require('./../../fixtures/verified/importUrl.json');
+        luisBuild.fromLUAsync([new luObj(luContent)])
+            .then(res => {
+              assert.deepEqual(res, expectedOutput)
+              done();
+            })
+            .catch(err => done(err))
+    })
+  })
+  
+  describe('luis:convert with URL imports', function() {
+    before(function () {
+      nock('https://vkstoragetest.blob.core.windows.net')
+        .head(/.*/)
+        .reply(200, { status: 'OK' })
+      
+      nock('https://vkstoragetest.blob.core.windows.net')
+        .get(uri => uri.includes('Expected.lu'))
+        .reply(200, `## None
+        - {@add=add {@globalCount={@count={@countNumber=two} apples}}}
+        
+        @ ml add
+            - @ globalCount count
+        
+        @ ml globalCount
+            - @ number countNumber
+        
+        @ prebuilt number`)
+      })
+    it('luis:convert [LUIS] with import statements to LU URLs is parsed correctly', (done) => {
+      let luContent = `
+# test
+- [import](https://vkstoragetest.blob.core.windows.net/testlu/Expected.lu#None)`;
+      const expectedOutput = require('./../../fixtures/verified/referenceUrl.json');
+      luisBuild.fromLUAsync([new luObj(luContent)])
+          .then(res => {
+            assert.deepEqual(res, expectedOutput)
+            done();
+          })
+          .catch(err => done(err))
+    })
+  })
+  
+  describe('luis:convert with URL imports', function() {
+    before(function () {
+      nock('https://vkstoragetest.blob.core.windows.net')
+        .head(/.*/)
+        .reply(200, { status: 'OK' })
+
+      nock('https://vkstoragetest.blob.core.windows.net')
+        .get(uri => uri.includes('Expected.lu'))
+        .reply(200, `## None
+        - {@add=add {@globalCount={@count={@countNumber=two} apples}}}
+        
+        @ ml add
+            - @ globalCount count
+        
+        @ ml globalCount
+            - @ number countNumber
+        
+        @ prebuilt number`)
+  
+        nock('https://vkstoragetest.blob.core.windows.net')
+        .get(uri => uri.includes('Actual.lu'))
+        .reply(200, `
+        ## test
+        - one
+        
+        ## test2
+        - two
+        - another {entity}
+        
+        
+        @ prebuilt number
+        `)
+      })
+      it('luis:convert [LUIS] with import statements to LU URLs is parsed correctly', (done) => {
+        let luContent = `
+# test
+- [import](https://vkstoragetest.blob.core.windows.net/testlu/Expected.lu#None)
+- [import](https://vkstoragetest.blob.core.windows.net/testlu/Actual.lu#*utterancessndpatterns*)`;
+        const expectedOutput = require('./../../fixtures/verified/referenceUrlWithWildCard.json');
+        luisBuild.fromLUAsync([new luObj(luContent)])
+            .then(res => {
+              assert.deepEqual(res, expectedOutput)
+              done();
+            })
+            .catch(err => done(err))
+      })
+  })
+
+


### PR DESCRIPTION
Fixes #922 

```markdown
> URI to LU resource
[import](http://.../foo.lu)

# intent1
> Ability to pull in specific utterances from an intent
- [import](http://.../foo.lu#None)

# intent2
> Ability to pull in utterances or patterns or both from a specific intent 'None'
- [import](http://..../foo.lu#None*utterances*)
- [import](http://..../bar.lu#None*patterns*)
- [import](http://..../taz.lu#None*utterancesandpatterns*)

# intent3
> Ability to pull in all utterances or patterns or both across all intents
- [import](http://..../foo.lu#*utterances*)
- [import](http://..../bar.lu#*patterns*)
- [import](http://..../taz.lu#*utterancesandpatterns*)
```