### PR TITLE
Fix lu parser to handle feature assignment via imports

### DIFF
--- a/packages/lu/src/parser/lufile/parseFileContents.js
+++ b/packages/lu/src/parser/lufile/parseFileContents.js
@@ -189,7 +189,7 @@ const parseLuAndQnaWithAntlr = async function (parsedContent, fileContent, log, 
     updateIntentAndEntityFeatures(parsedContent.LUISJsonStructure);
 
     helpers.checkAndUpdateVersion(parsedContent.LUISJsonStructure);
-
+    
 }
 
 const updateIntentAndEntityFeatures = function(luisObj) {
@@ -532,13 +532,7 @@ const parseFeatureSections = function(parsedContent, featuresToProcess) {
                         validateFeatureAssignment(entityType, section.Name, INTENTTYPE, feature, section.Range);
                         addFeatures(srcEntity, feature, featureTypeEnum.modelToFeature, section.Range, featureProperties.intentFeatureToModel);
                     } else {
-                        // Item must be defined before being added as a feature.
-                        let errorMsg = `Features must be defined before assigned to an entity. No definition found for feature "${feature}" in usesFeature definition for entity "${section.Name}"`;
-                        let error = BuildDiagnostic({
-                            message: errorMsg,
-                            range: section.Range
-                        })
-                        throw (new exception(retCode.errorCode.INVALID_INPUT, error.toString(), [error]));
+                        addFeatures(srcEntity, feature, featureTypeEnum.modelToFeature, section.Range, featureProperties.intentFeatureToModel);
                     }
                 });
             }

--- a/packages/lu/test/parser/lufile/parseFileContents.modelAsFeature.test.js
+++ b/packages/lu/test/parser/lufile/parseFileContents.modelAsFeature.test.js
@@ -2,6 +2,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+const luisBuilder = require('../../../src/parser/luis/luisBuilder');
 const parseFile = require('../../../src/parser/lufile/parseFileContents');
 const luconvert = require('../../../src/parser/luis/luConverter');
 const entityNameWithSpaceAndFeature = require('../../fixtures/testcases/entityNameWithSpaceAndFeature.json');
@@ -196,8 +197,7 @@ describe('Model as feature definitions', function () {
                     @ ml x1
                     @ x1 usesFeature city3
                 `;
-    
-                parseFile.parseFile(luFile)
+                luisBuilder.fromContentAsync(luFile)
                     .then(res => done(res))
                     .catch(err => done())
             });
@@ -435,11 +435,10 @@ describe('Model as feature definitions', function () {
         describe('Composite entity', function() {
             it('Features must be defined before they can be added.', function(done) {
                 let luFile = `
-                    @ patternany x1
+                    @ composite x1
                     @ x1 usesFeature city3
                 `;
-    
-                parseFile.parseFile(luFile)
+                luisBuilder.fromContentAsync(luFile)
                     .then(res => done(res))
                     .catch(err => done())
             });

--- a/packages/luis/src/commands/luis/convert.ts
+++ b/packages/luis/src/commands/luis/convert.ts
@@ -45,6 +45,7 @@ export default class LuisConvert extends Command {
       if (isLu) {
         const luFiles = await file.getLuObjects(stdin, flags.in, flags.recurse, fileExtEnum.LUFile)
         result = await LuisBuilder.build(luFiles, flags.log, flags.culture)
+        result.validate()
         if (!hasContent(result)) {
           throw new CLIError('No LU or Luis content parsed!')
         }


### PR DESCRIPTION
Fix an issue in lu parser where feature assignment via imports were not handled correctly.

phrases.lu:
```
@ phraseList addPhrases(interchangeable)=
- add, set
```

add.lu:
```
[phrase.lu](./phrases.lu)
@ ml add() usesFeature addPhrases
```