### PR TITLE
fix update kb issue in importUrlReference and importFileReference APIs

### DIFF
--- a/packages/lu/src/parser/qnabuild/builder.ts
+++ b/packages/lu/src/parser/qnabuild/builder.ts
@@ -313,15 +313,13 @@ export class Builder {
       }
     }
 
-    // compare models to update the model if a match found
-    // otherwise create a new kb
+    // delete the kb if it already exists
     if (kbId !== '') {
-      // To see if need update the model
-      await this.updateUrlKB(qnaBuildCore, url, kbId)
-    } else {
-      // create a new kb
-      kbId = await this.createUrlKB(qnaBuildCore, url, kbName)
+      await qnaBuildCore.deleteKB(kbId)
     }
+
+    // create a new kb
+    kbId = await this.createUrlKB(qnaBuildCore, url, kbName)
 
     const kbJson = await qnaBuildCore.exportKB(kbId, 'Test')
     const kb = new KB(kbJson)
@@ -349,15 +347,13 @@ export class Builder {
       }
     }
 
-    // compare models to update the model if a match found
-    // otherwise create a new kb
+    // delete the kb if it already exists
     if (kbId !== '') {
-      // To see if need update the model
-      await this.updateFileKB(qnaBuildCore, fileName, fileUri, kbId)
-    } else {
-      // create a new kb
-      kbId = await this.createFileKB(qnaBuildCore, fileName, fileUri, kbName)
+      await qnaBuildCore.deleteKB(kbId)
     }
+
+    // create a new kb
+    kbId = await this.createFileKB(qnaBuildCore, fileName, fileUri, kbName)
 
     const kbJson = await qnaBuildCore.exportKB(kbId, 'Test')
     const kb = new KB(kbJson)
@@ -485,24 +481,6 @@ export class Builder {
     return true
   }
 
-  async updateUrlKB(qnaBuildCore: QnaBuildCore, url: string, kbId: string) {
-    await qnaBuildCore.replaceKB(kbId, {
-      qnaList: [],
-      urls: [],
-      files: []
-    })
-
-    const updateConfig = {
-      add: {
-        urls: [url]
-      }
-    }
-
-    const response = await qnaBuildCore.updateKB(kbId, updateConfig)
-    const operationId = response.operationId
-    await this.getKBOperationStatus(qnaBuildCore, operationId, 1000)
-  }
-
   async createUrlKB(qnaBuildCore: QnaBuildCore, url: string, kbName: string) {
     const kbJson = {
       name: kbName,
@@ -517,27 +495,6 @@ export class Builder {
     const kbId = opResult.resourceLocation.split('/')[2]
 
     return kbId
-  }
-
-  async updateFileKB(qnaBuildCore: QnaBuildCore, fileName: string, fileUri: string, kbId: string) {
-    await qnaBuildCore.replaceKB(kbId, {
-      qnaList: [],
-      urls: [],
-      files: []
-    })
-
-    let updateConfig = {
-      add: {
-        files: [{
-          fileName,
-          fileUri
-        }]
-      }
-    }
-
-    const response = await qnaBuildCore.updateKB(kbId, updateConfig)
-    const operationId = response.operationId
-    await this.getKBOperationStatus(qnaBuildCore, operationId, 1000)
   }
 
   async createFileKB(qnaBuildCore: QnaBuildCore, fileName: string, fileUri: string, kbName: string) {

--- a/packages/lu/test/parser/qnabuild/qnabuild.test.js
+++ b/packages/lu/test/parser/qnabuild/qnabuild.test.js
@@ -70,6 +70,70 @@ describe('builder: importUrlOrFileReference function return lu content from file
   })
 })
 
