### PR TITLE
remove unused dup hash in luis/qnamaker build when reconstructing files

### DIFF
--- a/packages/lu/src/parser/luis/luConverter.js
+++ b/packages/lu/src/parser/luis/luConverter.js
@@ -66,7 +66,7 @@ const parseIntentsToLu = function(luisObj, luisJSON){
         if (luisJSON.test === true) {
             fileContent += `> Utterance passed in this intent: ${intent.intent.passNumber}/${intent.intent.count}` + NEWLINE
         }
-        fileContent += '## ' + intent.intent.name + NEWLINE;
+        fileContent += '# ' + intent.intent.name + NEWLINE;
         fileContent += parseUtterancesToLu(intent.utterances, luisJSON)
         fileContent += NEWLINE + NEWLINE;
         if (intent.intent.features) {

--- a/packages/lu/src/parser/qna/qnamaker/qnaConverter.js
+++ b/packages/lu/src/parser/qna/qnamaker/qnaConverter.js
@@ -29,7 +29,7 @@ const qnaToLuContent = function(qnaJSON){
     root.forEach(function(qnaItem) {
         fileContent += '> !# @qna.pair.source = ' + qnaItem.source + NEWLINE + NEWLINE;
         fileContent += qnaItem.id.toString() !== "0" ? `<a id = "${qnaItem.id}"></a>` + NEWLINE + NEWLINE : '';
-        fileContent += '## ? ' + qnaItem.questions[0] + NEWLINE;
+        fileContent += '# ? ' + qnaItem.questions[0] + NEWLINE;
         qnaItem.questions.splice(0,1);
         qnaItem.questions.forEach(function(question) {
             fileContent += '- ' + question + NEWLINE;

--- a/packages/lu/test/commands/luis/convert.test.js
+++ b/packages/lu/test/commands/luis/convert.test.js
@@ -113,7 +113,7 @@ describe('luis:convert', () => {
 
 > # Intent definitions
 
-## test
+# test
 - this is a {@test=one}
 
 

--- a/packages/lu/test/fixtures/verified/Child_Entity_With_Spaces.lu
+++ b/packages/lu/test/fixtures/verified/Child_Entity_With_Spaces.lu
@@ -10,7 +10,7 @@
 
 > # Intent definitions
 
-## CancelOrder
+# CancelOrder
 - cancel
 - cancel it i dont want it anymore
 - cancel it please
@@ -25,7 +25,7 @@
 
 @ intent CancelOrder usesFeature GreetingDescriptor
 
-## Confirmation
+# Confirmation
 - awesome
 - confirm
 - confirming
@@ -45,7 +45,7 @@
 
 @ intent Confirmation usesFeature GreetingDescriptor
 
-## Delivery
+# Delivery
 - {@Address={@Building Number=17}, {@Street=orouba street}, {@District=nasr city}, {@City=cairo}}
 - address is {@Address={@Building Number=675}, {@Street=gamal abd el nasser street}, {@City=giza}}
 - deliver it at {@Address={@Building Number=13}, {@Street=giza square}}
@@ -55,7 +55,7 @@
 
 @ intent Delivery usesFeature GreetingDescriptor
 
-## Greetings
+# Greetings
 - hello
 - hey
 - hey again
@@ -68,7 +68,7 @@
 
 @ intent Greetings usesFeature GreetingDescriptor
 
-## ModifyOrder
+# ModifyOrder
 - {@Order={@FullPizzaWithModifiers=a cheese pizza {@Size=medium} {@ToppingModifiers={@Modifier=with some} {@Topping=pineapple} and {@Topping=chicken}}}}
 - {@Order=add {@FullPizzaWithModifiers={@Quantity=5} {@Size=party size} {@PizzaType=marinera pizzas}} and i will pick them up at 6pm}
 - can i get {@Order={@FullPizzaWithModifiers={@Quantity=3} {@PizzaType=pepperoni pizzas}} and {@FullPizzaWithModifiers=a {@PizzaType=four cheese pizza}} {@SideOrder=with {@SideProduct=a large house salad} and {@SideProduct=a large fries}}}
@@ -166,7 +166,7 @@
 
 @ intent ModifyOrder usesFeatures ToppingDescriptor,SizeDescriptor,QuantityDescriptor,ModifierDescriptor,ScopeDescriptor,CrustDescriptor,GreetingDescriptor
 
-## None
+# None
 - deliver it at {@Address}
 - my address is {@Address}
 - address is {@Address}

--- a/packages/lu/test/fixtures/verified/LUISAppWithPAInherits.lu
+++ b/packages/lu/test/fixtures/verified/LUISAppWithPAInherits.lu
@@ -9,7 +9,7 @@
 
 > # Intent definitions
 
-## None
+# None
 - can you delete {@ToDo.TaskContent=abc} item
 - can you delete {@ToDo.TaskContent=todo1}
 - cancel {@ToDo.TaskContent=apples} from shopping list
@@ -95,7 +95,7 @@
 
 > !# @intent.inherits = name : ToDo.AddToDo; domain_name : ToDo; model_name : AddToDo
 
-## ToDo.AddToDo
+# ToDo.AddToDo
 - add a few items to the grocery list
 - add a grocery item to {@ToDo.TaskContent=buy fish}
 - add a grocery item to {@ToDo.TaskContent=buy fruit and vegetables}

--- a/packages/lu/test/fixtures/verified/allGen.lu
+++ b/packages/lu/test/fixtures/verified/allGen.lu
@@ -8,21 +8,21 @@
 
 > # Intent definitions
 
-## Greeting
+# Greeting
 - Hi
 - Hello
 - Good morning
 - Good evening
 
 
-## Help
+# Help
 - help
 - I need help
 - please help
 - can you help
 
 
-## AskForUserName
+# AskForUserName
 - {@userName=vishwac}
 - I'm {@userName=vishwac}
 - call me {@userName=vishwac}
@@ -31,28 +31,28 @@
 - you can call me {@userName=vishwac}
 
 
-## CreateAlarm
+# CreateAlarm
 - create an alarm
 - create an alarm for 7AM
 - set an alarm for 7AM next thursday
 
 
-## DeleteAlarm
+# DeleteAlarm
 - delete the {@alarmTime} alarm
 - remove the {@alarmTime} alarm
 
 
-## CommunicationPreference
+# CommunicationPreference
 - set phone call as my communication preference
 - I prefer to receive text message
 
 
-## None
+# None
 - who is your ceo?
 - santa wants a blue ribbon
 
 
-## Buy chocolate
+# Buy chocolate
 - can I get some m&m
 - I want some twix
 - I would like to buy some kit kat

--- a/packages/lu/test/fixtures/verified/emptyIntentDescriptors.lu
+++ b/packages/lu/test/fixtures/verified/emptyIntentDescriptors.lu
@@ -10,10 +10,10 @@
 
 > # Intent definitions
 
-## None
+# None
 
 
-## test
+# test
 - one
 - two
 

--- a/packages/lu/test/fixtures/verified/luis_sorted.lu
+++ b/packages/lu/test/fixtures/verified/luis_sorted.lu
@@ -8,7 +8,7 @@
 
 > # Intent definitions
 
-## AskForUserName
+# AskForUserName
 - {@userName=vishwac}
 - I'm {@userName=vishwac}
 - call me {@userName=vishwac}
@@ -17,53 +17,53 @@
 - you can call me {@userName=vishwac}
 
 
-## Buy chocolate
+# Buy chocolate
 - can I get some m&m
 - I want some twix
 - I would like to buy some kit kat
 
 
-## CommunicationPreference
+# CommunicationPreference
 - set phone call as my communication preference
 - I prefer to receive text message
 
 
-## CreateAlarm
+# CreateAlarm
 - create an alarm
 - create an alarm for 7AM
 - set an alarm for 7AM next thursday
 
 
-## DeleteAlarm
+# DeleteAlarm
 - delete the {alarmTime} alarm
 - remove the {@alarmTime} alarm
 
 
-## Greeting
+# Greeting
 - Hi
 - Hello
 - Good morning
 - Good evening
 
 
-## Help
+# Help
 - help
 - I need help
 - please help
 - can you help
 
 
-## None
+# None
 - who is your ceo?
 - santa wants a blue ribbon
 
 
-## setThermostat
+# setThermostat
 - Please set {@deviceTemperature=thermostat to 72}
 - Set {@deviceTemperature={@customDevice=owen} to 72}
 
 
-## testIntent
+# testIntent
 - I need a flight from {@fromDate=tomorrow} and returning on {@toDate=next thursday}
 
 

--- a/packages/lu/test/fixtures/verified/modelAsFeatureGen.lu
+++ b/packages/lu/test/fixtures/verified/modelAsFeatureGen.lu
@@ -7,19 +7,19 @@
 
 > # Intent definitions
 
-## test1
+# test1
 - one
 
 
 @ intent test1 usesFeature test3
 
-## test2
+# test2
 - two
 
 
 @ intent test2 usesFeature simple1
 
-## test3
+# test3
 - three
 
 

--- a/packages/lu/test/fixtures/verified/modelInfo.lu
+++ b/packages/lu/test/fixtures/verified/modelInfo.lu
@@ -8,7 +8,7 @@
 
 > # Intent definitions
 
-## AskForUserName
+# AskForUserName
 - {userName=vishwac}
 - I'm {userName=vishwac}
 - call me {userName=vishwac}
@@ -17,53 +17,53 @@
 - you can call me {userName=vishwac}
 
 
-## Buy chocolate
+# Buy chocolate
 - I would like to buy some kit kat
 - I want some twix
 - can I get some m&m
 
 
-## CommunicationPreference
+# CommunicationPreference
 - set phone call as my communication preference
 - I prefer to receive text message
 
 
-## CreateAlarm
+# CreateAlarm
 - create an alarm for 7AM
 - create an alarm
 - set an alarm for 7AM next thursday
 
 
-## DeleteAlarm
+# DeleteAlarm
 - delete the {alarmTime} alarm
 - remove the {alarmTime} alarm
 
 
-## Greeting
+# Greeting
 - Hi
 - Good morning
 - Good evening
 - Hello
 
 
-## Help
+# Help
 - can you help
 - please help
 - I need help
 - help
 
 
-## None
+# None
 - who is your ceo?
 - santa wants a blue ribbon
 
 
-## setThermostat
+# setThermostat
 - Please set {deviceTemperature=thermostat to 72}
 - Set {deviceTemperature={customDevice=owen} to 72}
 
 
-## testIntent
+# testIntent
 - I need a flight from {datetimeV2:fromDate=tomorrow} and returning on {datetimeV2:toDate=next thursday}
 
 

--- a/packages/lu/test/fixtures/verified/nDepthEntityInUtterance.lu
+++ b/packages/lu/test/fixtures/verified/nDepthEntityInUtterance.lu
@@ -7,7 +7,7 @@
 
 > # Intent definitions
 
-## None
+# None
 - {@nDepth=i have {@nDepth_child1=17 years old}}
 - {@nDepth=i have {@nDepth_child1=18 years old}}
 - {@nDepth=i have {@nDepth_child1=19 years old}}

--- a/packages/lu/test/fixtures/verified/newEntityWithFeatures.lu
+++ b/packages/lu/test/fixtures/verified/newEntityWithFeatures.lu
@@ -9,12 +9,12 @@
 
 > # Intent definitions
 
-## Greeting
+# Greeting
 - Hi
 - Hello
 
 
-## GetUserProfile
+# GetUserProfile
 - I'm {@userProfile={@userAge=36}} years old
 - My age is {@userProfile={@userAge=36}}
 - My name is {@userProfile={@userName={@firstName=vishwac}}}

--- a/packages/lu/test/fixtures/verified/plFeatures.lu
+++ b/packages/lu/test/fixtures/verified/plFeatures.lu
@@ -9,10 +9,10 @@
 
 > # Intent definitions
 
-## None
+# None
 
 
-## intent1
+# intent1
 
 
 @ intent intent1 usesFeature phraselist1

--- a/packages/lu/test/fixtures/verified/sorted.lu
+++ b/packages/lu/test/fixtures/verified/sorted.lu
@@ -1,7 +1,7 @@
 
 > # Intent definitions
 
-## AskForUserName
+# AskForUserName
 - {userName=vishwac}
 - I'm {userName=vishwac}
 - call me {userName=vishwac}
@@ -10,53 +10,53 @@
 - you can call me {userName=vishwac}
 
 
-## Buy chocolate
+# Buy chocolate
 - I would like to buy some kit kat
 - I want some twix
 - can I get some m&m
 
 
-## CommunicationPreference
+# CommunicationPreference
 - set phone call as my communication preference
 - I prefer to receive text message
 
 
-## CreateAlarm
+# CreateAlarm
 - create an alarm for 7AM
 - create an alarm
 - set an alarm for 7AM next thursday
 
 
-## DeleteAlarm
+# DeleteAlarm
 - delete the {alarmTime} alarm
 - remove the {alarmTime} alarm
 
 
-## Greeting
+# Greeting
 - Hi
 - Good morning
 - Good evening
 - Hello
 
 
-## Help
+# Help
 - can you help
 - please help
 - I need help
 - help
 
 
-## None
+# None
 - who is your ceo?
 - santa wants a blue ribbon
 
 
-## setThermostat
+# setThermostat
 - Please set {deviceTemperature=thermostat to 72}
 - Set {deviceTemperature={customDevice=owen} to 72}
 
 
-## testIntent
+# testIntent
 - I need a flight from {datetimeV2:fromDate=tomorrow} and returning on {datetimeV2:toDate=next thursday}
 
 
@@ -129,7 +129,7 @@ $units:[temperature]
 > # QnA pairs
 
 > Source: custom editorial
-## ? get me your ceo info
+# ? get me your ceo info
 - Who is your ceo?
 
 ```markdown
@@ -137,7 +137,7 @@ Vishwac
 ```
 
 > Source: custom editorial
-## ? How do I change the default message
+# ? How do I change the default message
 
 ```markdown
 You can change the default message if you use the QnAMakerDialog.
@@ -145,7 +145,7 @@ See [this link](https://docs.botframework.com/en-us/azure-bot-service/templates/
 ```
 
 > Source: custom editorial
-## ? How do I programmatically update my KB?
+# ? How do I programmatically update my KB?
 
 ```markdown
 You can use our REST apis to manage your KB.
@@ -153,7 +153,7 @@ You can use our REST apis to manage your KB.
 ```
 
 > Source: custom editorial
-## ? I need coffee
+# ? I need coffee
 - Where can I get coffee?
 
 
@@ -165,7 +165,7 @@ You can get coffee in our Seattle store at 1 pike place, Seattle, WA
 ```
 
 > Source: custom editorial
-## ? I need coffee
+# ? I need coffee
 - Where can I get coffee?
 
 
@@ -177,7 +177,7 @@ You can get coffee in our Portland store at 52 marine drive, Portland, OR
 ```
 
 > Source: custom editorial
-## ? ludown cli
+# ? ludown cli
 - What is Ludown?
 - where can i get more information about ludown cli?
 

--- a/packages/lu/test/fixtures/verified/test269-d.lu
+++ b/packages/lu/test/fixtures/verified/test269-d.lu
@@ -8,10 +8,10 @@
 
 > # Intent definitions
 
-## None
+# None
 
 
-## TestIntent
+# TestIntent
 - this is a {@EntityOne=one} and a {@EntityTwo=two} and a {@EntityOne=one} again
 
 

--- a/packages/lu/test/fixtures/verified/v7UpgradeTest.lu
+++ b/packages/lu/test/fixtures/verified/v7UpgradeTest.lu
@@ -7,7 +7,7 @@
 
 > # Intent definitions
 
-## test
+# test
 - my initials are {@userName={@middleName=VSK}}
 - i'm {@userProfile={@userAge=32} years old}
 - my name is {@userName={@firstName=vishwac sena} {@lastName=kannan}}

--- a/packages/lu/test/fixtures/verified/v7app.lu
+++ b/packages/lu/test/fixtures/verified/v7app.lu
@@ -11,7 +11,7 @@
 
 > # Intent definitions
 
-## None
+# None
 - my alias is {@P1={@CC1={@C1=omr}} {@C2={@CC2=sobeh}}}
 - my alias is {@C3=walid}
 - my name is {@P1={@CC1={@C1=omar}} {@C2={@CC2=sobeih}}}

--- a/packages/lu/test/parser/lubuild/lubuild.test.js
+++ b/packages/lu/test/parser/lubuild/lubuild.test.js
@@ -251,7 +251,7 @@ describe('builder: loadContents function can resolve import files with customize
 
     assert.equal(result.length, 1)
     assert.isTrue(result[0].content.includes(
-      `help${NEWLINE}- could you help${NEWLINE}- can you help me${NEWLINE}${NEWLINE}${NEWLINE}## cancel${NEWLINE}- cancel that${NEWLINE}- cancel the task${NEWLINE}- stop that${NEWLINE}${NEWLINE}${NEWLINE}## welcome${NEWLINE}- welcome here`
+      `help${NEWLINE}- could you help${NEWLINE}- can you help me${NEWLINE}${NEWLINE}${NEWLINE}# cancel${NEWLINE}- cancel that${NEWLINE}- cancel the task${NEWLINE}- stop that${NEWLINE}${NEWLINE}${NEWLINE}# welcome${NEWLINE}- welcome here`
     ))
   })
 })
@@ -271,7 +271,7 @@ describe('builder: loadContents function can resolve import files with new impor
 
     assert.equal(result.length, 1)
     assert.isTrue(result[0].content.includes(
-      `## cancel${NEWLINE}- stop that${NEWLINE}- cancel the task${NEWLINE}${NEWLINE}${NEWLINE}## greeting${NEWLINE}- hello`
+      `# cancel${NEWLINE}- stop that${NEWLINE}- cancel the task${NEWLINE}${NEWLINE}${NEWLINE}# greeting${NEWLINE}- hello`
     ))
   })
 })

--- a/packages/lu/test/parser/qnabuild/qnabuild.test.js
+++ b/packages/lu/test/parser/qnabuild/qnabuild.test.js
@@ -64,7 +64,7 @@ describe('builder: importUrlOrFileReference function return lu content from file
     assert.equal(luContent, `> # QnA pairs${NEWLINE}${NEWLINE}` +
                             `> !# @qna.pair.source = SurfaceManual.pdf${NEWLINE}${NEWLINE}` +
                             `<a id = "1"></a>${NEWLINE}${NEWLINE}` +
-                            `## ? how many sandwich types do you have${NEWLINE}${NEWLINE}` +
+                            `# ? how many sandwich types do you have${NEWLINE}${NEWLINE}` +
                             `\`\`\`markdown${NEWLINE}` +
                             `25 types${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}`)
   })
@@ -128,7 +128,7 @@ describe('builder: importUrlOrFileReference function return lu content from file
     assert.equal(luContent, `> # QnA pairs${NEWLINE}${NEWLINE}` +
       `> !# @qna.pair.source = SurfaceManual.pdf${NEWLINE}${NEWLINE}` +
       `<a id = "1"></a>${NEWLINE}${NEWLINE}` +
-      `## ? how many sandwich types do you have${NEWLINE}${NEWLINE}` +
+      `# ? how many sandwich types do you have${NEWLINE}${NEWLINE}` +
       `\`\`\`markdown${NEWLINE}` +
       `25 types${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}`)
   })
@@ -187,7 +187,7 @@ describe('builder: importUrlOrFileReference function return lu content from url 
     assert.equal(luContent, `> # QnA pairs${NEWLINE}${NEWLINE}` +
                             `> !# @qna.pair.source = faqs${NEWLINE}${NEWLINE}` +
                             `<a id = "1"></a>${NEWLINE}${NEWLINE}` +
-                            `## ? how many sandwich types do you have${NEWLINE}${NEWLINE}` +
+                            `# ? how many sandwich types do you have${NEWLINE}${NEWLINE}` +
                             `\`\`\`markdown${NEWLINE}` +
                             `25 types${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}`)
   })
