### PR TITLE
Fix lg:translate command failure

### DIFF
--- a/packages/lg/src/commands/lg/translate.ts
+++ b/packages/lg/src/commands/lg/translate.ts
@@ -40,6 +40,7 @@ export default class TranslateCommand extends Command {
     srclang: flags.string({description: 'Source lang code. Auto detect if missing.'}),
     translate_comments: flags.boolean({description: 'Machine translate all comments found in .lg file'}),
     translate_link_text: flags.boolean({description: 'Machine translate link description in .lg file'}),
+    region: flags.string({description: 'The sub region.', required: true}),
     help: flags.help({char: 'h', description: 'lg:translate help'}),
   }
 
@@ -68,7 +69,7 @@ export default class TranslateCommand extends Command {
     for (const toLang of toLangs) {
       const tgt_lang = toLang.trim()
       if (tgt_lang !== '') {
-        const translateOption = new TranslateOption(flags.translatekey, toLang, src_lang)
+        const translateOption = new TranslateOption(flags.translatekey, toLang, src_lang, flags.region)
         const result = await this.translateLGFileToSpecificLang(filePath, translateOption, translateParts)
         const outputFilePath = this.getOutputFile(filePath, tgt_lang, flags.out)
         if (!outputFilePath) {

--- a/packages/lg/src/utils/helper.ts
+++ b/packages/lg/src/utils/helper.ts
@@ -123,6 +123,7 @@ export class Helper {
       headers: {
         'Content-Type': 'application/json',
         'Ocp-Apim-Subscription-Key': translateOption.subscriptionKey,
+        'Ocp-Apim-Subscription-Region': translateOption.region,
         'X-ClientTraceId': Helper.get_guid(),
       },
     }
@@ -181,10 +182,16 @@ export class TranslateOption {
    */
   public src_lang: string
 
-  constructor(subscriptionKey: string, to_lang: string, src_lang: string) {
+  /**
+   * the ubscription region.
+  */
+  public region: string
+
+  constructor(subscriptionKey: string, to_lang: string, src_lang: string, region: string) {
     this.subscriptionKey = subscriptionKey
     this.to_lang = to_lang
     this.src_lang = src_lang
+    this.region = region
   }
 }
 

--- a/packages/lg/test/commands/lg/translate.test.ts
+++ b/packages/lg/test/commands/lg/translate.test.ts
@@ -17,6 +17,7 @@ const  generatedFolderPath = './../../fixtures/generated'
 const  verifiedFolderPath = './../../fixtures/verified'
 const  generatedFolder = path.join(__dirname, generatedFolderPath)
 const translatekey = '11111111111111111111111111111111'
+const subsregion = 'japaneast'
 
 describe('lg:translate to fr', async () => {
   const response = require('./../../fixtures/testcase/translate-fr-1.json')
@@ -48,6 +49,8 @@ describe('lg:translate to fr', async () => {
     .command(['lg:translate',
       '--translatekey',
       translatekey,
+      '--region',
+      subsregion,
       '--in',
       path.join(__dirname, testcaseFolderPath, inputFileName),
       '--tgtlang',
@@ -90,6 +93,8 @@ describe('lg:translate to zh-cn', async () => {
   .command(['lg:translate',
     '--translatekey',
     translatekey,
+    '--region',
+    subsregion,
     '--in',
     path.join(__dirname, testcaseFolderPath, inputFileName),
     '--tgtlang',
@@ -131,6 +136,8 @@ describe('lg:translate to zh-cn with comments', async () => {
   .command(['lg:translate',
     '--translatekey',
     translatekey,
+    '--region',
+    subsregion,
     '--in',
     path.join(__dirname, testcaseFolderPath, inputFileName),
     '--tgtlang',
@@ -173,6 +180,8 @@ describe('lg:translate to zh-cn with translate_link_text', async () => {
   .command(['lg:translate',
     '--translatekey',
     translatekey,
+    '--region',
+    subsregion,
     '--in',
     path.join(__dirname, testcaseFolderPath, inputFileName),
     '--tgtlang',


### PR DESCRIPTION
Due to the change of Azure Text Translate API ([API Ref)](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/reference/v3-0-reference). 
Now it requires a Ocp-Apim-Subscription-Region in the headers.
In this PR, a new flag "region" is added. The value of region is the location in the azure keys and endpoints page, see the picture below
![image](https://user-images.githubusercontent.com/17074777/94524614-6e468580-0265-11eb-8a12-4ecb484d1f1d.png)

Now the command should be called like:
bf lg:translate -i inputFile --srclang=src-lang --tgtlang=tgt-lang --translatekey=subscription-key --region=subscription-region