+describe('builder: importUrlOrFileReference function return lu content from file sucessfully when updating kb', () => {
+  before(function () {
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('qnamaker'))
+      .reply(200, {
+        knowledgebases:
+          [{
+            name: 'test.en-us.qna',
+            id: 'f8c64e2a-1111-3a09-8f78-39d7adc76ec5',
+            hostName: 'https://myqnamakerbot.azurewebsites.net'
+          }]
+      })
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .delete(uri => uri.includes('knowledgebases'))
+      .reply(200)
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .post(uri => uri.includes('createasync'))
+      .reply(202, {
+        operationId: 'f8c64e2a-aaaa-3a09-8f78-39d7adc76ec5'
+      })
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('operations'))
+      .reply(200, {
+        operationState: 'Succeeded',
+        resourceLocation: 'a/b/f8c64e2a-2222-3a09-8f78-39d7adc76ec5'
+      })
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('knowledgebases'))
+      .reply(200, {
+        qnaDocuments: [{
+          id: 1,
+          source: 'SurfaceManual.pdf',
+          questions: ['how many sandwich types do you have'],
+          answer: '25 types',
+          metadata: []
+        }]
+      })
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .delete(uri => uri.includes('knowledgebases'))
+      .reply(200)
+  })
+
+  it('should return lu content from file successfully when kb exists', async () => {
+    const builder = new Builder()
+    const luContent = await builder.importFileReference(
+      'SurfaceManual.pdf',
+      'https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN.pdf',
+      uuidv1(),
+      'https://westus.api.cognitive.microsoft.com/qnamaker/v4.0',
+      'test.en-us.qna')
+    assert.equal(luContent, `> # QnA pairs${NEWLINE}${NEWLINE}` +
+      `> !# @qna.pair.source = SurfaceManual.pdf${NEWLINE}${NEWLINE}` +
+      `<a id = "1"></a>${NEWLINE}${NEWLINE}` +
+      `## ? how many sandwich types do you have${NEWLINE}${NEWLINE}` +
+      `\`\`\`markdown${NEWLINE}` +
+      `25 types${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}`)
+  })
+})
+
 describe('builder: importUrlOrFileReference function return lu content from url sucessfully', () => {
   before(function () {
     nock('https://westus.api.cognitive.microsoft.com')
@@ -126,6 +190,69 @@ describe('builder: importUrlOrFileReference function return lu content from url 
                             `## ? how many sandwich types do you have${NEWLINE}${NEWLINE}` +
                             `\`\`\`markdown${NEWLINE}` +
                             `25 types${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}`)
+  })
+})
+
+describe('builder: importUrlOrFileReference function return lu content from url sucessfully when updating kb', () => {
+  before(function () {
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('qnamaker'))
+      .reply(200, {
+        knowledgebases:
+          [{
+            name: 'test.en-us.qna',
+            id: 'f8c64e2a-1111-3a09-8f78-39d7adc76ec5',
+            hostName: 'https://myqnamakerbot.azurewebsites.net'
+          }]
+      })
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .delete(uri => uri.includes('knowledgebases'))
+      .reply(200)
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .post(uri => uri.includes('createasync'))
+      .reply(202, {
+        operationId: 'f8c64e2a-aaaa-3a09-8f78-39d7adc76ec5'
+      })
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('operations'))
+      .reply(200, {
+        operationState: 'Succeeded',
+        resourceLocation: 'a/b/f8c64e2a-2222-3a09-8f78-39d7adc76ec5'
+      })
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('knowledgebases'))
+      .reply(200, {
+        qnaDocuments: [{
+          id: 1,
+          source: 'faqs',
+          questions: ['how many sandwich types do you have'],
+          answer: '25 types',
+          metadata: []
+        }]
+      })
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .delete(uri => uri.includes('knowledgebases'))
+      .reply(200)
+  })
+
+  it('should return lu content from url successfully', async () => {
+    const builder = new Builder()
+    const luContent = await builder.importUrlReference(
+      'https://docs.microsoft.com/en-in/azure/cognitive-services/qnamaker/faqs',
+      uuidv1(),
+      'https://westus.api.cognitive.microsoft.com/qnamaker/v4.0',
+      'test.en-us.qna')
+    assert.equal(luContent, `> # QnA pairs${NEWLINE}${NEWLINE}` +
+      `> !# @qna.pair.source = faqs${NEWLINE}${NEWLINE}` +
+      `<a id = "1"></a>${NEWLINE}${NEWLINE}` +
+      `## ? how many sandwich types do you have${NEWLINE}${NEWLINE}` +
+      `\`\`\`markdown${NEWLINE}` +
+      `25 types${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}`)
   })
 })
 


### PR DESCRIPTION
fix #953. Before the fix, it will fail when importing url or file reference into an existing kb since replacing kb with empty content is not allowed. To unblock the importing, we have to delete the kb and create a new one. This will be only applied for importUrlReference and importFileReference APIs in qna builder.