### PR TITLE
Update README.md

### DIFF
--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -13,6 +13,10 @@ _BF_ plugins command group allows you to extend the CLI with preview commands. O
 
 ## Available plugins
 
+There are currently no plugins available.
+
+The most recent plugin was [@microsoft/bf-dialog](https://github.com/microsoft/botframework-cli/tree/master/packages/dialog), it is now a core part of the [BF CLI](https://github.com/microsoft/botframework-cli).
+<!--
 [@microsoft/bf-dialog](https://github.com/microsoft/botframework-cli/tree/master/packages/dialog)
 ```
 npm config set registry https://botbuilder.myget.org/F/botframework-cli/npm/
@@ -21,9 +25,13 @@ bf plugins:install @microsoft/bf-dialog
 
 npm config set registry https://registry.npmjs.org/
 ```
-<!-- toc -->
+
+-->
+
+<!-- toc 
 * [Commands](#commands)
-<!-- tocstop -->
+ tocstop -->
+
 # Commands
 <!-- commands -->
 * [`bf plugins`](#bf-plugins)


### PR DESCRIPTION
- Removed dialog as a plugin since it is no longer pre-release...
- Remove the one TOC item since the section it linked to was the next line down, it didn't seem necessary.

Note: This is related to [PR 939](https://github.com/microsoft/botframework-cli/pull/939)