@@ -250,7 +250,7 @@ describe('builder: importUrlOrFileReference function return lu content from url 
     assert.equal(luContent, `> # QnA pairs${NEWLINE}${NEWLINE}` +
       `> !# @qna.pair.source = faqs${NEWLINE}${NEWLINE}` +
       `<a id = "1"></a>${NEWLINE}${NEWLINE}` +
-      `## ? how many sandwich types do you have${NEWLINE}${NEWLINE}` +
+      `# ? how many sandwich types do you have${NEWLINE}${NEWLINE}` +
       `\`\`\`markdown${NEWLINE}` +
       `25 types${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}`)
   })
@@ -285,7 +285,7 @@ describe('builder: loadContents function can resolve import files with customize
 
     assert.equal(result.length, 1)
     assert.isTrue(result[0].content.includes(
-      `!# @qna.pair.source = custom editorial${NEWLINE}${NEWLINE}## ? help${NEWLINE}- could you help${NEWLINE}${NEWLINE}\`\`\`markdown${NEWLINE}help answer${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}> !# @qna.pair.source = custom editorial${NEWLINE}${NEWLINE}## ? welcome${NEWLINE}${NEWLINE}\`\`\`markdown${NEWLINE}welcome here${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}> !# @qna.pair.source = custom editorial${NEWLINE}${NEWLINE}## ? cancel${NEWLINE}${NEWLINE}\`\`\`markdown${NEWLINE}cancel the task${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}> !# @qna.pair.source = custom editorial${NEWLINE}${NEWLINE}## ? stop${NEWLINE}${NEWLINE}\`\`\`markdown${NEWLINE}stop that${NEWLINE}\`\`\``))
+      `!# @qna.pair.source = custom editorial${NEWLINE}${NEWLINE}# ? help${NEWLINE}- could you help${NEWLINE}${NEWLINE}\`\`\`markdown${NEWLINE}help answer${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}> !# @qna.pair.source = custom editorial${NEWLINE}${NEWLINE}# ? welcome${NEWLINE}${NEWLINE}\`\`\`markdown${NEWLINE}welcome here${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}> !# @qna.pair.source = custom editorial${NEWLINE}${NEWLINE}# ? cancel${NEWLINE}${NEWLINE}\`\`\`markdown${NEWLINE}cancel the task${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}> !# @qna.pair.source = custom editorial${NEWLINE}${NEWLINE}# ? stop${NEWLINE}${NEWLINE}\`\`\`markdown${NEWLINE}stop that${NEWLINE}\`\`\``))
   })
 })
 

--- a/packages/luis/test/fixtures/qna.lu
+++ b/packages/luis/test/fixtures/qna.lu
@@ -1,17 +1,17 @@
 > # Intents
 
-## Greeting
+# Greeting
 - Hi
 - Hello
 - Good morning
 - Good evening
 
-## Help
+# Help
 - help
 - I need help
 - please help
 
-## AskForUserName
+# AskForUserName
 - {userName=vishwac}
 - I'm {userName=vishwac}
 - call me {userName=vishwac}
@@ -19,22 +19,22 @@
 - {userName=vishwac} is my name
 - you can call me {userName=vishwac}
 
-## CreateAlarm
+# CreateAlarm
 - create an alarm
 - create an alarm for 7AM
 - set an alarm for 7AM next thursday
 
-## DeleteAlarm
+# DeleteAlarm
 - delete alarm
 - delete the {alarmTime} alarm
 
 
 
-## CommunicationPreference
+# CommunicationPreference
 - set call as my communication preference
 - I prefer to receive text messages
 
-## Help
+# Help
 - can you help
 
 
@@ -88,19 +88,19 @@ $ChocolateType:phraseList
 > # QnA Definitions
 > This is a QnA definition. Follows # ? Question: \<list of questions\> \```markdown \<Answer> ``` format
 
-### ? How can I change the default message from QnA Maker?
+# ? How can I change the default message from QnA Maker?
 ```markdown
 You can change the default message if you use the QnAMakerDialog. 
 See [this link](https://docs.botframework.com/en-us/azure-bot-service/templates/qnamaker/#navtitle) for details. 
 ```
 
-### ?How do I programmatically update my KB?
+# ?How do I programmatically update my KB?
 ```markdown
 You can use our REST apis to manage your KB. 
 \#1. See here for details: https://westus.dev.cognitive.microsoft.com/docs/services/58994a073d9e04097c7ba6fe/operations/58994a073d9e041ad42d9baa
 ```
 
