### PR TITLE
Fix luconverter to handle intent names with spaces correctly when features are assigned

### DIFF
--- a/packages/lu/src/parser/luis/luConverter.js
+++ b/packages/lu/src/parser/luis/luConverter.js
@@ -72,7 +72,7 @@ const parseIntentsToLu = function(luisObj, luisJSON){
         if (intent.intent.features) {
             let rolesAndFeatures = addRolesAndFeatures(intent.intent);
             if (rolesAndFeatures !== '') {
-                fileContent += `@ intent ${intent.intent.name}`;
+                fileContent += `@ intent ${intent.intent.name.includes(' ') ? `"${intent.intent.name}"` : `${intent.intent.name}`}`;
                 fileContent += rolesAndFeatures;
                 fileContent += NEWLINE + NEWLINE;
             }

--- a/packages/lu/test/fixtures/testcases/intentWithSpace.json
+++ b/packages/lu/test/fixtures/testcases/intentWithSpace.json
@@ -1,0 +1,39 @@
+{
+  "intents": [
+    {
+      "name": "test intent",
+      "features": [
+        {
+          "modelName": "bar",
+          "isRequired": false
+        }
+      ]
+    }
+  ],
+  "entities": [
+    {
+      "name": "bar",
+      "roles": []
+    }
+  ],
+  "composites": [],
+  "closedLists": [],
+  "regex_entities": [],
+  "regex_features": [],
+  "utterances": [
+    {
+      "text": "foo",
+      "intent": "test intent",
+      "entities": []
+    }
+  ],
+  "patterns": [],
+  "patternAnyEntities": [],
+  "prebuiltEntities": [],
+  "luis_schema_version": "7.0.0",
+  "versionId": "0.1",
+  "name": "",
+  "desc": "",
+  "culture": "en-us",
+  "phraselists": []
+}

--- a/packages/lu/test/parser/luis/luisBuilder.test.js
+++ b/packages/lu/test/parser/luis/luisBuilder.test.js
@@ -72,5 +72,11 @@ assert.isTrue(luisObject.validate())
         assert.equal(luisObject.content.includes(`- {@add=add {@globalCount={@count={@countNumber=two} apples}}}`), true);
     })
 
+    it('Intent name with spaces are handled correctly with feature assignment', async () => {
+        let testJSON = require('../../fixtures/testcases/intentWithSpace.json');
+        const luisObject = LUISBuilder.fromJson(testJSON).parseToLU();
+        assert.equal(luisObject.content.includes(`@ intent "test intent" usesFeature bar`), true);
+    })
+
     
 });


### PR DESCRIPTION
Fixes #943 

The issue is in conversion from JSON -> LU where intent name with spaces were not wrapped in quotes. This caused subsequent issue with LU -> JSON conversion for missing quotes around intent names that have spaces in them. 