### PR TITLE
Make prepack scripts more consistent

### DIFF
--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -15,8 +15,8 @@
   "main": "lib/index.js",
   "repository": "https://github.com/microsoft/botframework-cli",
   "scripts": {
-    "prepack": "",
     "postpack": "",
+    "prepack": "npm run clean && npm run build",
     "posttest": "",
     "build": "tsc -b",
     "clean": "rimraf ./.nyc_output ./lib ./package-lock.json ./tsconfig.tsbuildinfo",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -26,6 +26,7 @@
   "repository": "https://github.com/microsoft/botframework-cli/tree/master/packages/config",
   "scripts": {
     "postpack": "rimraf oclif.manifest.json",
+    "prepack": "npm run clean && npm run build && npm run doc:readme",
     "posttest": "tslint -p test -t stylish",
     "build": "tsc -b",
     "clean": "rimraf ./.nyc_output ./lib ./package-lock.json ./tsconfig.tsbuildinfo",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -27,6 +27,7 @@
   "repository": "https://github.com/microsoft/botframework-cli/tree/master/packages/dialog",
   "scripts": {
     "postpack": "rimraf oclif.manifest.json",
+    "prepack": "npm run clean && npm run build && npm run doc:readme",
     "posttest": "tslint -p test -t stylish",
     "build": "tsc -b",
     "clean": "rimraf ./.nyc_output ./lib ./package-lock.json ./tsconfig.tsbuildinfo",

--- a/packages/lg/package.json
+++ b/packages/lg/package.json
@@ -63,7 +63,7 @@
   "scripts": {
     "unittest": "rush test -t @microsoft/bf-lg-cli",
     "posttest": "eslint . --ext .ts --config .eslintrc",
-    "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
+    "prepack": "npm run clean && npm run build && npm run doc:readme",
     "postpack": "rimraf oclif.manifest.json",
     "build": "tsc -b",
     "clean": "rimraf ./.nyc_output ./lib ./package-lock.json ./tsconfig.tsbuildinfo",

--- a/packages/lu/package.json
+++ b/packages/lu/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "repository": "https://github.com/microsoft/botframework-cli/tree/master/packages/lu",
   "scripts": {
-    "postpack": "",
+    "prepack": "npm run clean && npm run build",
     "posttest": "tslint -p test -t stylish",
     "build": "tsc -b",
     "clean": "rimraf ./.nyc_output ./lib ./package-lock.json ./tsconfig.tsbuildinfo",

--- a/packages/luis/package.json
+++ b/packages/luis/package.json
@@ -26,6 +26,7 @@
   "repository": "https://github.com/microsoft/botframework-cli/tree/master/packages/luis",
   "scripts": {
     "postpack": "rimraf oclif.manifest.json",
+    "prepack": "npm run clean && npm run build && npm run doc:readme",
     "posttest": "tslint -p test -t stylish",
     "build": "tsc -b",
     "clean": "rimraf ./.nyc_output ./lib ./package-lock.json ./tsconfig.tsbuildinfo",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -53,7 +53,7 @@
   "scripts": {
     "postpack": "rimraf oclif.manifest.json",
     "posttest": "eslint . --ext .ts --config .eslintrc",
-    "prepack": "rimraf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
+    "prepack": "npm run clean && npm run build && oclif-dev manifest && oclif-dev readme",
     "build": "tsc -b",
     "clean": "rimraf ./.nyc_output ./lib ./package-lock.json ./tsconfig.tsbuildinfo",
     "test": "mocha",

--- a/packages/qnamaker/package.json
+++ b/packages/qnamaker/package.json
@@ -27,6 +27,7 @@
   "repository": "https://github.com/microsoft/botframework-cli/tree/master/packages/qnamaker",
   "scripts": {
     "postpack": "rimraf oclif.manifest.json",
+    "prepack": "npm run clean && npm run build && npm run doc:readme",
     "posttest": "",
     "build": "tsc -b",
     "clean": "rimraf ./.nyc_output ./lib ./package-lock.json ./tsconfig.tsbuildinfo",


### PR DESCRIPTION
Somewhere between Typescript 3.5.x and 4.0.x, the behavior of the
compiler changed in a subtle way when using the `-b` flag.

In 3.5.x, if `outDir` was removed after a build but
`tsconfig.tsbuildinfo` remained, running `tsc -b` again would fully
reproduce `outDir`. Technically, this is incorrect behavior because the
compiler state should be fully derived from the `include`/`rootDir`
files and the `tsconfig.tsbuildinfo` file.

In 4.0.x, `outDir` is not reproduced because the compiler properly loads
its state from `tsconfig.tsbuildinfo` and does not perform any
recompilation.

Why did this affect `packages/plugins`? The `prepack` script runs
`rimraf lib && tsc -b`. In the 3.5.x compiler version, this would
reproduce the `lib` directory. In 4.0.x, it would not. This, the
packaged set of files does not include the `lib` directory.

This commit makes `prepack` scripts more consistent by using `npm run
clean` and `npm run build`. The `clean` scripts already properly clean
up both `outDir` and the `tsconfig.tsbuildinfo` file.