-### ? Who is your ceo?
+# ? Who is your ceo?
 - get me your ceo info
 ```markdown
 Vishwac

--- a/packages/luis/test/fixtures/testcases/lutest/output/AllEntity.lu
+++ b/packages/luis/test/fixtures/testcases/lutest/output/AllEntity.lu
@@ -10,7 +10,7 @@
 > # Intent definitions
 
 > Utterance passed in this intent: 3/3
-## AcceptEventEntry
+# AcceptEventEntry
 > PASS. Predicted intent: AcceptEventEntry(0.948831439)
 > PASS. Predicted entities: accept all meetings for {@Subject=christmas party} {@FromDate=next week}.
 - accept all meetings for {@Subject=christmas party} {@FromDate=next week}.
@@ -24,7 +24,7 @@
 
 
 > Utterance passed in this intent: 5/5
-## CreateCalendarEntry
+# CreateCalendarEntry
 > PASS. Predicted intent: CreateCalendarEntry(0.999999762)
 > PASS. Predicted entities: book a meeting with huanx@abc.com
 - book a meeting with huanx@abc.com

--- a/packages/luis/test/fixtures/testcases/lutest/output/CompositeEntity.lu
+++ b/packages/luis/test/fixtures/testcases/lutest/output/CompositeEntity.lu
@@ -10,7 +10,7 @@
 > # Intent definitions
 
 > Utterance passed in this intent: 2/2
-## AcceptEventEntry
+# AcceptEventEntry
 > PASS. Predicted intent: AcceptEventEntry(0.9554455)
 > PASS. Predicted entities: accept my meeting at {@FromDateTime={@FromDate=tomorrow} {@FromTime=10am}}
 - accept my meeting at {@FromDateTime={@FromDate=tomorrow} {@FromTime=10am}}

--- a/packages/luis/test/fixtures/testcases/lutest/output/EntityRole.lu
+++ b/packages/luis/test/fixtures/testcases/lutest/output/EntityRole.lu
@@ -10,7 +10,7 @@
 > # Intent definitions
 
 > Utterance passed in this intent: 4/4
-## AcceptEventEntry
+# AcceptEventEntry
 > PASS. Predicted intent: AcceptEventEntry(0.9898117)
 > PASS. Predicted entities: accept {@Meals=dinner}
 - accept {@Meals=dinner}
@@ -26,7 +26,7 @@
 
 
 > Utterance passed in this intent: 1/1
-## CreateCalendarEntry
+# CreateCalendarEntry
 > PASS. Predicted intent: CreateCalendarEntry(0.99999994)
 > PASS. Predicted entities: create a meeting with {@OutLook=tom34@outlook.com}
 - create a meeting with {@OutLook=tom34@outlook.com}

--- a/packages/luis/test/fixtures/testcases/lutest/output/HierarchicalEntity.lu
+++ b/packages/luis/test/fixtures/testcases/lutest/output/HierarchicalEntity.lu
@@ -11,7 +11,7 @@
 > # Intent definitions
 
 > Utterance passed in this intent: 3/3
-## ModifyOrder
+# ModifyOrder
 > PASS. Predicted intent: ModifyOrder(0.99580574)
 > PASS. Predicted entities: {@Order={@FullPizzaWithModifiers=a cheese pizza {@Size=medium} {@ToppingModifiers={@Modifier=with some} {@Topping=pineapple} and {@Topping=chicken}}}}
 - {@Order={@FullPizzaWithModifiers=a cheese pizza {@Size=medium} {@ToppingModifiers={@Modifier=with some} {@Topping=pineapple} and {@Topping=chicken}}}}

--- a/packages/luis/test/fixtures/testcases/lutest/output/SimpleEntity.lu
+++ b/packages/luis/test/fixtures/testcases/lutest/output/SimpleEntity.lu
@@ -10,7 +10,7 @@
 > # Intent definitions
 
 > Utterance passed in this intent: 2/2
-## AcceptEventEntry
+# AcceptEventEntry
 > PASS. Predicted intent: AcceptEventEntry(0.9916137)
 > PASS. Predicted entities: accept the event
 - accept the event

--- a/packages/luis/test/fixtures/testcases/lutest/output/TestFile.lu
+++ b/packages/luis/test/fixtures/testcases/lutest/output/TestFile.lu
@@ -10,7 +10,7 @@
 > # Intent definitions
 
 > Utterance passed in this intent: 6/6
-## AcceptEventEntry
+# AcceptEventEntry
 > PASS. Predicted intent: AcceptEventEntry(0.948831439)
 > PASS. Predicted entities: accept all meetings for {@Subject=christmas party} {@FromDate=next week}.
 - accept all meetings for {@Subject=christmas party} {@FromDate=next week}.
@@ -33,7 +33,7 @@
 
 
 > Utterance passed in this intent: 6/6
-## CreateCalendarEntry
+# CreateCalendarEntry
 > PASS. Predicted intent: CreateCalendarEntry(0.999999762)
 > PASS. Predicted entities: book a meeting with huanx@abc.com
 - book a meeting with huanx@abc.com
@@ -55,7 +55,7 @@
 
 
 > Utterance passed in this intent: 2/2
-## FindCalendarEntry
+# FindCalendarEntry
 > PASS. Predicted intent: FindCalendarEntry(0.951522648)
 > PASS. Predicted entities: find a meeting subject {@Subject=daily meeting}
 - find a meeting subject {@Subject=daily meeting}
@@ -65,7 +65,7 @@
 
 
 > Utterance passed in this intent: 3/3
-## None
+# None
 > PASS. Predicted intent: None(0.962541759)
 > PASS. Predicted entities: 1
 - 1

--- a/packages/luis/test/fixtures/testcases/lutest/output/TestFile1.lu
+++ b/packages/luis/test/fixtures/testcases/lutest/output/TestFile1.lu
@@ -10,7 +10,7 @@
 > # Intent definitions
 
 > Utterance passed in this intent: 4/4
-## AcceptEventEntry
+# AcceptEventEntry
 > PASS. Predicted intent: AcceptEventEntry(0.948831439)
 > PASS. Predicted entities: accept all meetings for {@Subject=christmas party} {@FromDate=next week}.
 - accept all meetings for {@Subject=christmas party} {@FromDate=next week}.
@@ -27,7 +27,7 @@
 
 
 > Utterance passed in this intent: 5/7
-## CreateCalendarEntry
+# CreateCalendarEntry
 > FAIL. Predicted intent: AcceptEventEntry(0.959497333)
 > PASS. Predicted entities: accept my meeting with {@Female=lucy}
 - accept my meeting with {@Female=lucy}
@@ -52,7 +52,7 @@
 
 
 > Utterance passed in this intent: 2/3
-## FindCalendarEntry
+# FindCalendarEntry
 > FAIL. Predicted intent: CreateCalendarEntry(0.972337842)
 > PASS. Predicted entities: create appointment for {@Duration=30 minutes}
 - create appointment for {@Duration=30 minutes}
@@ -65,7 +65,7 @@
 
 
 > Utterance passed in this intent: 3/3
-## None
+# None
 > PASS. Predicted intent: None(0.962541759)
 > PASS. Predicted entities: 1
 - 1

--- a/packages/luis/test/fixtures/testcases/lutest/output/TestFile2.lu
+++ b/packages/luis/test/fixtures/testcases/lutest/output/TestFile2.lu
@@ -10,7 +10,7 @@
 > # Intent definitions
 
 > Utterance passed in this intent: 6/6
-## AcceptEventEntry
+# AcceptEventEntry
 > PASS. Predicted intent: AcceptEventEntry(0.948831439)
 > PASS. Predicted entities: accept all meetings for {@Subject=christmas party} {@FromDate=next week}.
 - accept all meetings for {@Subject=christmas party} {@FromDate=next week}.
@@ -33,7 +33,7 @@
 
 
 > Utterance passed in this intent: 5/6
-## CreateCalendarEntry
+# CreateCalendarEntry
 > PASS. Predicted intent: CreateCalendarEntry(0.999999762)
 > PASS. Predicted entities: book a meeting with huanx@abc.com
 - book a meeting with huanx@abc.com
@@ -55,7 +55,7 @@
 
 
 > Utterance passed in this intent: 2/2
-## FindCalendarEntry
+# FindCalendarEntry
 > PASS. Predicted intent: FindCalendarEntry(0.951522648)
 > PASS. Predicted entities: find a meeting subject {@Subject=daily meeting}
 - find a meeting subject {@Subject=daily meeting}
@@ -65,7 +65,7 @@
 
 
 > Utterance passed in this intent: 3/3
-## None
+# None
 > PASS. Predicted intent: None(0.962541759)
 > PASS. Predicted entities: 1
 - 1

--- a/packages/luis/test/fixtures/testcases/lutest/output/TestFile2_3intent.lu
+++ b/packages/luis/test/fixtures/testcases/lutest/output/TestFile2_3intent.lu
@@ -10,7 +10,7 @@
 > # Intent definitions
 
 > Utterance passed in this intent: 6/6
-## AcceptEventEntry
+# AcceptEventEntry
 > PASS. Predicted intent: AcceptEventEntry(0.948831439), FindCalendarEntry(0.0371829346), None(0.00728923827)
 > PASS. Predicted entities: accept all meetings for {@Subject=christmas party} {@FromDate=next week}.
 - accept all meetings for {@Subject=christmas party} {@FromDate=next week}.
@@ -33,7 +33,7 @@
 
 
 > Utterance passed in this intent: 5/6
-## CreateCalendarEntry
+# CreateCalendarEntry
 > PASS. Predicted intent: CreateCalendarEntry(0.999999762), FindCalendarEntry(8.77192235e-7), None(4.94949234e-7)
 > PASS. Predicted entities: book a meeting with huanx@abc.com
 - book a meeting with huanx@abc.com
@@ -55,7 +55,7 @@
 
 
 > Utterance passed in this intent: 2/2
-## FindCalendarEntry
+# FindCalendarEntry
 > PASS. Predicted intent: FindCalendarEntry(0.951522648), CreateCalendarEntry(0.0267035775), AcceptEventEntry(0.009956521)
 > PASS. Predicted entities: find a meeting subject {@Subject=daily meeting}
 - find a meeting subject {@Subject=daily meeting}
@@ -65,7 +65,7 @@
 
 
 > Utterance passed in this intent: 3/3
-## None
+# None
 > PASS. Predicted intent: None(0.962541759), FindCalendarEntry(0.0138276508), AcceptEventEntry(0.005194204)
 > PASS. Predicted entities: 1
 - 1

--- a/packages/luis/test/fixtures/testcases/lutest/output/TestFile2_intentOnly.lu
+++ b/packages/luis/test/fixtures/testcases/lutest/output/TestFile2_intentOnly.lu
@@ -10,7 +10,7 @@
 > # Intent definitions
 
 > Utterance passed in this intent: 6/6
-## AcceptEventEntry
+# AcceptEventEntry
 > PASS. Predicted intent: AcceptEventEntry(0.948831439)
 - accept all meetings for {@Subject=christmas party} {@FromDate=next week}.
 > PASS. Predicted intent: AcceptEventEntry(0.9806283)
@@ -27,7 +27,7 @@
 
 
 > Utterance passed in this intent: 6/6
-## CreateCalendarEntry
+# CreateCalendarEntry
 > PASS. Predicted intent: CreateCalendarEntry(0.999999762)
 - book a meeting with huanx@abc.com
 > PASS. Predicted intent: CreateCalendarEntry(0.993257463)
@@ -43,7 +43,7 @@
 
 
 > Utterance passed in this intent: 2/2
-## FindCalendarEntry
+# FindCalendarEntry
 > PASS. Predicted intent: FindCalendarEntry(0.951522648)
 - find a meeting subject {@Subject=daily meeting}
 > PASS. Predicted intent: FindCalendarEntry(0.959091961)
@@ -51,7 +51,7 @@
 
 
 > Utterance passed in this intent: 3/3
-## None
+# None
 > PASS. Predicted intent: None(0.962541759)
 - 1
 > PASS. Predicted intent: None(0.9742338)

--- a/packages/luis/test/fixtures/verified/interruption/Dia1.lu
+++ b/packages/luis/test/fixtures/verified/interruption/Dia1.lu
@@ -8,11 +8,11 @@
 
 > # Intent definitions
 
-## hotelLevel
+# hotelLevel
 - I need a four star hotel
 
 
-## hotelLocation
+# hotelLocation
 - can I book a hotel near space needle
 
 

--- a/packages/luis/test/fixtures/verified/interruption/Main.lu
+++ b/packages/luis/test/fixtures/verified/interruption/Main.lu
@@ -7,16 +7,16 @@
 
 > # Intent definitions
 
-## dia1_trigger
+# dia1_trigger
 - book a hotel for me
 
 
-## dia2_trigger
+# dia2_trigger
 - book a flight for me
 - book a train ticket for me
 
 
-## greeting
+# greeting
 - hi
 - hello
 

--- a/packages/luis/test/fixtures/verified/interruption/dia1.fr-fr.lu
+++ b/packages/luis/test/fixtures/verified/interruption/dia1.fr-fr.lu
@@ -7,11 +7,11 @@
 
 > # Intent definitions
 
-## hotelLevel
+# hotelLevel
 - J'ai besoin d'un hôtel quatre étoiles
 
 
-## hotelLocation
+# hotelLocation
 - puis-je réserver un hôtel près de l'aiguille spatiale
 
 

--- a/packages/luis/test/fixtures/verified/interruption/dia2.lu
+++ b/packages/luis/test/fixtures/verified/interruption/dia2.lu
@@ -7,11 +7,11 @@
 
 > # Intent definitions
 
-## dia3_trigger
+# dia3_trigger
 - book a flight from {@fromLocation=Seattle} to {@toLocation=Beijing}
 
 
-## dia4_trigger
+# dia4_trigger
 - book a train ticket from Seattle to Portland
 
 

--- a/packages/luis/test/fixtures/verified/interruption/dia3.lu
+++ b/packages/luis/test/fixtures/verified/interruption/dia3.lu
@@ -7,11 +7,11 @@
 
 > # Intent definitions
 
-## flightDestination
+# flightDestination
 - book a flight to {@toLocation=Beijing}
 
 
-## flightTime
+# flightTime
 - which {@flightTime} do you prefer
 
 

--- a/packages/luis/test/fixtures/verified/interruption/dia4.lu
+++ b/packages/luis/test/fixtures/verified/interruption/dia4.lu
@@ -7,11 +7,11 @@
 
 > # Intent definitions
 
-## railwayStation
+# railwayStation
 - which station will you leave from
 
 
-## railwayTime
+# railwayTime
 - When do you want to leave from Seattle train station
 
 

--- a/packages/luis/test/fixtures/verified/interruption/main.fr-fr.lu
+++ b/packages/luis/test/fixtures/verified/interruption/main.fr-fr.lu
@@ -7,7 +7,7 @@
 
 > # Intent definitions
 
-## dia1_trigger
+# dia1_trigger
 - réserver un hôtel
 
 

--- a/packages/luis/test/fixtures/verified/interruption2/dia1.lu
+++ b/packages/luis/test/fixtures/verified/interruption2/dia1.lu
@@ -7,7 +7,7 @@
 
 > # Intent definitions
 
-## FlightTime
+# FlightTime
 - which {@flightTime} do you prefer
 
 

--- a/packages/luis/test/fixtures/verified/interruption2/dia2.lu
+++ b/packages/luis/test/fixtures/verified/interruption2/dia2.lu
@@ -7,7 +7,7 @@
 
 > # Intent definitions
 
-## HotelLevel
+# HotelLevel
 - which hotel star do you prefer
 
 

--- a/packages/luis/test/fixtures/verified/interruption2/dia3.lu
+++ b/packages/luis/test/fixtures/verified/interruption2/dia3.lu
@@ -7,7 +7,7 @@
 
 > # Intent definitions
 
-## help
+# help
 - can I help you
 
 

--- a/packages/luis/test/fixtures/verified/interruption2/main.lu
+++ b/packages/luis/test/fixtures/verified/interruption2/main.lu
@@ -7,20 +7,20 @@
 
 > # Intent definitions
 
-## dia2_trigger
+# dia2_trigger
 - book a hotel for me
 
 
-## dia3_trigger
+# dia3_trigger
 - cancel
 
 
-## local_intent
+# local_intent
 - Hello
 - Hi
 
 
-## dia1_trigger
+# dia1_trigger
 - book a flight for me
 
 

--- a/packages/luis/test/fixtures/verified/interruption3/dia1.lu
+++ b/packages/luis/test/fixtures/verified/interruption3/dia1.lu
@@ -7,7 +7,7 @@
 
 > # Intent definitions
 
-## bookFlight
+# bookFlight
 - book a flight for me
 
 

--- a/packages/luis/test/fixtures/verified/interruption3/dia2.lu
+++ b/packages/luis/test/fixtures/verified/interruption3/dia2.lu
@@ -7,7 +7,7 @@
 
 > # Intent definitions
 
-## bookTrain
+# bookTrain
 - book a train ticket for me
 
 

--- a/packages/luis/test/fixtures/verified/interruption3/dia3.lu
+++ b/packages/luis/test/fixtures/verified/interruption3/dia3.lu
@@ -7,7 +7,7 @@
 
 > # Intent definitions
 
-## HotelLevel
+# HotelLevel
 - I prefer 4 stars hotel
 
 

--- a/packages/luis/test/fixtures/verified/interruption3/main.lu
+++ b/packages/luis/test/fixtures/verified/interruption3/main.lu
@@ -7,11 +7,11 @@
 
 > # Intent definitions
 
-## dia1_trigger
+# dia1_trigger
 - I want to travel to Seattle
 
 
-## dia2_trigger
+# dia2_trigger
 - book a hotel for me
 
 

--- a/packages/luis/test/fixtures/verified/interruption5/dia1.lu
+++ b/packages/luis/test/fixtures/verified/interruption5/dia1.lu
@@ -7,7 +7,7 @@
 
 > # Intent definitions
 
-## hotelLocation
+# hotelLocation
 - can I book a hotel near space needle
 
 

--- a/packages/luis/test/fixtures/verified/interruption5/main.lu
+++ b/packages/luis/test/fixtures/verified/interruption5/main.lu
@@ -7,7 +7,7 @@
 
 > # Intent definitions
 
-## dia1_trigger
+# dia1_trigger
 - book a hotel for me
 
 

--- a/packages/luis/test/fixtures/verified/luis_sorted.lu
+++ b/packages/luis/test/fixtures/verified/luis_sorted.lu
@@ -8,7 +8,7 @@
 
 > # Intent definitions
 
-## AskForUserName
+# AskForUserName
 - {@userName=vishwac}
 - I'm {@userName=vishwac}
 - call me {@userName=vishwac}
@@ -17,53 +17,53 @@
 - you can call me {@userName=vishwac}
 
 
-## Buy chocolate
+# Buy chocolate
 - can I get some m&m
 - I want some twix
 - I would like to buy some kit kat
 
 
-## CommunicationPreference
+# CommunicationPreference
 - set phone call as my communication preference
 - I prefer to receive text message
 
 
-## CreateAlarm
+# CreateAlarm
 - create an alarm
 - create an alarm for 7AM
 - set an alarm for 7AM next thursday
 
 
-## DeleteAlarm
+# DeleteAlarm
 - delete the {alarmTime} alarm
 - remove the {@alarmTime} alarm
 
 
-## Greeting
+# Greeting
 - Hi
 - Hello
 - Good morning
 - Good evening
 
 
-## Help
+# Help
 - help
 - I need help
 - please help
 - can you help
 
 
-## None
+# None
 - who is your ceo?
 - santa wants a blue ribbon
 
 
-## setThermostat
+# setThermostat
 - Please set {@deviceTemperature=thermostat to 72}
 - Set {@deviceTemperature={@customDevice=owen} to 72}
 
 
-## testIntent
+# testIntent
 - I need a flight from {@fromDate=tomorrow} and returning on {@toDate=next thursday}
 
 

--- a/packages/luis/test/fixtures/verified/modelInfo.lu
+++ b/packages/luis/test/fixtures/verified/modelInfo.lu
@@ -8,7 +8,7 @@
 
 > # Intent definitions
 
-## AskForUserName
+# AskForUserName
 - {userName=vishwac}
 - I'm {userName=vishwac}
 - call me {userName=vishwac}
@@ -17,53 +17,53 @@
 - you can call me {userName=vishwac}
 
 
-## Buy chocolate
+# Buy chocolate
 - I would like to buy some kit kat
 - I want some twix
 - can I get some m&m
 
 
-## CommunicationPreference
+# CommunicationPreference
 - set phone call as my communication preference
 - I prefer to receive text message
 
 
-## CreateAlarm
+# CreateAlarm
 - create an alarm for 7AM
 - create an alarm
 - set an alarm for 7AM next thursday
 
 
-## DeleteAlarm
+# DeleteAlarm
 - delete the {alarmTime} alarm
 - remove the {alarmTime} alarm
 
 
-## Greeting
+# Greeting
 - Hi
 - Good morning
 - Good evening
 - Hello
 
 
-## Help
+# Help
 - can you help
 - please help
 - I need help
 - help
 
 
-## None
+# None
 - who is your ceo?
 - santa wants a blue ribbon
 
 
-## setThermostat
+# setThermostat
 - Please set {deviceTemperature=thermostat to 72}
 - Set {deviceTemperature={customDevice=owen} to 72}
 
 
-## testIntent
+# testIntent
 - I need a flight from {datetimeV2:fromDate=tomorrow} and returning on {datetimeV2:toDate=next thursday}
 
 

--- a/packages/luis/test/fixtures/verified/sorted.lu
+++ b/packages/luis/test/fixtures/verified/sorted.lu
@@ -1,7 +1,7 @@
 
 > # Intent definitions
 
-## AskForUserName
+# AskForUserName
 - {userName=vishwac}
 - I'm {userName=vishwac}
 - call me {userName=vishwac}
@@ -10,53 +10,53 @@
 - you can call me {userName=vishwac}
 
 
-## Buy chocolate
+# Buy chocolate
 - I would like to buy some kit kat
 - I want some twix
 - can I get some m&m
 
 
-## CommunicationPreference
+# CommunicationPreference
 - set phone call as my communication preference
 - I prefer to receive text message
 
 
-## CreateAlarm
+# CreateAlarm
 - create an alarm for 7AM
 - create an alarm
 - set an alarm for 7AM next thursday
 
 
-## DeleteAlarm
+# DeleteAlarm
 - delete the {alarmTime} alarm
 - remove the {alarmTime} alarm
 
 
-## Greeting
+# Greeting
 - Hi
 - Good morning
 - Good evening
 - Hello
 
 
-## Help
+# Help
 - can you help
 - please help
 - I need help
 - help
 
 
-## None
+# None
 - who is your ceo?
 - santa wants a blue ribbon
 
 
-## setThermostat
+# setThermostat
 - Please set {deviceTemperature=thermostat to 72}
 - Set {deviceTemperature={customDevice=owen} to 72}
 
 
-## testIntent
+# testIntent
 - I need a flight from {datetimeV2:fromDate=tomorrow} and returning on {datetimeV2:toDate=next thursday}
 
 
@@ -129,7 +129,7 @@ $units:[temperature]
 > # QnA pairs
 
 > Source: custom editorial
-## ? get me your ceo info
+# ? get me your ceo info
 - Who is your ceo?
 
 ```markdown
