### PR TITLE
Fix lg:expand cannot retrieve the value from scope with certain paths

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -352,10 +352,10 @@
                 "lg:expand",
                 "--in",
                 "accessScope.lg",
-                "--out",
-                "accessScope.out.lg",
+                "--testInput",
+                "data.json",
                 "--template",
-                "AddItemReadBack"
+                "GetIndex"
             ],
             "internalConsoleOptions": "openOnSessionStart",
             "cwd": "${workspaceFolder}/packages/lg/test/fixtures/testcase"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -337,6 +337,28 @@
             ],
             "internalConsoleOptions": "openOnSessionStart",
             "cwd": "${workspaceFolder}/../botbuilder-dotnet/tests/Microsoft.Bot.Builder.Dialogs.Adaptive.Tests/tests/LUISRecognizerTests"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "LG Expand Test",
+            "preLaunchTask": "${defaultBuildTask}",
+            "program": "${workspaceFolder}/packages/lg/bin/run",
+            "outputCapture": "std",
+            "outFiles": [
+                "./packages/lg/lib/**"
+            ],
+            "args": [
+                "lg:expand",
+                "--in",
+                "accessScope.lg",
+                "--out",
+                "accessScope.out.lg",
+                "--template",
+                "AddItemReadBack"
+            ],
+            "internalConsoleOptions": "openOnSessionStart",
+            "cwd": "${workspaceFolder}/packages/lg/test/fixtures/testcase"
         }
     ]
 }

