### PR TITLE
[bf-lu] fix issue in parser where mixed case settings values were not handled correctly

### DIFF
--- a/packages/lu/src/parser/lufile/parseFileContents.js
+++ b/packages/lu/src/parser/lufile/parseFileContents.js
@@ -1934,14 +1934,14 @@ const parseAndHandleModelInfoSection = function (parsedContent, luResource, log)
                         let settingsPair = settingsRegExp.exec(kvPair[2]);
                         if (settingsPair && settingsPair.groups && settingsPair.groups.property) {
                             if (!parsedContent.LUISJsonStructure.settings) {
-                                parsedContent.LUISJsonStructure.settings = [{name : settingsPair.groups.property, value : kvPair[3] === "true"}];
+                                parsedContent.LUISJsonStructure.settings = [{name : settingsPair.groups.property, value : kvPair[3].toLowerCase() === "true"}];
                             } else {
                                 // find the setting
                                 let sFound = parsedContent.LUISJsonStructure.settings.find(setting => setting.name == settingsPair.groups.property);
                                 if (sFound) {
                                     sFound.value = kvPair[3] === "true";
                                 } else {
-                                    parsedContent.LUISJsonStructure.settings.push({name : settingsPair.groups.property, value : kvPair[3] === "true"})
+                                    parsedContent.LUISJsonStructure.settings.push({name : settingsPair.groups.property, value : kvPair[3].toLowerCase() === "true"})
                                 }
                             }
                         }

--- a/packages/lu/test/parser/lufile/appKbMetaData.test.js
+++ b/packages/lu/test/parser/lufile/appKbMetaData.test.js
@@ -87,7 +87,7 @@ describe('App/ Kb meta data information', function () {
     it ('Settings information is parsed correctly', function(done){
         let testLU = `
 > !# @app.settings.NormalizeDiacritics = true
-> !# @app.settings.NormalizePunctuation = false
+> !# @app.settings.NormalizePunctuation = True
 > !# @app.settings.UseAllTrainingData = true
 
 # test
@@ -97,7 +97,7 @@ describe('App/ Kb meta data information', function () {
                 .then(res => {
                     assert.equal(res.LUISJsonStructure.settings.length, 3);
                     assert.equal(res.LUISJsonStructure.settings[1].name, "NormalizePunctuation")
-                    assert.equal(res.LUISJsonStructure.settings[1].value, false)
+                    assert.equal(res.LUISJsonStructure.settings[1].value, true)
                     done();
                 })
                 .catch(err => done(err))


### PR DESCRIPTION
Issue was reported via LUIS team where `settings` properties in LU content was not handled correctly when the value is mixed case.