@@ -137,7 +137,7 @@ Vishwac
 ```
 
 > Source: custom editorial
-## ? How do I change the default message
+# ? How do I change the default message
 
 ```markdown
 You can change the default message if you use the QnAMakerDialog.
@@ -145,7 +145,7 @@ See [this link](https://docs.botframework.com/en-us/azure-bot-service/templates/
 ```
 
 > Source: custom editorial
-## ? How do I programmatically update my KB?
+# ? How do I programmatically update my KB?
 
 ```markdown
 You can use our REST apis to manage your KB.
@@ -153,7 +153,7 @@ You can use our REST apis to manage your KB.
 ```
 
 > Source: custom editorial
-## ? I need coffee
+# ? I need coffee
 - Where can I get coffee?
 
 
@@ -165,7 +165,7 @@ You can get coffee in our Seattle store at 1 pike place, Seattle, WA
 ```
 
 > Source: custom editorial
-## ? I need coffee
+# ? I need coffee
 - Where can I get coffee?
 
 
@@ -177,7 +177,7 @@ You can get coffee in our Portland store at 52 marine drive, Portland, OR
 ```
 
 > Source: custom editorial
-## ? ludown cli
+# ? ludown cli
 - What is Ludown?
 - where can i get more information about ludown cli?
 

--- a/packages/qnamaker/test/fixtures/file.lu
+++ b/packages/qnamaker/test/fixtures/file.lu
@@ -1,6 +1,6 @@
 > # Intent definitions
 
-## Calendar.Add
+# Calendar.Add
 - add a new event on 27 - apr
 - add a new task finish assignment
 - add an event to read about adam lambert news
@@ -14,7 +14,7 @@
 - the meeting will last for one hour
 
 
-## Calendar.Find
+# Calendar.Find
 - calendar for november 1948
 - display weekend plans
 - do i have anything on wednesday ?
@@ -26,7 +26,7 @@
 - voice activated reading of appointments this week
 
 
-## None
+# None
 - am i free to be with friends saturday ?
 - appointment with johnson needs to be next week
 - call dad mike

--- a/packages/qnamaker/test/fixtures/qna.lu
+++ b/packages/qnamaker/test/fixtures/qna.lu
@@ -1,17 +1,17 @@
 > # Intents
 
-## Greeting
+# Greeting
 - Hi
 - Hello
 - Good morning
 - Good evening
 
-## Help
+# Help
 - help
 - I need help
 - please help
 
-## AskForUserName
+# AskForUserName
 - {userName=vishwac}
 - I'm {userName=vishwac}
 - call me {userName=vishwac}
@@ -19,22 +19,22 @@
 - {userName=vishwac} is my name
 - you can call me {userName=vishwac}
 
-## CreateAlarm
+# CreateAlarm
 - create an alarm
 - create an alarm for 7AM
 - set an alarm for 7AM next thursday
 
-## DeleteAlarm
+# DeleteAlarm
 - delete alarm
 - delete the {alarmTime} alarm
 
 
 
-## CommunicationPreference
+# CommunicationPreference
 - set call as my communication preference
 - I prefer to receive text messages
 
-## Help
+# Help
 - can you help
 
 
@@ -88,19 +88,19 @@ $ChocolateType:phraseList
 > # QnA Definitions
 > This is a QnA definition. Follows # ? Question: \<list of questions\> \```markdown \<Answer> ``` format
 
-### ? How can I change the default message from QnA Maker?
+## ? How can I change the default message from QnA Maker?
 ```markdown
 You can change the default message if you use the QnAMakerDialog. 
 See [this link](https://docs.botframework.com/en-us/azure-bot-service/templates/qnamaker/#navtitle) for details. 
 ```
 
-### ?How do I programmatically update my KB?
+## ?How do I programmatically update my KB?
 ```markdown
 You can use our REST apis to manage your KB. 
 \#1. See here for details: https://westus.dev.cognitive.microsoft.com/docs/services/58994a073d9e04097c7ba6fe/operations/58994a073d9e041ad42d9baa
 ```
 
-### ? Who is your ceo?
+## ? Who is your ceo?
 - get me your ceo info
 ```markdown
 Vishwac

--- a/packages/qnamaker/test/fixtures/replacekb.qna
+++ b/packages/qnamaker/test/fixtures/replacekb.qna
@@ -1,4 +1,4 @@
-## ? I need help
+# ? I need help
 - help
 - can you please help
 - what can I say

--- a/packages/qnamaker/test/fixtures/verified/LUISAppWithPAInherits.lu
+++ b/packages/qnamaker/test/fixtures/verified/LUISAppWithPAInherits.lu
@@ -9,7 +9,7 @@
 
 > # Intent definitions
 
-## None
+# None
 - can you delete {@ToDo.TaskContent=abc} item
 - can you delete {@ToDo.TaskContent=todo1}
 - cancel {@ToDo.TaskContent=apples} from shopping list
@@ -95,7 +95,7 @@
 
 > !# @intent.inherits = name : ToDo.AddToDo; domain_name : ToDo; model_name : AddToDo
 
-## ToDo.AddToDo
+# ToDo.AddToDo
 - add a few items to the grocery list
 - add a grocery item to {@ToDo.TaskContent=buy fish}
 - add a grocery item to {@ToDo.TaskContent=buy fruit and vegetables}

--- a/packages/qnamaker/test/fixtures/verified/MultiturnReplaceKbWithFlattenedTree.qna
+++ b/packages/qnamaker/test/fixtures/verified/MultiturnReplaceKbWithFlattenedTree.qna
@@ -4,7 +4,7 @@
 
 <a id = "1"></a>
 
-## ? ques1
+# ? ques1
 
 ```markdown
 ans1
@@ -19,7 +19,7 @@ ans1
 
 <a id = "2"></a>
 
-## ? p1
+# ? p1
 
 ```markdown
 ap1
@@ -29,7 +29,7 @@ ap1
 
 <a id = "3"></a>
 
-## ? p2
+# ? p2
 
 ```markdown
 ap2
@@ -39,7 +39,7 @@ ap2
 
 <a id = "4"></a>
 
-## ? p3
+# ? p3
 
 ```markdown
 ap3
@@ -49,7 +49,7 @@ ap3
 
 <a id = "5"></a>
 
-## ? qew
+# ? qew
 
 ```markdown
 zxc

--- a/packages/qnamaker/test/fixtures/verified/allGen.lu
+++ b/packages/qnamaker/test/fixtures/verified/allGen.lu
@@ -8,21 +8,21 @@
 
 > # Intent definitions
 
-## Greeting
+# Greeting
 - Hi
 - Hello
 - Good morning
 - Good evening
 
 
-## Help
+# Help
 - help
 - I need help
 - please help
 - can you help
 
 
-## AskForUserName
+# AskForUserName
 - {@userName=vishwac}
 - I'm {@userName=vishwac}
 - call me {@userName=vishwac}
@@ -31,28 +31,28 @@
 - you can call me {@userName=vishwac}
 
 
-## CreateAlarm
+# CreateAlarm
 - create an alarm
 - create an alarm for 7AM
 - set an alarm for 7AM next thursday
 
 
-## DeleteAlarm
+# DeleteAlarm
 - delete the {@alarmTime} alarm
 - remove the {@alarmTime} alarm
 
 
-## CommunicationPreference
+# CommunicationPreference
 - set phone call as my communication preference
 - I prefer to receive text message
 
 
-## None
+# None
 - who is your ceo?
 - santa wants a blue ribbon
 
 
-## Buy chocolate
+# Buy chocolate
 - can I get some m&m
 - I want some twix
 - I would like to buy some kit kat

--- a/packages/qnamaker/test/fixtures/verified/allGenQnA.lu
+++ b/packages/qnamaker/test/fixtures/verified/allGenQnA.lu
@@ -2,7 +2,7 @@
 
 > !# @qna.pair.source = custom editorial
 
-## ? How do I change the default message
+# ? How do I change the default message
 
 ```markdown
 You can change the default message if you use the QnAMakerDialog. 
@@ -11,7 +11,7 @@ See [this link](https://docs.botframework.com/en-us/azure-bot-service/templates/
 
 > !# @qna.pair.source = custom editorial
 
-## ? How do I programmatically update my KB?
+# ? How do I programmatically update my KB?
 
 ```markdown
 You can use our REST apis to manage your KB. 
@@ -20,7 +20,7 @@ You can use our REST apis to manage your KB.
 
 > !# @qna.pair.source = custom editorial
 
-## ? Who is your ceo?
+# ? Who is your ceo?
 - get me your ceo info
 
 ```markdown
@@ -29,7 +29,7 @@ Vishwac
 
 > !# @qna.pair.source = custom editorial
 
-## ? Where can I get coffee?
+# ? Where can I get coffee?
 - I need coffee
 
 **Filters:**
@@ -41,7 +41,7 @@ You can get coffee in our Seattle store at 1 pike place, Seattle, WA
 
 > !# @qna.pair.source = custom editorial
 
-## ? Where can I get coffee?
+# ? Where can I get coffee?
 - I need coffee
 
 **Filters:**
@@ -53,7 +53,7 @@ You can get coffee in our Portland store at 52 marine drive, Portland, OR
 
 > !# @qna.pair.source = custom editorial
 
-## ? What is Ludown?
+# ? What is Ludown?
 - ludown cli
 - where can i get more information about ludown cli?
 

--- a/packages/qnamaker/test/fixtures/verified/allRefresh.lu
+++ b/packages/qnamaker/test/fixtures/verified/allRefresh.lu
@@ -1,21 +1,21 @@
 
 > # Intent definitions
 
-## Greeting
+# Greeting
 - Hi
 - Hello
 - Good morning
 - Good evening
 
 
-## Help
+# Help
 - help
 - I need help
 - please help
 - can you help
 
 
-## AskForUserName
+# AskForUserName
 - {userName=vishwac}
 - I'm {userName=vishwac}
 - call me {userName=vishwac}
@@ -24,28 +24,28 @@
 - you can call me {userName=vishwac}
 
 
-## CreateAlarm
+# CreateAlarm
 - create an alarm
 - create an alarm for 7AM
 - set an alarm for 7AM next thursday
 
 
-## DeleteAlarm
+# DeleteAlarm
 - delete the {alarmTime} alarm
 - remove the {alarmTime} alarm
 
 
-## CommunicationPreference
+# CommunicationPreference
 - set phone call as my communication preference
 - I prefer to receive text message
 
 
-## None
+# None
 - who is your ceo?
 - santa wants a blue ribbon
 
 
-## Buy chocolate
+# Buy chocolate
 - can I get some m&m
 - I want some twix
 - I would like to buy some kit kat

--- a/packages/qnamaker/test/fixtures/verified/allall-qna.lu
+++ b/packages/qnamaker/test/fixtures/verified/allall-qna.lu
@@ -1,21 +1,21 @@
 
 > # Intent definitions
 
-## Greeting
+# Greeting
 - Hi
 - Hello
 - Good morning
 - Good evening
 
 
-## Help
+# Help
 - help
 - I need help
 - please help
 - can you help
 
 
-## AskForUserName
+# AskForUserName
 - {userName=vishwac}
 - I'm {userName=vishwac}
 - call me {userName=vishwac}
@@ -24,28 +24,28 @@
 - you can call me {userName=vishwac}
 
 
-## CreateAlarm
+# CreateAlarm
 - create an alarm
 - create an alarm for 7AM
 - set an alarm for 7AM next thursday
 
 
-## DeleteAlarm
+# DeleteAlarm
 - delete the {alarmTime} alarm
 - remove the {alarmTime} alarm
 
 
-## CommunicationPreference
+# CommunicationPreference
 - set phone call as my communication preference
 - I prefer to receive text message
 
 
-## None
+# None
 - who is your ceo?
 - santa wants a blue ribbon
 
 
-## Buy chocolate
+# Buy chocolate
 - can I get some m&m
 - I want some twix
 - I would like to buy some kit kat
@@ -96,7 +96,7 @@ $commPreference:fax=
 > # QnA pairs
 
 > Source: custom editorial
-## ? How do I change the default message
+# ? How do I change the default message
 
 ```markdown
 You can change the default message if you use the QnAMakerDialog. 
@@ -104,7 +104,7 @@ See [this link](https://docs.botframework.com/en-us/azure-bot-service/templates/
 ```
 
 > Source: custom editorial
-## ? How do I programmatically update my KB?
+# ? How do I programmatically update my KB?
 
 ```markdown
 You can use our REST apis to manage your KB. 
@@ -112,7 +112,7 @@ You can use our REST apis to manage your KB.
 ```
 
 > Source: custom editorial
-## ? Who is your ceo?
+# ? Who is your ceo?
 - get me your ceo info
 
 ```markdown
@@ -120,7 +120,7 @@ Vishwac
 ```
 
 > Source: custom editorial
-## ? Where can I get coffee?
+# ? Where can I get coffee?
 - I need coffee
 
 
@@ -132,7 +132,7 @@ You can get coffee in our Seattle store at 1 pike place, Seattle, WA
 ```
 
 > Source: custom editorial
-## ? Where can I get coffee?
+# ? Where can I get coffee?
 - I need coffee
 
 
@@ -144,7 +144,7 @@ You can get coffee in our Portland store at 52 marine drive, Portland, OR
 ```
 
 > Source: custom editorial
-## ? What is Ludown?
+# ? What is Ludown?
 - ludown cli
 - where can i get more information about ludown cli?
 

--- a/packages/qnamaker/test/fixtures/verified/calendar_all_prebuilt.lu
+++ b/packages/qnamaker/test/fixtures/verified/calendar_all_prebuilt.lu
@@ -10,7 +10,7 @@
 
 > !# @intent.inherits = name : Calendar.FindCalendarWhen; domain_name : Calendar; model_name : FindCalendarWhen
 
-## Calendar.FindCalendarWhen
+# Calendar.FindCalendarWhen
 - which {Calendar.StartDate=weekend} am i {Calendar.Subject=shopping} with sarah
 - what day is {Calendar.Subject=lego land} scheduled for
 - my next meeting with emily is when
@@ -70,7 +70,7 @@
 
 > !# @intent.inherits = name : Calendar.AcceptEventEntry; domain_name : Calendar; model_name : AcceptEventEntry
 
-## Calendar.AcceptEventEntry
+# Calendar.AcceptEventEntry
 - accept all meetings for {Calendar.Subject=christmas party} {Calendar.StartDate=next week}.
 - accept an appointment
 - accept {Calendar.Subject=dinner}
@@ -104,7 +104,7 @@
 
 > !# @intent.inherits = name : Calendar.FindCalendarWhere; domain_name : Calendar; model_name : FindCalendarWhere
 
-## Calendar.FindCalendarWhere
+# Calendar.FindCalendarWhere
 - meeting at {Calendar.StartTime=3 pm} {Calendar.StartDate=today} locations
 - show me the place of the {Calendar.Subject=work smart training}
 - show me where my next appointment is
@@ -163,7 +163,7 @@
 
 > !# @intent.inherits = name : Calendar.ChangeCalendarEntry; domain_name : Calendar; model_name : ChangeCalendarEntry
 
-## Calendar.ChangeCalendarEntry
+# Calendar.ChangeCalendarEntry
 - update {Calendar.Subject=party}
 - update my tomorrow 6pm meeting to {Calendar.StartTime=7pm}
 - update my next appointment
@@ -284,7 +284,7 @@
 
 > !# @intent.inherits = name : Calendar.Cancel; domain_name : Calendar; model_name : Cancel
 
-## Calendar.Cancel
+# Calendar.Cancel
 - abort edition
 - will you cancel it please
 - stop finding it
@@ -354,7 +354,7 @@
 
 > !# @intent.inherits = name : Calendar.FindCalendarWho; domain_name : Calendar; model_name : FindCalendarWho
 
-## Calendar.FindCalendarWho
+# Calendar.FindCalendarWho
 - {Calendar.StartTime=2 pm} meeting {Calendar.StartDate=tomorrow} - who else is going
 - {Calendar.StartTime=2 pm} meeting with who
 - did hellen come to {Calendar.StartTime=3 pm}'s meeting
@@ -427,7 +427,7 @@
 
 > !# @intent.inherits = name : Calendar.ConnectToMeeting; domain_name : Calendar; model_name : ConnectToMeeting
 
-## Calendar.ConnectToMeeting
+# Calendar.ConnectToMeeting
 - dial into conference call
 - dial {Calendar.Subject=marketing meeting}
 - add me to conference call
@@ -487,7 +487,7 @@
 
 > !# @intent.inherits = name : Calendar.CheckAvailability; domain_name : Calendar; model_name : CheckAvailability
 
-## Calendar.CheckAvailability
+# Calendar.CheckAvailability
 - will tyler be free on {Calendar.StartDate=friday}
 - when will jordan be free
 - when is samuel available {Calendar.StartDate=tomorrow}
@@ -548,7 +548,7 @@
 
 > !# @intent.inherits = name : Calendar.Confirm; domain_name : Calendar; model_name : Confirm
 
-## Calendar.Confirm
+# Calendar.Confirm
 - yup
 - yes yes
 - yes that ' s fine
@@ -598,7 +598,7 @@
 
 > !# @intent.inherits = name : Calendar.FindMeetingRoom; domain_name : Calendar; model_name : FindMeetingRoom
 
-## Calendar.FindMeetingRoom
+# Calendar.FindMeetingRoom
 - reserve the conference room for {Calendar.StartTime=3pm} {Calendar.StartDate=tomorrow}
 - find a free meeting room for {Calendar.StartDate=next tuesday}
 - schedule conference room with mary cooper for {Calendar.StartDate=thursday} at {Calendar.StartTime=one}
@@ -635,7 +635,7 @@
 
 > !# @intent.inherits = name : Calendar.FindCalendarDetail; domain_name : Calendar; model_name : FindCalendarDetail
 
-## Calendar.FindCalendarDetail
+# Calendar.FindCalendarDetail
 - tell me about my {Calendar.StartDate=sunday} schedule
 - can you tell me something about {Calendar.Subject=shakespeare}
 - detail about {Calendar.StartDate=tomorrow}'s meeting
@@ -666,7 +666,7 @@
 
 > !# @intent.inherits = name : Calendar.DeleteCalendarEntry; domain_name : Calendar; model_name : DeleteCalendarEntry
 
-## Calendar.DeleteCalendarEntry
+# Calendar.DeleteCalendarEntry
 - delete meeting
 - cancel an appointment
 - cancel all events
@@ -744,7 +744,7 @@
 
 > !# @intent.inherits = name : Calendar.CreateCalendarEntry; domain_name : Calendar; model_name : CreateCalendarEntry
 
-## Calendar.CreateCalendarEntry
+# Calendar.CreateCalendarEntry
 - 2 hours meeting with ladawn padilla at {Calendar.StartTime=5} on {Calendar.StartDate=tuesday}
 - add a meeting with herman to my calendar
 - add an appointment on {Calendar.StartDate=may 8th} at shanghai
@@ -987,7 +987,7 @@
 
 > !# @intent.inherits = name : Calendar.ContactMeetingAttendees; domain_name : Calendar; model_name : ContactMeetingAttendees
 
-## Calendar.ContactMeetingAttendees
+# Calendar.ContactMeetingAttendees
 - tell next meeting that {Calendar.Message=i'm running late}
 - tell everyone {Calendar.Message=the meeting is now in room 204}
 - tell attendees {Calendar.Message=i am late}
@@ -1045,7 +1045,7 @@
 
 > !# @intent.inherits = name : Calendar.FindCalendarEntry; domain_name : Calendar; model_name : FindCalendarEntry
 
-## Calendar.FindCalendarEntry
+# Calendar.FindCalendarEntry
 - next meeting
 - calendar for {Calendar.StartDate=today}
 - which will be my next {Calendar.Subject=flight}
@@ -1163,7 +1163,7 @@
 
 > !# @intent.inherits = name : Calendar.FindDuration; domain_name : Calendar; model_name : FindDuration
 
-## Calendar.FindDuration
+# Calendar.FindDuration
 - about how long will the meeting last
 - minutes in {Calendar.Subject=lunch break}
 - how long will my {Calendar.Subject=dentist appointment} last
@@ -1206,7 +1206,7 @@
 
 > !# @intent.inherits = name : Calendar.GoBack; domain_name : Calendar; model_name : GoBack
 
-## Calendar.GoBack
+# Calendar.GoBack
 - please go back
 - go back to the previous step
 - go back to the main menu
@@ -1234,7 +1234,7 @@
 
 > !# @intent.inherits = name : Calendar.Reject; domain_name : Calendar; model_name : Reject
 
-## Calendar.Reject
+# Calendar.Reject
 - nope
 - of course not
 - not at this time
@@ -1294,7 +1294,7 @@
 
 > !# @intent.inherits = name : Calendar.ShowNext; domain_name : Calendar; model_name : ShowNext
 
-## Calendar.ShowNext
+# Calendar.ShowNext
 - could you show the next one
 - i need to go to the next one
 - show the next
@@ -1314,7 +1314,7 @@
 
 > !# @intent.inherits = name : Calendar.ShowPrevious; domain_name : Calendar; model_name : ShowPrevious
 
-## Calendar.ShowPrevious
+# Calendar.ShowPrevious
 - what is the previous
 - i need to check the previous appointment
 - show the previous one
@@ -1328,7 +1328,7 @@
 
 > !# @intent.inherits = name : Calendar.TimeRemaining; domain_name : Calendar; model_name : TimeRemaining
 
-## Calendar.TimeRemaining
+# Calendar.TimeRemaining
 - tell me how much free time i have before next appt
 - how much longer until my next meeting
 - time before my next appointment
@@ -1386,7 +1386,7 @@
 - ^how long do i have (until|before|till) the [next] (meeting|appointment|{Calendar.Subject})
 
 
-## None
+# None
 - running late for the {Calendar.Subject=board meeting} alert catherine dennis and all the other attendees
 
 

--- a/packages/qnamaker/test/fixtures/verified/collate_refresh.lu
+++ b/packages/qnamaker/test/fixtures/verified/collate_refresh.lu
@@ -1,21 +1,21 @@
 
 > # Intent definitions
 
-## Greeting
+# Greeting
 - Hi
 - Hello
 - Good morning
 - Good evening
 
 
-## Help
+# Help
 - help
 - I need help
 - please help
 - can you help
 
 
-## AskForUserName
+# AskForUserName
 - {userName=vishwac}
 - I'm {userName=vishwac}
 - call me {userName=vishwac}
@@ -24,19 +24,19 @@
 - you can call me {userName=vishwac}
 
 
-## CreateAlarm
+# CreateAlarm
 - create an alarm
 - create an alarm for 7AM
 - set an alarm for 7AM next thursday
 
 
-## DeleteAlarm
+# DeleteAlarm
 - delete the {alarmTime} alarm
 - delete alarm
 - remove the {alarmTime} alarm
 
 
-## CommunicationPreference
+# CommunicationPreference
 - set phone call as my communication preference
 - I prefer to receive text message
 - set call as my communication preference
@@ -45,28 +45,28 @@
 - I prefer to receive {commPreference}
 
 
-## Buy chocolate
+# Buy chocolate
 - can I get some m&m
 - I want some twix
 - I would like to buy some kit kat
 
 
-## changeAlarm
+# changeAlarm
 - change an alarm
 - change {remTime} to {newTime}
 
 
-## None
+# None
 - who is your ceo?
 - santa wants a blue ribbon
 
 
-## addAlarm
+# addAlarm
 - create an alarm for 7AM
 - create an alarm for {datetimeV2}
 
 
-## Menu
+# Menu
 - I want {foodType=sandwich}
 - can you get me some {foodType}
 - please get me a {drinkType}
@@ -126,7 +126,7 @@ $drinkType:soda=
 > # QnA pairs
 
 > Source: custom editorial
-## ? How can I change the default message from QnA Maker?
+# ? How can I change the default message from QnA Maker?
 
 ```markdown
 You can change the default message if you use the QnAMakerDialog. 
@@ -134,7 +134,7 @@ See [this link](https://docs.botframework.com/en-us/azure-bot-service/templates/
 ```
 
 > Source: custom editorial
-## ? How do I programmatically update my KB?
+# ? How do I programmatically update my KB?
 
 ```markdown
 You can use our REST apis to manage your KB. 
@@ -142,7 +142,7 @@ You can use our REST apis to manage your KB.
 ```
 
 > Source: custom editorial
-## ? Who is your ceo?
+# ? Who is your ceo?
 - get me your ceo info
 
 ```markdown
@@ -150,7 +150,7 @@ Vishwac
 ```
 
 > Source: custom editorial
-## ? How do I change the default message
+# ? How do I change the default message
 
 ```markdown
 You can change the default message if you use the QnAMakerDialog. 
@@ -158,7 +158,7 @@ See [this link](https://docs.botframework.com/en-us/azure-bot-service/templates/
 ```
 
 > Source: custom editorial
-## ? Where can I get coffee?
+# ? Where can I get coffee?
 - I need coffee
 
 
@@ -170,7 +170,7 @@ You can get coffee in our Seattle store at 1 pike place, Seattle, WA
 ```
 
 > Source: custom editorial
-## ? Where can I get coffee?
+# ? Where can I get coffee?
 - I need coffee
 
 
@@ -182,7 +182,7 @@ You can get coffee in our Portland store at 52 marine drive, Portland, OR
 ```
 
 > Source: custom editorial
-## ? What is Ludown?
+# ? What is Ludown?
 - ludown cli
 - where can i get more information about ludown cli?
 

--- a/packages/qnamaker/test/fixtures/verified/de/faq.lu
+++ b/packages/qnamaker/test/fixtures/verified/de/faq.lu
@@ -1,18 +1,18 @@
 > # QnA pairs
 
-## ? Was ist ein virtueller Assistent?
+# ? Was ist ein virtueller Assistent?
 ```markdown
 Wir haben ein erhebliches Bedürfnis unserer Kunden und Partner gesehen, einen auf ihre Marke zugeschnittenen, auf ihre Kunden zugeschnittenen und über eine breite Palette von Konversationsgeräten und-geräten zugeschnittenen Assistenten zu liefern. Die Open-Source-Lösung Custom Personal Assistant von Microsoft setzt den Open-Sourcing-Ansatz für Bot Framework SDK fort und bietet die volle Kontrolle über die Erfahrung des Endverbrauchers, die auf einer Reihe von grundlegenden Fähigkeiten basiert. Darüber hinaus kann die Erfahrung mit Intelligenz über den Endverbraucher und alle deviko/Ökosystem-Informationen für eine wirklich integrierte und intelligente Erfahrung durchdrungen werden.
 Weitere Informationen [hier] (https:/github.com/Microsoft/AI/blob/solutions/Virtual-Assistant/docs/README.md).
 ```
 
-## ? Was ist eine Fähigkeit?
+# ? Was ist eine Fähigkeit?
 ```markdown
 Es gibt eine breite Palette gemeinsamer Fähigkeiten, die heute von jedem Entwickler gezwungen werden, sich selbst aufzubauen. Unsere Virtual-Assistant-Lösung beinhaltet eine neue Skill-Fähigkeit, die es ermöglicht, neue Fähigkeiten nur durch Konfiguration in einen virtuellen Assistenten einzubinden und einen Authentifizierungsmechanismus für Skills bereitzustellen, um Token für nachgelagerte Aktivitäten anzufordern.
 Erfahren Sie mehr [hier] (https:/github.com/Microsoft/AI/blob/solutions/Virtual-Assistenten-skills.md).
 ```
 
-## ? Was kann die Kalenderqualifikationen tun?
+# ? Was kann die Kalenderqualifikationen tun?
 ```markdown
 # # Übersicht
 Die Kalenderkompetenz bietet einem virtuellen Assistenten die kalendarbezogenen Fähigkeiten. Die gängigsten Szenarien wurden in dieser ersten Version mit zusätzlichen Szenarien in der Entwicklung umgesetzt.
@@ -25,7 +25,7 @@ Folgende Szenarien werden derzeit von der Fähigkeit unterstützt:
 -Treffen löschen-z.B. Treffen löschen
 ```
 
-## ? Was kann die E-Mail-Fähigung tun?
+# ? Was kann die E-Mail-Fähigung tun?
 ```markdown
 # Übersicht
 Die E-Mail-Fähigung stellt E-Mail-bezogene Fähigkeiten an einen virtuellen Assistenten zur Verfügung. Die gängigsten Szenarien wurden in dieser ersten Version mit zusätzlichen Szenarien in der Entwicklung umgesetzt.
@@ -40,7 +40,7 @@ Folgende Szenarien werden derzeit von der Fähigkeit unterstützt:
 -E-Mail von John Smith finden
 -Welche E-Mail habe ich
 ```
-## ? Was kann der Punkt der Zinskompetentlichkeit tun?
+# ? Was kann der Punkt der Zinskompetentlichkeit tun?
 ```markdown
 # # Übersicht
 Die "Point of Interest Skill" bietet einem virtuellen Assistenten poI-bezogene Fähigkeiten. Die gängigsten Szenarien wurden in dieser ersten Version mit zusätzlichen Szenarien in der Entwicklung umgesetzt.
@@ -62,7 +62,7 @@ Folgende Szenarien werden derzeit von der Fähigkeit unterstützt:
 -Am zweiten Gedanken vergessen, zum Flughafen zu gehen
 ```
 
-## ? Was kann die ToDo Skill tun?
+# ? Was kann die ToDo Skill tun?
 ```markdown
 # # Übersicht
 Die Task Skill bietet einem virtuellen Assistenten aufgabenbezogene Fähigkeiten. Die gängigsten Szenarien wurden in dieser ersten Version mit zusätzlichen Szenarien in der Entwicklung umgesetzt.
@@ -77,19 +77,19 @@ Folgende Szenarien werden derzeit von der Fähigkeit unterstützt:
 Welche Aufgaben habe ich
 ```
 
-## ? Was ist neu
+# ? Was ist neu
 ```markdown
 Der Virtual Assistant hat vor kurzem eine neue Lokalisierung für den virtuellen Assistenten und Fähigkeiten veröffentlicht, die die Verwendung in Englisch, Französisch, Italienisch, Deutsch, Spanisch und Chinesisch ermöglicht.
 ```
 
 > Source:
-## ? Was ist das für gelbes Licht?
+# ? Was ist das für gelbes Licht?
 ```markdown
 Wenn die Reifendruckmesslampe gelb aufkommt, dann ist der Reifendruck etwa 10% oder mehr ausgeschaltet.
 ```
 
 > Source:
-## ? Wie kann ich einen Fehler anheben?
+# ? Wie kann ich einen Fehler anheben?
 ```markdown
 Erstellen Sie eine Ausgabe auf dem [GitHub repo] (https:/github.com/Microsoft/AI/blob/solutions/Virtual-Assistant/docs/README.md)
 ```

--- a/packages/qnamaker/test/fixtures/verified/de/reduced.lu
+++ b/packages/qnamaker/test/fixtures/verified/de/reduced.lu
@@ -1,5 +1,5 @@
 
-## ChangeCalendarEntry
+# ChangeCalendarEntry
 - Ändern  {Subject=Mittagstermin}  Von  {OriginalStartTime=11}  -  {OriginalEndTime=12}  An  {StartTime=12}  -  {EndTime=1 30} 
 - move my  {OriginalStartTime=10 nach 10}   {Subject=Arztbesuch}  An  {StartTime=10} 
 - Ändern  {Subject=Kino}   {SlotAttribute=Lage} 

--- a/packages/qnamaker/test/fixtures/verified/emptyIntentDescriptors.lu
+++ b/packages/qnamaker/test/fixtures/verified/emptyIntentDescriptors.lu
@@ -10,10 +10,10 @@
 
 > # Intent definitions
 
-## None
+# None
 
 
-## test
+# test
 - one
 - two
 

--- a/packages/qnamaker/test/fixtures/verified/interruption/dia1.fr-fr.lu
+++ b/packages/qnamaker/test/fixtures/verified/interruption/dia1.fr-fr.lu
@@ -7,11 +7,11 @@
 
 > # Intent definitions
 
-## hotelLevel
+# hotelLevel
 - J'ai besoin d'un hôtel quatre étoiles
 
 
-## hotelLocation
+# hotelLocation
 - puis-je réserver un hôtel près de l'aiguille spatiale
 
 

--- a/packages/qnamaker/test/fixtures/verified/interruption/dia1.lu
+++ b/packages/qnamaker/test/fixtures/verified/interruption/dia1.lu
@@ -8,11 +8,11 @@
 
 > # Intent definitions
 
-## hotelLevel
+# hotelLevel
 - I need a four star hotel
 
 
-## hotelLocation
+# hotelLocation
 - can I book a hotel near space needle
 
 

--- a/packages/qnamaker/test/fixtures/verified/interruption/dia2.lu
+++ b/packages/qnamaker/test/fixtures/verified/interruption/dia2.lu
@@ -7,11 +7,11 @@
 
 > # Intent definitions
 
-## dia3_trigger
+# dia3_trigger
 - book a flight from {@fromLocation=Seattle} to {@toLocation=Beijing}
 
 
-## dia4_trigger
+# dia4_trigger
 - book a train ticket from Seattle to Portland
 
 

--- a/packages/qnamaker/test/fixtures/verified/interruption/dia3.lu
+++ b/packages/qnamaker/test/fixtures/verified/interruption/dia3.lu
@@ -7,11 +7,11 @@
 
 > # Intent definitions
 
-## flightDestination
+# flightDestination
 - book a flight to {@toLocation=Beijing}
 
 
-## flightTime
+# flightTime
 - which {@flightTime} do you prefer
 
 

--- a/packages/qnamaker/test/fixtures/verified/interruption/dia4.lu
+++ b/packages/qnamaker/test/fixtures/verified/interruption/dia4.lu
@@ -7,11 +7,11 @@
 
 > # Intent definitions
 
-## railwayStation
+# railwayStation
 - which station will you leave from
 
 
-## railwayTime
+# railwayTime
 - When do you want to leave from Seattle train station
 
 

--- a/packages/qnamaker/test/fixtures/verified/interruption/main.fr-fr.lu
+++ b/packages/qnamaker/test/fixtures/verified/interruption/main.fr-fr.lu
@@ -7,7 +7,7 @@
 
 > # Intent definitions
 
-## dia1_trigger
+# dia1_trigger
 - réserver un hôtel
 
 

--- a/packages/qnamaker/test/fixtures/verified/interruption/main.lu
+++ b/packages/qnamaker/test/fixtures/verified/interruption/main.lu
@@ -7,11 +7,11 @@
 
 > # Intent definitions
 
-## dia1_trigger
+# dia1_trigger
 - book a hotel for me
 
 
-## dia2_trigger
+# dia2_trigger
 - book a flight for me
 - book a train ticket for me
 

--- a/packages/qnamaker/test/fixtures/verified/interruption2/dia1.lu
+++ b/packages/qnamaker/test/fixtures/verified/interruption2/dia1.lu
@@ -7,7 +7,7 @@
 
 > # Intent definitions
 
-## FlightTime
+# FlightTime
 - which {@flightTime} do you prefer
 
 

--- a/packages/qnamaker/test/fixtures/verified/interruption2/dia2.lu
+++ b/packages/qnamaker/test/fixtures/verified/interruption2/dia2.lu
@@ -7,7 +7,7 @@
 
 > # Intent definitions
 
-## HotelLevel
+# HotelLevel
 - which hotel star do you prefer
 
 

--- a/packages/qnamaker/test/fixtures/verified/interruption2/dia3.lu
+++ b/packages/qnamaker/test/fixtures/verified/interruption2/dia3.lu
@@ -7,7 +7,7 @@
 
 > # Intent definitions
 
-## help
+# help
 - can I help you
 
 

--- a/packages/qnamaker/test/fixtures/verified/interruption2/main.lu
+++ b/packages/qnamaker/test/fixtures/verified/interruption2/main.lu
@@ -7,20 +7,20 @@
 
 > # Intent definitions
 
-## dia2_trigger
+# dia2_trigger
 - book a hotel for me
 
 
-## dia3_trigger
+# dia3_trigger
 - cancel
 
 
-## local_intent
+# local_intent
 - Hello
 - Hi
 
 
-## dia1_trigger
+# dia1_trigger
 - book a flight for me
 
 

--- a/packages/qnamaker/test/fixtures/verified/interruption3/dia1.lu
+++ b/packages/qnamaker/test/fixtures/verified/interruption3/dia1.lu
@@ -7,7 +7,7 @@
 
 > # Intent definitions
 
-## bookFlight
+# bookFlight
 - book a flight for me
 
 

--- a/packages/qnamaker/test/fixtures/verified/interruption3/dia2.lu
+++ b/packages/qnamaker/test/fixtures/verified/interruption3/dia2.lu
@@ -7,7 +7,7 @@
 
 > # Intent definitions
 
-## bookTrain
+# bookTrain
 - book a train ticket for me
 
 

--- a/packages/qnamaker/test/fixtures/verified/interruption3/dia3.lu
+++ b/packages/qnamaker/test/fixtures/verified/interruption3/dia3.lu
@@ -7,7 +7,7 @@
 
 > # Intent definitions
 
-## HotelLevel
+# HotelLevel
 - I prefer 4 stars hotel
 
 

--- a/packages/qnamaker/test/fixtures/verified/interruption3/main.lu
+++ b/packages/qnamaker/test/fixtures/verified/interruption3/main.lu
@@ -7,11 +7,11 @@
 
 > # Intent definitions
 
-## dia1_trigger
+# dia1_trigger
 - I want to travel to Seattle
 
 
-## dia2_trigger
+# dia2_trigger
 - book a hotel for me
 
 

--- a/packages/qnamaker/test/fixtures/verified/luis_sorted.lu
+++ b/packages/qnamaker/test/fixtures/verified/luis_sorted.lu
@@ -8,7 +8,7 @@
 
 > # Intent definitions
 
-## AskForUserName
+# AskForUserName
 - {@userName=vishwac}
 - I'm {@userName=vishwac}
 - call me {@userName=vishwac}
@@ -17,53 +17,53 @@
 - you can call me {@userName=vishwac}
 
 
-## Buy chocolate
+# Buy chocolate
 - can I get some m&m
 - I want some twix
 - I would like to buy some kit kat
 
 
-## CommunicationPreference
+# CommunicationPreference
 - set phone call as my communication preference
 - I prefer to receive text message
 
 
-## CreateAlarm
+# CreateAlarm
 - create an alarm
 - create an alarm for 7AM
 - set an alarm for 7AM next thursday
 
 
-## DeleteAlarm
+# DeleteAlarm
 - delete the {alarmTime} alarm
 - remove the {@alarmTime} alarm
 
 
-## Greeting
+# Greeting
 - Hi
 - Hello
 - Good morning
 - Good evening
 
 
-## Help
+# Help
 - help
 - I need help
 - please help
 - can you help
 
 
-## None
+# None
 - who is your ceo?
 - santa wants a blue ribbon
 
 
-## setThermostat
+# setThermostat
 - Please set {@deviceTemperature=thermostat to 72}
 - Set {@deviceTemperature={@customDevice=owen} to 72}
 
 
-## testIntent
+# testIntent
 - I need a flight from {@fromDate=tomorrow} and returning on {@toDate=next thursday}
 
 

--- a/packages/qnamaker/test/fixtures/verified/modelAsFeatureGen.lu
+++ b/packages/qnamaker/test/fixtures/verified/modelAsFeatureGen.lu
@@ -7,19 +7,19 @@
 
 > # Intent definitions
 
-## test1
+# test1
 - one
 
 
 @ intent test1 usesFeature test3
 
-## test2
+# test2
 - two
 
 
 @ intent test2 usesFeature simple1
 
-## test3
+# test3
 - three
 
 

--- a/packages/qnamaker/test/fixtures/verified/modelInfo.lu
+++ b/packages/qnamaker/test/fixtures/verified/modelInfo.lu
@@ -8,7 +8,7 @@
 
 > # Intent definitions
 
-## AskForUserName
+# AskForUserName
 - {userName=vishwac}
 - I'm {userName=vishwac}
 - call me {userName=vishwac}
@@ -17,53 +17,53 @@
 - you can call me {userName=vishwac}
 
 
-## Buy chocolate
+# Buy chocolate
 - I would like to buy some kit kat
 - I want some twix
 - can I get some m&m
 
 
-## CommunicationPreference
+# CommunicationPreference
 - set phone call as my communication preference
 - I prefer to receive text message
 
 
-## CreateAlarm
+# CreateAlarm
 - create an alarm for 7AM
 - create an alarm
 - set an alarm for 7AM next thursday
 
 
-## DeleteAlarm
+# DeleteAlarm
 - delete the {alarmTime} alarm
 - remove the {alarmTime} alarm
 
 
-## Greeting
+# Greeting
 - Hi
 - Good morning
 - Good evening
 - Hello
 
 
-## Help
+# Help
 - can you help
 - please help
 - I need help
 - help
 
 
-## None
+# None
 - who is your ceo?
 - santa wants a blue ribbon
 
 
-## setThermostat
+# setThermostat
 - Please set {deviceTemperature=thermostat to 72}
 - Set {deviceTemperature={customDevice=owen} to 72}
 
 
-## testIntent
+# testIntent
 - I need a flight from {datetimeV2:fromDate=tomorrow} and returning on {datetimeV2:toDate=next thursday}
 
 

--- a/packages/qnamaker/test/fixtures/verified/multiturn.json.qna
+++ b/packages/qnamaker/test/fixtures/verified/multiturn.json.qna
@@ -4,7 +4,7 @@
 
 <a id = "1"></a>
 
-## ? hello
+# ? hello
 
 **Filters:**
 - a = b
@@ -22,7 +22,7 @@ hi there
 
 <a id = "2"></a>
 
-## ? weather
+# ? weather
 
 ```markdown
 sure will get weather
@@ -32,7 +32,7 @@ sure will get weather
 
 <a id = "3"></a>
 
-## ? q2
+# ? q2
 - tell me a joke
 
 ```markdown
@@ -43,7 +43,7 @@ ha ha ha
 
 <a id = "32"></a>
 
-## ? book flight
+# ? book flight
 
 ```markdown
 sure. happy to help with that.
@@ -53,7 +53,7 @@ sure. happy to help with that.
 
 <a id = "4"></a>
 
-## ? batata
+# ? batata
 
 ```markdown
 tomato
@@ -63,7 +63,7 @@ tomato
 
 <a id = "5"></a>
 
-## ? testquestion
+# ? testquestion
 
 ```markdown
 test answer

--- a/packages/qnamaker/test/fixtures/verified/nDepthEntity.lu
+++ b/packages/qnamaker/test/fixtures/verified/nDepthEntity.lu
@@ -1,10 +1,10 @@
 
 > # Intent definitions
 
-## None
+# None
 
 
-## intent1
+# intent1
 
 
 @ intent intent1 usesFeatures simple1,phraselist1

--- a/packages/qnamaker/test/fixtures/verified/nDepthEntityInUtterance.lu
+++ b/packages/qnamaker/test/fixtures/verified/nDepthEntityInUtterance.lu
@@ -7,7 +7,7 @@
 
 > # Intent definitions
 
-## None
+# None
 - {@nDepth=i have {@nDepth_child1=17 years old}}
 - {@nDepth=i have {@nDepth_child1=18 years old}}
 - {@nDepth=i have {@nDepth_child1=19 years old}}

--- a/packages/qnamaker/test/fixtures/verified/newEntityWithFeatures.lu
+++ b/packages/qnamaker/test/fixtures/verified/newEntityWithFeatures.lu
@@ -9,12 +9,12 @@
 
 > # Intent definitions
 
-## Greeting
+# Greeting
 - Hi
 - Hello
 
 
-## GetUserProfile
+# GetUserProfile
 - I'm {@userProfile={@userAge=36}} years old
 - My age is {@userProfile={@userAge=36}}
 - My name is {@userProfile={@userName={@firstName=vishwac}}}

--- a/packages/qnamaker/test/fixtures/verified/plFeatures.lu
+++ b/packages/qnamaker/test/fixtures/verified/plFeatures.lu
@@ -9,10 +9,10 @@
 
 > # Intent definitions
 
-## None
+# None
 
 
-## intent1
+# intent1
 
 
 @ intent intent1 usesFeature phraselist1

--- a/packages/qnamaker/test/fixtures/verified/prebuilt_mode.lu
+++ b/packages/qnamaker/test/fixtures/verified/prebuilt_mode.lu
@@ -8,12 +8,12 @@
 
 > # Intent definitions
 
-## None
+# None
 
 
 > !# @intent.inherits = name : Web.WebSearch; domain_name : Web; model_name : WebSearch
 
-## Web.WebSearch
+# Web.WebSearch
 - open {Web.SearchText=pinterest.com}
 - {Web.SearchText=amazon.com}
 - {Web.SearchText=ancestry login}

--- a/packages/qnamaker/test/fixtures/verified/qna_sorted.lu
+++ b/packages/qnamaker/test/fixtures/verified/qna_sorted.lu
@@ -2,7 +2,7 @@
 
 > !# @qna.pair.source = custom editorial
 
-## ? get me your ceo info
+# ? get me your ceo info
 - Who is your ceo?
 
 ```markdown
@@ -11,7 +11,7 @@ Vishwac
 
 > !# @qna.pair.source = custom editorial
 
-## ? How do I change the default message
+# ? How do I change the default message
 
 ```markdown
 You can change the default message if you use the QnAMakerDialog.
@@ -20,7 +20,7 @@ See [this link](https://docs.botframework.com/en-us/azure-bot-service/templates/
 
 > !# @qna.pair.source = custom editorial
 
-## ? How do I programmatically update my KB?
+# ? How do I programmatically update my KB?
 
 ```markdown
 You can use our REST apis to manage your KB.
@@ -29,7 +29,7 @@ You can use our REST apis to manage your KB.
 
 > !# @qna.pair.source = custom editorial
 
-## ? I need coffee
+# ? I need coffee
 - Where can I get coffee?
 
 **Filters:**
@@ -41,7 +41,7 @@ You can get coffee in our Seattle store at 1 pike place, Seattle, WA
 
 > !# @qna.pair.source = custom editorial
 
-## ? I need coffee
+# ? I need coffee
 - Where can I get coffee?
 
 **Filters:**
@@ -53,7 +53,7 @@ You can get coffee in our Portland store at 52 marine drive, Portland, OR
 
 > !# @qna.pair.source = custom editorial
 
-## ? ludown cli
+# ? ludown cli
 - What is Ludown?
 - where can i get more information about ludown cli?
 

--- a/packages/qnamaker/test/fixtures/verified/sorted.lu
+++ b/packages/qnamaker/test/fixtures/verified/sorted.lu
@@ -1,7 +1,7 @@
 
 > # Intent definitions
 
-## AskForUserName
+# AskForUserName
 - {userName=vishwac}
 - I'm {userName=vishwac}
 - call me {userName=vishwac}
@@ -10,53 +10,53 @@
 - you can call me {userName=vishwac}
 
 
-## Buy chocolate
+# Buy chocolate
 - I would like to buy some kit kat
 - I want some twix
 - can I get some m&m
 
 
-## CommunicationPreference
+# CommunicationPreference
 - set phone call as my communication preference
 - I prefer to receive text message
 
 
-## CreateAlarm
+# CreateAlarm
 - create an alarm for 7AM
 - create an alarm
 - set an alarm for 7AM next thursday
 
 
-## DeleteAlarm
+# DeleteAlarm
 - delete the {alarmTime} alarm
 - remove the {alarmTime} alarm
 
 
-## Greeting
+# Greeting
 - Hi
 - Good morning
 - Good evening
 - Hello
 
 
-## Help
+# Help
 - can you help
 - please help
 - I need help
 - help
 
 
-## None
+# None
 - who is your ceo?
 - santa wants a blue ribbon
 
 
-## setThermostat
+# setThermostat
 - Please set {deviceTemperature=thermostat to 72}
 - Set {deviceTemperature={customDevice=owen} to 72}
 
 
-## testIntent
+# testIntent
 - I need a flight from {datetimeV2:fromDate=tomorrow} and returning on {datetimeV2:toDate=next thursday}
 
 
@@ -129,7 +129,7 @@ $units:[temperature]
 > # QnA pairs
 
 > Source: custom editorial
-## ? get me your ceo info
+# ? get me your ceo info
 - Who is your ceo?
 
 ```markdown
@@ -137,7 +137,7 @@ Vishwac
 ```
 
 > Source: custom editorial
-## ? How do I change the default message
+# ? How do I change the default message
 
 ```markdown
 You can change the default message if you use the QnAMakerDialog.
@@ -145,7 +145,7 @@ See [this link](https://docs.botframework.com/en-us/azure-bot-service/templates/
 ```
 
 > Source: custom editorial
-## ? How do I programmatically update my KB?
+# ? How do I programmatically update my KB?
 
 ```markdown
 You can use our REST apis to manage your KB.
@@ -153,7 +153,7 @@ You can use our REST apis to manage your KB.
 ```
 
 > Source: custom editorial
-## ? I need coffee
+# ? I need coffee
 - Where can I get coffee?
 
 
@@ -165,7 +165,7 @@ You can get coffee in our Seattle store at 1 pike place, Seattle, WA
 ```
 
 > Source: custom editorial
-## ? I need coffee
+# ? I need coffee
 - Where can I get coffee?
 
 
@@ -177,7 +177,7 @@ You can get coffee in our Portland store at 52 marine drive, Portland, OR
 ```
 
 > Source: custom editorial
-## ? ludown cli
+# ? ludown cli
 - What is Ludown?
 - where can i get more information about ludown cli?
 

--- a/packages/qnamaker/test/fixtures/verified/stdin-qna.lu
+++ b/packages/qnamaker/test/fixtures/verified/stdin-qna.lu
@@ -1,7 +1,7 @@
 > # QnA pairs
 
 > Source: custom editorial
-## ? How do I change the default message
+# ? How do I change the default message
 
 ```markdown
 You can change the default message if you use the QnAMakerDialog.
@@ -10,7 +10,7 @@ See [this link](https://docs.botframework.com/en-us/azure-bot-service/templates/
 ```
 
 > Source: custom editorial
-## ? How do I programmatically update my KB?
+# ? How do I programmatically update my KB?
 
 ```markdown
 You can use our REST apis to manage your KB.
@@ -19,7 +19,7 @@ You can use our REST apis to manage your KB.
 ```
 
 > Source: custom editorial
-## ? Who is your ceo?
+# ? Who is your ceo?
 - get me your ceo info
 
 ```markdown
@@ -28,7 +28,7 @@ Vishwac
 ```
 
 > Source: custom editorial
-## ? Where can I get coffee?
+# ? Where can I get coffee?
 - I need coffee
 
 
@@ -41,7 +41,7 @@ You can get coffee in our Seattle store at 1 pike place, Seattle, WA
 ```
 
 > Source: custom editorial
-## ? Where can I get coffee?
+# ? Where can I get coffee?
 - I need coffee
 
 
@@ -54,7 +54,7 @@ You can get coffee in our Portland store at 52 marine drive, Portland, OR
 ```
 
 > Source: custom editorial
-## ? What is Ludown?
+# ? What is Ludown?
 - ludown cli
 - where can i get more information about ludown cli?
 

--- a/packages/qnamaker/test/fixtures/verified/stdin.lu
+++ b/packages/qnamaker/test/fixtures/verified/stdin.lu
@@ -1,21 +1,21 @@
 
 > # Intent definitions
 
-## Greeting
+# Greeting
 - Hi
 - Hello
 - Good morning
 - Good evening
 
 
-## Help
+# Help
 - help
 - I need help
 - please help
 - can you help
 
 
-## AskForUserName
+# AskForUserName
 - {userName=vishwac}
 - I'm {userName=vishwac}
 - call me {userName=vishwac}
@@ -24,28 +24,28 @@
 - you can call me {userName=vishwac}
 
 
-## CreateAlarm
+# CreateAlarm
 - create an alarm
 - create an alarm for 7AM
 - set an alarm for 7AM next thursday
 
 
-## DeleteAlarm
+# DeleteAlarm
 - delete the {alarmTime} alarm
 - remove the {alarmTime} alarm
 
 
-## CommunicationPreference
+# CommunicationPreference
 - set phone call as my communication preference
 - I prefer to receive text message
 
 
-## None
+# None
 - who is your ceo?
 - santa wants a blue ribbon
 
 
-## Buy chocolate
+# Buy chocolate
 - can I get some m&m
 - I want some twix
 - I would like to buy some kit kat

--- a/packages/qnamaker/test/fixtures/verified/test269-d.lu
+++ b/packages/qnamaker/test/fixtures/verified/test269-d.lu
@@ -8,10 +8,10 @@
 
 > # Intent definitions
 
-## None
+# None
 
 
-## TestIntent
+# TestIntent
 - this is a {@EntityOne=one} and a {@EntityTwo=two} and a {@EntityOne=one} again
 
 

--- a/packages/qnamaker/test/fixtures/verified/zh-Hans/reduced.lu
+++ b/packages/qnamaker/test/fixtures/verified/zh-Hans/reduced.lu
@@ -1,5 +1,5 @@
 
-## ChangeCalendarEntry
+# ChangeCalendarEntry
 - 改变 {Subject=午餐约会} 从 {OriginalStartTime=11} - {OriginalEndTime=12} 自 {StartTime=12} - {EndTime=1 30} 
 - 移动我的 {OriginalStartTime=10过去10}   {Subject=医生预约} 自 {StartTime=10} 
 - 改变 {Subject=电影院}   {SlotAttribute=位置} 


### PR DESCRIPTION
Before changes, when calling luConverter or qnaConverter, it will add double hash before intent name for luis and double hash before first question for qnamaker which is confusing users since we are always using single hash now. After changes, it will only keep one hash when reconstructing the lu or qna files. Of course, double hash is still working for parsing. The changes here only apply for reconstructing lu or qna files from json object.