--- a/packages/lg/src/commands/lg/expand.ts
+++ b/packages/lg/src/commands/lg/expand.ts
@@ -253,12 +253,12 @@ export default class ExpandCommand extends Command {
     const paths = path.split('.')
     let current = obj
 
-    for (let i = 0; i < paths.length; i++) {
-      if (current[paths[i]] === undefined) {
+    for (const segPath of paths) {
+      if (current[segPath] === undefined) {
         return undefined
       }
 
-      current = current[paths[i]]
+      current = current[segPath]
     }
 
     return current

--- a/packages/lg/src/commands/lg/expand.ts
+++ b/packages/lg/src/commands/lg/expand.ts
@@ -141,8 +141,7 @@ export default class ExpandCommand extends Command {
       }
 
       const expectedVariables = lg.analyzeTemplate(templateName).Variables
-      const variableObjFromFile = this.getVariableObject(testInput)
-      variablesValue = this.getVariableValues(variableObjFromFile, expectedVariables, userInputValues)
+      variablesValue = this.getVariableValues(testInput, expectedVariables, userInputValues)
       for (const variableValue of variablesValue) {
         if (variableValue[1] === undefined) {
           if (interactive) {
@@ -207,26 +206,8 @@ export default class ExpandCommand extends Command {
     return result
   }
 
-  private getVariableValues(variablesObj: any, expectedVariables: string[], userInputValues: Map<string, any>): Map<string, any> {
+  private getVariableValues(testinput: string, expectedVariables: string[], userInputValues: Map<string, any>): Map<string, any> {
     const result: Map<string, any> = new Map<string, any>()
-
-    if (expectedVariables !== undefined) {
-      for (const variable of expectedVariables) {
-        const deepFindResult = lodash.get(variablesObj, variable)
-        if (variablesObj !== undefined && deepFindResult !== undefined) {
-          result.set(variable, deepFindResult)
-        } else if (userInputValues !== undefined && userInputValues.has(variable)) {
-          result.set(variable, userInputValues.get(variable))
-        } else {
-          result.set(variable, undefined)
-        }
-      }
-    }
-
-    return result
-  }
-
-  private getVariableObject(testinput: string): any {
     let variablesObj: any
     if (testinput !== undefined) {
       let filePath: string = testinput
@@ -248,26 +229,20 @@ export default class ExpandCommand extends Command {
       variablesObj = JSON.parse(fileContent)
     }
 
-    return variablesObj
-  }
-
-  private deepFind(obj: any, path: string): any {
-    if (obj === undefined) {
-      return undefined
-    }
-
-    const paths = path.split('.')
-    let current = obj
-
-    for (const segPath of paths) {
-      if (current[segPath] === undefined) {
-        return undefined
+    if (expectedVariables !== undefined) {
+      for (const variable of expectedVariables) {
+        const deepFindResult = lodash.get(variablesObj, variable)
+        if (variablesObj !== undefined && deepFindResult !== undefined) {
+          result.set(variable, deepFindResult)
+        } else if (userInputValues !== undefined && userInputValues.has(variable)) {
+          result.set(variable, userInputValues.get(variable))
+        } else {
+          result.set(variable, undefined)
+        }
       }
-
-      current = current[segPath]
     }
 
-    return current
+    return result
   }
 
   private generateVariableObj(variablesValue: Map<string, any>): any {

--- a/packages/lg/src/commands/lg/expand.ts
+++ b/packages/lg/src/commands/lg/expand.ts
@@ -231,9 +231,9 @@ export default class ExpandCommand extends Command {
 
     if (expectedVariables !== undefined) {
       for (const variable of expectedVariables) {
-        const deepFindResult = lodash.get(variablesObj, variable)
-        if (variablesObj !== undefined && deepFindResult !== undefined) {
-          result.set(variable, deepFindResult)
+        const evalPathResult = lodash.get(variablesObj, variable)
+        if (variablesObj !== undefined && evalPathResult !== undefined) {
+          result.set(variable, evalPathResult)
         } else if (userInputValues !== undefined && userInputValues.has(variable)) {
           result.set(variable, userInputValues.get(variable))
         } else {

--- a/packages/lg/src/commands/lg/expand.ts
+++ b/packages/lg/src/commands/lg/expand.ts
@@ -13,6 +13,7 @@ import * as txtfile from 'read-text-file'
 import * as path from 'path'
 import * as fs from 'fs-extra'
 import * as readlineSync from 'readline-sync'
+import * as lodash from 'lodash'
 
 export default class ExpandCommand extends Command {
   static description = 'Expand one or all templates in .lg file(s). Expand an inline expression.'
@@ -230,8 +231,9 @@ export default class ExpandCommand extends Command {
 
     if (expectedVariables !== undefined) {
       for (const variable of expectedVariables) {
-        if (variablesObj !== undefined && variablesObj[variable] !== undefined) {
-          result.set(variable, variablesObj[variable])
+        const deepFindResult = this.deepFind(variablesObj, variable)
+        if (variablesObj !== undefined && deepFindResult !== undefined) {
+          result.set(variable, deepFindResult)
         } else if (userInputValues !== undefined && userInputValues.has(variable)) {
           result.set(variable, userInputValues.get(variable))
         } else {
@@ -243,11 +245,30 @@ export default class ExpandCommand extends Command {
     return result
   }
 
+  private deepFind(obj: any, path: string): any {
+    if (obj === undefined) {
+      return undefined
+    }
+
+    const paths = path.split('.')
+    let current = obj
+
+    for (let i = 0; i < paths.length; i++) {
+      if (current[paths[i]] === undefined) {
+        return undefined
+      }
+
+      current = current[paths[i]]
+    }
+
+    return current
+  }
+
   private generateVariableObj(variablesValue: Map<string, any>): any {
     const result: any = {}
     if (variablesValue !== undefined) {
       for (const variable of variablesValue) {
-        result[variable[0]] = variable[1]
+        lodash.set(result, variable[0], variable[1])
       }
     }
 

--- a/packages/lg/test/commands/lg/expand.test.ts
+++ b/packages/lg/test/commands/lg/expand.test.ts
@@ -93,3 +93,53 @@ describe('lg:expand lg template', async () => {
     await TestUtil.compareFiles(path.join(generatedFolderPath, outputFileName), path.join(verifiedFolderPath, '4.testinput.expand.lg'))
   })
 })
+
+describe('lg:expand lg template with scope', async () => {
+  after(async function () {
+    await fs.remove(generatedFolder)
+  })
+
+  before(async function () {
+    await fs.remove(generatedFolder)
+    await fs.mkdirp(generatedFolder)
+  })
+
+  const inputFileName = 'accessScope.lg'
+  let outputFileName = 'accessScope.expand.lg'
+
+  let testInputTemplate = 'welcomeUser'
+  // test access nested path
+  test
+  .command(['lg:expand',
+    '--in',
+    path.join(__dirname, testcaseFolderPath, inputFileName),
+    '--out',
+    generatedFolder,
+    '--template',
+    testInputTemplate,
+    '--testInput',
+    path.join(__dirname, testcaseFolderPath, 'data.json'),
+    '-r',
+    '-f'])
+  .it('', async () => {
+    await TestUtil.compareFiles(path.join(generatedFolderPath, outputFileName), path.join(verifiedFolderPath, 'accessScope.testinput.expand.lg'))
+  })
+
+  testInputTemplate = 'AddItemReadBack'
+  // test multiple nested path access
+  test
+  .command(['lg:expand',
+    '--in',
+    path.join(__dirname, testcaseFolderPath, inputFileName),
+    '--out',
+    generatedFolder,
+    '--template',
+    testInputTemplate,
+    '--testInput',
+    path.join(__dirname, testcaseFolderPath, 'data.json'),
+    '-r',
+    '-f'])
+  .it('', async () => {
+    await TestUtil.compareFiles(path.join(generatedFolderPath, outputFileName), path.join(verifiedFolderPath, 'accessScope2.testinput.expand.lg'))
+  })
+})

--- a/packages/lg/test/commands/lg/expand.test.ts
+++ b/packages/lg/test/commands/lg/expand.test.ts
@@ -142,4 +142,22 @@ describe('lg:expand lg template with scope', async () => {
   .it('', async () => {
     await TestUtil.compareFiles(path.join(generatedFolderPath, outputFileName), path.join(verifiedFolderPath, 'accessScope2.testinput.expand.lg'))
   })
+
+  testInputTemplate = 'GetIndex'
+  // test multiple nested path access
+  test
+  .command(['lg:expand',
+    '--in',
+    path.join(__dirname, testcaseFolderPath, inputFileName),
+    '--out',
+    generatedFolder,
+    '--template',
+    testInputTemplate,
+    '--testInput',
+    path.join(__dirname, testcaseFolderPath, 'data.json'),
+    '-r',
+    '-f'])
+  .it('', async () => {
+    await TestUtil.compareFiles(path.join(generatedFolderPath, outputFileName), path.join(verifiedFolderPath, 'accessScope3.testinput.expand.lg'))
+  })
 })

--- a/packages/lg/test/fixtures/testcase/accessScope.lg
+++ b/packages/lg/test/fixtures/testcase/accessScope.lg
@@ -17,3 +17,6 @@
 [Activity
     SuggestedActions = Add item | View lists | Remove item | Profile | Cancel | Help
 ]
+
+#GetIndex
+- ${user.lists.reminder[1]}

--- a/packages/lg/test/fixtures/testcase/accessScope.lg
+++ b/packages/lg/test/fixtures/testcase/accessScope.lg
@@ -1,0 +1,19 @@
+#welcomeUser(age)
+- hi ${user.name} at ${age}
+- hello ${user.name} at ${age}
+
+# AddItemReadBack
+[Activity
+    Text = ${HelpPrefix()}, I have added "**${dialog.itemTitle}**" to your **${dialog.listType}** list. You have **${count(user.lists[dialog.listType])}** items in your ${dialog.listType} list.
+    ${WelcomeActions()}
+]
+
+# HelpPrefix
+- Sure
+- You bet
+- Absolutely
+
+# WelcomeActions
+[Activity
+    SuggestedActions = Add item | View lists | Remove item | Profile | Cancel | Help
+]

--- a/packages/lg/test/fixtures/testcase/data.json
+++ b/packages/lg/test/fixtures/testcase/data.json
@@ -1,3 +1,14 @@
 {
-    "time":"morning"
+    "time":"morning",
+    "user": {
+        "name": "cosmic",
+        "lists": {
+            "reminder": ["car washing", "laundry", "cooking"]
+        }
+    },
+    "age": 18,
+    "dialog": {
+        "itemTitle": "Sunday ToDo",
+        "listType": "reminder"
+    }
 }

--- a/packages/lg/test/fixtures/verified/accessScope.testinput.expand.lg
+++ b/packages/lg/test/fixtures/verified/accessScope.testinput.expand.lg
@@ -1,0 +1,4 @@
+# welcomeUser
+- hi cosmic at 18
+- hello cosmic at 18
+

--- a/packages/lg/test/fixtures/verified/accessScope2.testinput.expand.lg
+++ b/packages/lg/test/fixtures/verified/accessScope2.testinput.expand.lg
@@ -1,0 +1,5 @@
+# AddItemReadBack
+- {"lgType":"Activity","text":"Sure, I have added "**Sunday ToDo**" to your **reminder** list. You have **3** items in your reminder list.","suggestedactions":["Add item ","View lists ","Remove item ","Profile ","Cancel ","Help"]}
+- {"lgType":"Activity","text":"You bet, I have added "**Sunday ToDo**" to your **reminder** list. You have **3** items in your reminder list.","suggestedactions":["Add item ","View lists ","Remove item ","Profile ","Cancel ","Help"]}
+- {"lgType":"Activity","text":"Absolutely, I have added "**Sunday ToDo**" to your **reminder** list. You have **3** items in your reminder list.","suggestedactions":["Add item ","View lists ","Remove item ","Profile ","Cancel ","Help"]}
+

--- a/packages/lg/test/fixtures/verified/accessScope3.testinput.expand.lg
+++ b/packages/lg/test/fixtures/verified/accessScope3.testinput.expand.lg
@@ -1,0 +1,3 @@
+# GetIndex
+- laundry
+


### PR DESCRIPTION
closes: #993 
By changing the way of read data from scope and reformation of the variables. Now LG can evaluate expressions like ${user.name} correctly.
 For example:
```
# AddItemReadBack
[Activity
    Text = ${HelpPrefix()}, I have added "**${dialog.itemTitle}**" to your **${dialog.listType}** list. You have **${count(user.lists[dialog.listType])}** items in your ${dialog.listType} list.
    ${WelcomeActions()}
]

# HelpPrefix
- Sure
- You bet
- Absolutely

# WelcomeActions
[Activity
    SuggestedActions = Add item | View lists | Remove item | Profile | Cancel | Help
]
```
```json
{
    "time":"morning",
    "user": {
        "name": "cosmic",
        "lists": {
            "reminder": ["car washing", "laundry", "cooking"]
        }
    },
    "age": 18,
    "dialog": {
        "itemTitle": "Sunday ToDo",
        "listType": "reminder"
    }
}
```
will return
```
# AddItemReadBack
- {"lgType":"Activity","text":"Sure, I have added "**Sunday ToDo**" to your **reminder** list. You have **3** items in your reminder list.","suggestedactions":["Add item ","View lists ","Remove item ","Profile ","Cancel ","Help"]}
- {"lgType":"Activity","text":"You bet, I have added "**Sunday ToDo**" to your **reminder** list. You have **3** items in your reminder list.","suggestedactions":["Add item ","View lists ","Remove item ","Profile ","Cancel ","Help"]}
- {"lgType":"Activity","text":"Absolutely, I have added "**Sunday ToDo**" to your **reminder** list. You have **3** items in your reminder list.","suggestedactions":["Add item ","View lists ","Remove item ","Profile ","Cancel ","Help"]}

```