### PR TITLE
Fix loadContents not working issue when loading both non-empty and empty files in luis/qnamaker:build

### DIFF
--- a/packages/lu/src/parser/lu/luMerger.js
+++ b/packages/lu/src/parser/lu/luMerger.js
@@ -547,7 +547,7 @@ const parseLuFile = async function(luOb, log, luis_culture) {
     let parsedContent = ''
     if (!luOb.content) {
         let error = BuildDiagnostic({ message: `Cannot parse empty ${luOb.id}. Please add content to the file or remove it.` })
-        throw(new exception(retCode.errorCode.EMPTY_CONTENT, error.toString()));
+        throw(new exception(retCode.errorCode.INVALID_INPUT_FILE, error.toString()));
     } 
     try {
         parsedContent = await parseFileContents.parseFile(luOb.content, log, luis_culture);

--- a/packages/lu/src/parser/lubuild/builder.ts
+++ b/packages/lu/src/parser/lubuild/builder.ts
@@ -74,15 +74,18 @@ export class Builder {
       let fileContent = ''
       let result
       let luisObj
-      const luFiles = await fileHelper.getLuObjects(undefined, file, true, fileExtEnum.LUFile)
+      let luFiles = await fileHelper.getLuObjects(undefined, file, true, fileExtEnum.LUFile)
+      this.handler(`${file} loaded\n`)
+
+      // filter empty lu files
+      luFiles = luFiles.filter((file: any) => file.content !== '')
+      if (luFiles.length <= 0) continue
+
       try {
         result = await LuisBuilderVerbose.build(luFiles, true, fileCulture)
         luisObj = new Luis(result)
         fileContent = luisObj.parseToLuContent()
-        this.handler(`${file} loaded\n`)
       } catch (err) {
-        if (err.errCode === retCode.errorCode.EMPTY_CONTENT) continue
-
         if (err.source) {
           err.text = `Invalid LU file ${err.source}: ${err.text}`
         } else {

--- a/packages/lu/src/parser/qnabuild/builder.ts
+++ b/packages/lu/src/parser/qnabuild/builder.ts
@@ -73,8 +73,12 @@ export class Builder {
         crosstrainedRecognizers.set(fileName, new CrossTrainedRecognizer(crossTrainedRecognizerPath, crosstrainedRecognizerContent, crosstrainedRecognizerSchema as string))
       }
 
-      const qnaFiles = await fileHelper.getLuObjects(undefined, file, true, fileExtEnum.QnAFile)
+      let qnaFiles = await fileHelper.getLuObjects(undefined, file, true, fileExtEnum.QnAFile)
       this.handler(`${file} loaded\n`)
+
+      // filter empty qna files
+      qnaFiles = qnaFiles.filter((file: any) => file.content !== '')
+      if (qnaFiles.length <= 0) continue
 
       const multiRecognizerPath = path.join(fileFolder, `${fileName}.qna.dialog`)
       if (!multiRecognizers.has(fileName)) {
@@ -588,8 +592,6 @@ export class Builder {
         content.content = mergedContent
         contents.set(name, content)
       } catch (err) {
-        if (err.errCode === retCode.errorCode.EMPTY_CONTENT) continue
-
         if (err.source) {
           err.text = `Invalid QnA file ${err.source}: ${err.text}`
         } else {

--- a/packages/lu/src/parser/utils/enums/CLI-errors.js
+++ b/packages/lu/src/parser/utils/enums/CLI-errors.js
@@ -29,7 +29,6 @@ module.exports = {
         INVALID_REGEX_ENTITY:       22,
         INVALID_COMPOSITE_ENTITY:   23,
         LUIS_API_CALL_FAILED:       24,
-        EMPTY_CONTENT:              25,
         UNKNOWN_ERROR:              99,
         BOUNDARY_INTENTS:           501,
         BOUNDARY_PATTERNANYENTITY:  502,

--- a/packages/luis/test/fixtures/testcases/lubuild/empty-file/config/luis.settings.development.westus.json
+++ b/packages/luis/test/fixtures/testcases/lubuild/empty-file/config/luis.settings.development.westus.json
@@ -1,0 +1,5 @@
+{
+    "luis": {
+        "non_empty_en_us_lu": "f8c64e2a-1111-3a09-8f78-39d7adc76ec5"
+    }
+}

--- a/packages/luis/test/fixtures/testcases/lubuild/empty-file/dialogs/non-empty.en-us.lu.dialog
+++ b/packages/luis/test/fixtures/testcases/lubuild/empty-file/dialogs/non-empty.en-us.lu.dialog
@@ -1,0 +1,7 @@
+{
+    "$kind": "Microsoft.LuisRecognizer",
+    "id": "LUIS_non-empty",
+    "applicationId": "=settings.luis.non_empty_en_us_lu",
+    "endpoint": "=settings.luis.endpoint",
+    "endpointKey": "=settings.luis.endpointKey"
+}

--- a/packages/luis/test/fixtures/testcases/lubuild/empty-file/dialogs/non-empty.lu.dialog
+++ b/packages/luis/test/fixtures/testcases/lubuild/empty-file/dialogs/non-empty.lu.dialog
@@ -1,0 +1,8 @@
+{
+    "$kind": "Microsoft.MultiLanguageRecognizer",
+    "id": "LUIS_non-empty",
+    "recognizers": {
+        "en-us": "non-empty.en-us.lu",
+        "": "non-empty.en-us.lu"
+    }
+}

--- a/packages/luis/test/fixtures/testcases/lubuild/empty-file/dialogs/non-empty.lu.qna.dialog
+++ b/packages/luis/test/fixtures/testcases/lubuild/empty-file/dialogs/non-empty.lu.qna.dialog
@@ -1,0 +1,6 @@
+{
+    "$kind": "Microsoft.CrossTrainedRecognizerSet",
+    "recognizers": [
+        "non-empty.lu"
+    ]
+}

--- a/packages/luis/test/fixtures/testcases/lubuild/empty-file/lufiles/non-empty.lu
+++ b/packages/luis/test/fixtures/testcases/lubuild/empty-file/lufiles/non-empty.lu
@@ -1,0 +1,2 @@
+# greeting
+- hello

--- a/packages/qnamaker/test/fixtures/testcases/qnabuild/empty-file/config/qnamaker.settings.development.westus.json
+++ b/packages/qnamaker/test/fixtures/testcases/qnabuild/empty-file/config/qnamaker.settings.development.westus.json
@@ -1,0 +1,6 @@
+{
+    "qna": {
+        "non_empty_en_us_qna": "f8c64e2a-2222-3a09-8f78-39d7adc76ec5",
+        "hostname": "https://myqnamakerbot.azurewebsites.net/qnamaker"
+    }
+}

--- a/packages/qnamaker/test/fixtures/testcases/qnabuild/empty-file/dialogs/empty.zh-ch.lu.qna.dialog
+++ b/packages/qnamaker/test/fixtures/testcases/qnabuild/empty-file/dialogs/empty.zh-ch.lu.qna.dialog
@@ -1,0 +1,4 @@
+{
+    "$kind": "Microsoft.CrossTrainedRecognizerSet",
+    "recognizers": []
+}

--- a/packages/qnamaker/test/fixtures/testcases/qnabuild/empty-file/dialogs/non-empty.en-us.qna.dialog
+++ b/packages/qnamaker/test/fixtures/testcases/qnabuild/empty-file/dialogs/non-empty.en-us.qna.dialog
@@ -1,0 +1,7 @@
+{
+    "$kind": "Microsoft.QnAMakerRecognizer",
+    "id": "QnA_non-empty",
+    "knowledgeBaseId": "=settings.qna.non_empty_en_us_qna",
+    "hostname": "=settings.qna.hostname",
+    "endpointKey": "=settings.qna.endpointKey"
+}

--- a/packages/qnamaker/test/fixtures/testcases/qnabuild/empty-file/dialogs/non-empty.lu.qna.dialog
+++ b/packages/qnamaker/test/fixtures/testcases/qnabuild/empty-file/dialogs/non-empty.lu.qna.dialog
@@ -1,0 +1,6 @@
+{
+    "$kind": "Microsoft.CrossTrainedRecognizerSet",
+    "recognizers": [
+        "non-empty.qna"
+    ]
+}

--- a/packages/qnamaker/test/fixtures/testcases/qnabuild/empty-file/dialogs/non-empty.qna.dialog
+++ b/packages/qnamaker/test/fixtures/testcases/qnabuild/empty-file/dialogs/non-empty.qna.dialog
@@ -1,0 +1,8 @@
+{
+    "$kind": "Microsoft.MultiLanguageRecognizer",
+    "id": "QnA_non-empty",
+    "recognizers": {
+        "en-us": "non-empty.en-us.qna",
+        "": "non-empty.en-us.qna"
+    }
+}

--- a/packages/qnamaker/test/fixtures/testcases/qnabuild/empty-file/qnafiles/non-empty.qna
+++ b/packages/qnamaker/test/fixtures/testcases/qnabuild/empty-file/qnafiles/non-empty.qna
@@ -1,0 +1,4 @@
+# ? greeting
+```
+hello
+```


### PR DESCRIPTION
Fix #924 to make loadContents function load files correctly when both non-empty and empty files are there at the same time.

Tests are added.

Composer reported issue since they have empty lu or qna files in many scenarios.