### PR TITLE
Adjust cross-train to use id as key-value instead of path in config

### DIFF
--- a/packages/lu/src/parser/cross-train/crossTrainer.js
+++ b/packages/lu/src/parser/cross-train/crossTrainer.js
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  */
 
-const helpers = require('../utils/helpers')
 const fileExtEnum = require('../utils/helpers').FileExtTypeEnum
 const luParser = require('../lufile/luParser')
 const SectionOperator = require('../lufile/sectionOperator')
@@ -46,10 +45,10 @@ module.exports = {
       const {rootIds, triggerRules, intentName, verbose} = crossTrainConfig
 
       // parse lu content to LUResource object
-      let {fileIdToResourceMap: luFileIdToResourceMap, allEmpty: allLuEmpty} = await parseAndValidateContent(luObjectArray, verbose, importResolver)
+      let {fileIdToResourceMap: luFileIdToResourceMap, allEmpty: allLuEmpty} = await parseAndValidateContent(luObjectArray, verbose, importResolver, fileExtEnum.LUFile)
 
       // parse qna content to LUResource object
-      let {fileIdToResourceMap: qnaFileIdToResourceMap, allEmpty: allQnAEmpty} = await parseAndValidateContent(qnaObjectArray, verbose, importResolver)
+      let {fileIdToResourceMap: qnaFileIdToResourceMap, allEmpty: allQnAEmpty} = await parseAndValidateContent(qnaObjectArray, verbose, importResolver, fileExtEnum.QnAFile)
 
       if (!allLuEmpty) {
         // construct resource tree to build the father-children relationship among lu files
@@ -181,8 +180,7 @@ const mergeRootInterruptionToLeaves = function (rootResource, result, qnaFileToR
   for (const child of rootResource.children) {
     let childResource = result.get(child.target)
     if (childResource && childResource.visited === undefined) {
-      let rootQnaFileId = rootResource.id.toLowerCase().replace(new RegExp(helpers.FileExtTypeEnum.LUFile + '$'), helpers.FileExtTypeEnum.QnAFile)
-      rootQnaFileId = Array.from(qnaFileToResourceMap.keys()).find(x => x.toLowerCase() === rootQnaFileId)
+      const rootQnaFileId = Array.from(qnaFileToResourceMap.keys()).find(x => x.toLowerCase() === rootResource.id.toLowerCase())
       const rootQnaResource = qnaFileToResourceMap.get(rootQnaFileId)
       const newChildResource = mergeFatherInterruptionToChild(rootResource, rootQnaResource, childResource, intentName)
       result.set(child.target, newChildResource)
@@ -356,12 +354,11 @@ const extractIntentUtterances = function(resource, intentName) {
 const qnaCrossTrain = function (qnaFileIdToResourceMap, luFileIdToResourceMap, interruptionIntentName, allLuEmpty) {
   try {
     for (const qnaObjectId of Array.from(qnaFileIdToResourceMap.keys())) {
-      let luObjectId = qnaObjectId.toLowerCase().replace(new RegExp(helpers.FileExtTypeEnum.QnAFile + '$'), helpers.FileExtTypeEnum.LUFile)
       let fileName = path.basename(qnaObjectId, path.extname(qnaObjectId))
       const culture = fileHelper.getCultureFromPath(qnaObjectId)
       fileName = culture ? fileName.substring(0, fileName.length - culture.length - 1) : fileName
 
-      luObjectId = Array.from(luFileIdToResourceMap.keys()).find(x => x.toLowerCase() === luObjectId)
+      const luObjectId = Array.from(luFileIdToResourceMap.keys()).find(x => x.toLowerCase() === qnaObjectId.toLowerCase())
       if (luObjectId) {
         const { luResource, qnaResource } = qnaCrossTrainCore(luFileIdToResourceMap.get(luObjectId), qnaFileIdToResourceMap.get(qnaObjectId), fileName, interruptionIntentName, allLuEmpty)
         luFileIdToResourceMap.set(luObjectId, luResource)
@@ -506,16 +503,17 @@ const qnaAddMetaData = function (qnaResource, fileName) {
  * @param {luObject[]} objectArray the lu or qna object list to be parsed
  * @param {boolean} verbose indicate to enable log messages or not
  * @param {any} importResolver import Resolver when resolving import files
+ * @param {any} fileExt file extension to indicate the file is .lu or .qna format 
  * @returns {Map<string, LUResource>} map of file id and luResource
  * @throws {exception} throws errors
  */
-const parseAndValidateContent = async function (objectArray, verbose, importResolver) {
+const parseAndValidateContent = async function (objectArray, verbose, importResolver, fileExt) {
   let fileIdToResourceMap = new Map()
   let allEmpty = true
   for (const object of objectArray) {    
     let fileContent = object.content
     if (object.content && object.content !== '') {
-      if (object.id.toLowerCase().endsWith(fileExtEnum.LUFile)) {
+      if (fileExt === fileExtEnum.LUFile) {
         let result = await LuisBuilderVerbose.build([object], verbose, undefined, importResolver)
         let luisObj = new Luis(result)
         fileContent = luisObj.parseToLuContent()

--- a/packages/lu/src/parser/cross-train/crossTrainer.js
+++ b/packages/lu/src/parser/cross-train/crossTrainer.js
@@ -37,7 +37,6 @@ module.exports = {
 
       const crossTrainConfig = fileHelper.getConfigObject(
         configObject,
-        options.configId,
         options.intentName || '_Interruption',
         options.verbose || true)
 

--- a/packages/lu/src/utils/filehelper.ts
+++ b/packages/lu/src/utils/filehelper.ts
@@ -220,7 +220,7 @@ export function getParsedObjects(contents: {id: string, content: string}[]) {
   return parsedObjects
 }
 
-export function getConfigObject(configObject: any, configId: string, intentName: string, verbose: boolean) {
+export function getConfigObject(configObject: any, intentName: string, verbose: boolean) {
   let finalConfigObj = Object.create(null)
   let rootFileIds: string[] = []
   if (configObject) {

--- a/packages/lu/src/utils/filehelper.ts
+++ b/packages/lu/src/utils/filehelper.ts
@@ -172,7 +172,7 @@ export async function getFilesContent(input: string, extType: string) {
   if (fileStat.isFile()) {
     const filePath = path.resolve(input)
     const content = await getContentFromFile(input)
-    return [{id: filePath, content}]
+    return [{id: path.basename(filePath, extType), content}]
   }
 
   if (!fileStat.isDirectory()) {
@@ -182,7 +182,7 @@ export async function getFilesContent(input: string, extType: string) {
   return Promise.all(paths.map(async (item: string) => {
     const itemPath = path.resolve(path.join(input, item))
     const content = await getContentFromFile(itemPath)
-    return {id: itemPath, content}
+    return {id: path.basename(itemPath, extType), content}
   }))
 }
 
@@ -221,36 +221,33 @@ export function getParsedObjects(contents: {id: string, content: string}[]) {
 }
 
 export function getConfigObject(configObject: any, configId: string, intentName: string, verbose: boolean) {
-  let finalLuConfigObj = Object.create(null)
-  let rootLuFiles: string[] = []
-  const configFileDir = configId && configId !== '' ? path.dirname(configId) : undefined
+  let finalConfigObj = Object.create(null)
+  let rootFileIds: string[] = []
   if (configObject) {
     try {
-      for (const rootluFilePath of Object.keys(configObject)) {
-        const rootLuFileFullPath = configFileDir ? path.resolve(configFileDir, rootluFilePath) : rootluFilePath
-        const triggerObj = configObject[rootluFilePath]
+      for (const rootFileId of Object.keys(configObject)) {
+        const triggerObj = configObject[rootFileId]
         for (const triggerObjKey of Object.keys(triggerObj)) {
           if (triggerObjKey === 'rootDialog') {
             if (triggerObj[triggerObjKey]) {
-              rootLuFiles.push(rootLuFileFullPath)
+              rootFileIds.push(rootFileId)
             }
           } else if (triggerObjKey === 'triggers') {
             const triggers = triggerObj[triggerObjKey]
             for (const triggerKey of Object.keys(triggers)) {
-              const destLuFiles = triggers[triggerKey] instanceof Array ? triggers[triggerKey] : [triggers[triggerKey]]
-              for (const destLuFile of destLuFiles) {
-                const destLuFileFullPath = configFileDir && destLuFile && destLuFile !== '' ? path.resolve(configFileDir, destLuFile) : destLuFile
-                if (rootLuFileFullPath in finalLuConfigObj) {
-                  const finalIntentToDestLuFiles = finalLuConfigObj[rootLuFileFullPath]
-                  if (finalIntentToDestLuFiles[triggerKey]) {
-                    finalIntentToDestLuFiles[triggerKey].push(destLuFileFullPath)
+              const destFileIds = triggers[triggerKey] instanceof Array ? triggers[triggerKey] : [triggers[triggerKey]]
+              for (const destFileId of destFileIds) {
+                if (rootFileId in finalConfigObj) {
+                  let finalIntentToDestFileIds = finalConfigObj[rootFileId]
+                  if (finalIntentToDestFileIds[triggerKey]) {
+                    finalIntentToDestFileIds[triggerKey].push(destFileId)
                   } else {
-                    finalIntentToDestLuFiles[triggerKey] = [destLuFileFullPath]
+                    finalIntentToDestFileIds[triggerKey] = [destFileId]
                   }
                 } else {
-                  let finalIntentToDestLuFiles = Object.create(null)
-                  finalIntentToDestLuFiles[triggerKey] = [destLuFileFullPath]
-                  finalLuConfigObj[rootLuFileFullPath] = finalIntentToDestLuFiles
+                  let finalIntentToDestFileIds = Object.create(null)
+                  finalIntentToDestFileIds[triggerKey] = [destFileId]
+                  finalConfigObj[rootFileId] = finalIntentToDestFileIds
                 }
               }
             }
@@ -263,8 +260,8 @@ export function getConfigObject(configObject: any, configId: string, intentName:
   }
 
   let crossTrainConfig = {
-    rootIds: rootLuFiles,
-    triggerRules: finalLuConfigObj,
+    rootIds: rootFileIds,
+    triggerRules: finalConfigObj,
     intentName,
     verbose
   }

--- a/packages/lu/test/parser/cross-train/crossTrainer.test.js
+++ b/packages/lu/test/parser/cross-train/crossTrainer.test.js
@@ -26,7 +26,7 @@ describe('luis:cross training tests among lu and qna contents', () => {
         # dia2_trigger
         - book a flight for me
         - book a train ticket for me`,
-      id: 'Main.lu'})
+      id: 'Main'})
 
     qnaContentArray.push({
       content:
@@ -43,14 +43,14 @@ describe('luis:cross training tests among lu and qna contents', () => {
         \`\`\`
             tell a funny joke
         \`\`\``,
-      id: 'Main.qna'}
+      id: 'Main'}
     )
 
     luContentArray.push({
       content:
         `# dia1_trigger
         - réserver un hôtel`,
-      id: 'main.fr-fr.lu'}
+      id: 'main.fr-fr'}
     )
 
     qnaContentArray.push({
@@ -63,7 +63,7 @@ describe('luis:cross training tests among lu and qna contents', () => {
         \`\`\`
             Voici le [guide de l'utilisateur] (http://contoso.com/userguide.pdf)
         \`\`\``,
-      id: 'main.fr-fr.qna'}
+      id: 'main.fr-fr'}
     )
 
     luContentArray.push({
@@ -75,7 +75,7 @@ describe('luis:cross training tests among lu and qna contents', () => {
         
         # hotelLocation
         - can I book a hotel near Space Needle`,
-      id: 'Dia1.lu'}
+      id: 'Dia1'}
     )
 
     qnaContentArray.push({
@@ -94,7 +94,7 @@ describe('luis:cross training tests among lu and qna contents', () => {
         \`\`\`
             of course you can
         \`\`\``,
-      id: 'dia1.qna'}
+      id: 'dia1'}
     )
 
     luContentArray.push({
@@ -104,7 +104,7 @@ describe('luis:cross training tests among lu and qna contents', () => {
         
         # hotelLocation
         - puis-je réserver un hôtel près de l'aiguille spatiale`,
-      id: 'dia1.fr-fr.lu'}
+      id: 'dia1.fr-fr'}
     )
 
     qnaContentArray.push({
@@ -114,7 +114,7 @@ describe('luis:cross training tests among lu and qna contents', () => {
         \`\`\`
             ha ha ha
         \`\`\``,
-      id: 'dia1.fr-fr.qna'}
+      id: 'dia1.fr-fr'}
     )
 
     luContentArray.push({
@@ -124,7 +124,7 @@ describe('luis:cross training tests among lu and qna contents', () => {
         
         # dia4_trigger
         - book a train ticket from Seattle to Portland`,
-      id: 'Dia2.lu'}
+      id: 'Dia2'}
     )
 
     qnaContentArray.push({
@@ -138,7 +138,7 @@ describe('luis:cross training tests among lu and qna contents', () => {
         \`\`\`
             ha ha ha
         \`\`\``,
-     id: 'dia2.qna'}
+     id: 'dia2'}
     )
 
     luContentArray.push({
@@ -148,12 +148,12 @@ describe('luis:cross training tests among lu and qna contents', () => {
         
         # flightTime
         - which {flightTime} do you prefer`,
-      id: 'dia3.lu'}
+      id: 'dia3'}
     )
 
     qnaContentArray.push({
       content: ``,
-      id: 'dia3.qna'
+      id: 'dia3'
     })
 
     luContentArray.push({
@@ -163,7 +163,7 @@ describe('luis:cross training tests among lu and qna contents', () => {
         
         # railwayTime
         - when do you want to leave from Seattle train station`,
-      id: 'dia4.lu'})
+      id: 'dia4'})
 
     qnaContentArray.push({
       content:
@@ -171,27 +171,27 @@ describe('luis:cross training tests among lu and qna contents', () => {
       \`\`\`
       should add filter meta data here
       \`\`\``,
-      id: 'dia5.qna'
+      id: 'dia5'
     })
 
     const configObject = {
-      'main.lu': {
+      'main': {
         'rootDialog': true,
         'triggers': {
-          'dia1_trigger': 'dia1.lu',
-          'dia2_trigger': 'dia2.lu'
+          'dia1_trigger': 'dia1',
+          'dia2_trigger': 'dia2'
         }
       },
-      'dia2.lu': {
+      'dia2': {
         'triggers': {
-          'dia3_trigger': 'dia3.lu',
-          'dia4_trigger': 'dia4.lu'
+          'dia3_trigger': 'dia3',
+          'dia4_trigger': 'dia4'
         }
       },
-      'main.fr-fr.lu': {
+      'main.fr-fr': {
         'rootDialog': true,
         'triggers': {
-          'dia1_trigger': 'dia1.fr-fr.lu'
+          'dia1_trigger': 'dia1.fr-fr'
         }
       }
     }
@@ -200,91 +200,91 @@ describe('luis:cross training tests among lu and qna contents', () => {
     const luResult = trainedResult.luResult
     const qnaResult = trainedResult.qnaResult
 
-    let foundIndex = luResult.get('Main.lu').Sections.findIndex(s => s.Name === 'DeferToRecognizer_QnA_Main')
+    let foundIndex = luResult.get('Main').Sections.findIndex(s => s.Name === 'DeferToRecognizer_QnA_Main')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('Main.lu').Sections[foundIndex].Body, `- user guide${NEWLINE}- tell joke`)
+    assert.equal(luResult.get('Main').Sections[foundIndex].Body, `- user guide${NEWLINE}- tell joke`)
 
-    foundIndex = qnaResult.get('Main.qna').Sections.findIndex(s => s.Answer === 'intent=DeferToRecognizer_LUIS_Main')
+    foundIndex = qnaResult.get('Main').Sections.findIndex(s => s.Answer === 'intent=DeferToRecognizer_LUIS_Main')
     assert.isTrue(foundIndex > -1)
-    assert.equal(qnaResult.get('Main.qna').Sections[foundIndex].FilterPairs[0].key, 'dialogName')
-    assert.equal(qnaResult.get('Main.qna').Sections[foundIndex].FilterPairs[0].value, 'Main')
-    assert.equal(qnaResult.get('Main.qna').Sections[foundIndex].Questions[0], 'book a hotel for me')
-    assert.equal(qnaResult.get('Main.qna').Sections[foundIndex].Questions[2], 'book a train ticket for me')
+    assert.equal(qnaResult.get('Main').Sections[foundIndex].FilterPairs[0].key, 'dialogName')
+    assert.equal(qnaResult.get('Main').Sections[foundIndex].FilterPairs[0].value, 'Main')
+    assert.equal(qnaResult.get('Main').Sections[foundIndex].Questions[0], 'book a hotel for me')
+    assert.equal(qnaResult.get('Main').Sections[foundIndex].Questions[2], 'book a train ticket for me')
 
-    foundIndex = luResult.get('Dia1.lu').Sections.findIndex(s => s.ModelInfo === '> !# @app.name = my luis application')
+    foundIndex = luResult.get('Dia1').Sections.findIndex(s => s.ModelInfo === '> !# @app.name = my luis application')
     assert.isTrue(foundIndex > -1)
 
-    foundIndex = luResult.get('Dia1.lu').Sections.findIndex(s => s.Name === '_Interruption')
+    foundIndex = luResult.get('Dia1').Sections.findIndex(s => s.Name === '_Interruption')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('Dia1.lu').Sections[foundIndex].Body, `- book a flight for me${NEWLINE}- book a train ticket for me${NEWLINE}- user guide${NEWLINE}${NEWLINE}> Source: cross training. Please do not edit these directly!`)
+    assert.equal(luResult.get('Dia1').Sections[foundIndex].Body, `- book a flight for me${NEWLINE}- book a train ticket for me${NEWLINE}- user guide${NEWLINE}${NEWLINE}> Source: cross training. Please do not edit these directly!`)
     
-    foundIndex = luResult.get('Dia1.lu').Sections.findIndex(s => s.Name === 'DeferToRecognizer_QnA_dia1')
+    foundIndex = luResult.get('Dia1').Sections.findIndex(s => s.Name === 'DeferToRecognizer_QnA_dia1')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('Dia1.lu').Sections[foundIndex].Body, `- tell Joke${NEWLINE}- tell me a joke`)
+    assert.equal(luResult.get('Dia1').Sections[foundIndex].Body, `- tell Joke${NEWLINE}- tell me a joke`)
 
-    foundIndex = qnaResult.get('dia1.qna').Sections.findIndex(s => s.FilterPairs && s.FilterPairs[0].key === 'dialogName')
+    foundIndex = qnaResult.get('dia1').Sections.findIndex(s => s.FilterPairs && s.FilterPairs[0].key === 'dialogName')
     assert.isTrue(foundIndex > -1)
-    assert.equal(qnaResult.get('dia1.qna').Sections[foundIndex].FilterPairs[0].value, 'dia1')
+    assert.equal(qnaResult.get('dia1').Sections[foundIndex].FilterPairs[0].value, 'dia1')
 
-    foundIndex = qnaResult.get('dia1.qna').Sections.findIndex(s => s.Questions.join(', ') === 'I need a four star hotel, book a flight for me, book a train ticket for me, user guide')
+    foundIndex = qnaResult.get('dia1').Sections.findIndex(s => s.Questions.join(', ') === 'I need a four star hotel, book a flight for me, book a train ticket for me, user guide')
     assert.isTrue(foundIndex > -1)
 
-    foundIndex = luResult.get('Dia2.lu').Sections.findIndex(s => s.Name === '_Interruption')
+    foundIndex = luResult.get('Dia2').Sections.findIndex(s => s.Name === '_Interruption')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('Dia2.lu').Sections[foundIndex].Name, '_Interruption')
-    assert.equal(luResult.get('Dia2.lu').Sections[foundIndex].Body, `- book a hotel for me${NEWLINE}- user guide${NEWLINE}- tell joke${NEWLINE}${NEWLINE}> Source: cross training. Please do not edit these directly!`)
+    assert.equal(luResult.get('Dia2').Sections[foundIndex].Name, '_Interruption')
+    assert.equal(luResult.get('Dia2').Sections[foundIndex].Body, `- book a hotel for me${NEWLINE}- user guide${NEWLINE}- tell joke${NEWLINE}${NEWLINE}> Source: cross training. Please do not edit these directly!`)
     
-    foundIndex = luResult.get('Dia2.lu').Sections.findIndex(s => s.Name === 'DeferToRecognizer_QnA_dia2')
+    foundIndex = luResult.get('Dia2').Sections.findIndex(s => s.Name === 'DeferToRecognizer_QnA_dia2')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('Dia2.lu').Sections[foundIndex].Body, `- sing song${NEWLINE}- tell a joke`)
+    assert.equal(luResult.get('Dia2').Sections[foundIndex].Body, `- sing song${NEWLINE}- tell a joke`)
 
-    foundIndex = qnaResult.get('dia2.qna').Sections.findIndex(s => s.FilterPairs && s.FilterPairs[0].key === 'dialogName')
+    foundIndex = qnaResult.get('dia2').Sections.findIndex(s => s.FilterPairs && s.FilterPairs[0].key === 'dialogName')
     assert.isTrue(foundIndex > -1)
-    assert.equal(qnaResult.get('dia2.qna').Sections[foundIndex].FilterPairs[0].value, 'dia2')
+    assert.equal(qnaResult.get('dia2').Sections[foundIndex].FilterPairs[0].value, 'dia2')
 
-    foundIndex = qnaResult.get('dia2.qna').Sections.findIndex(s => s.Questions.join(', ') === 'book a flight from Seattle to Beijing, book a train ticket from Seattle to Portland, book a hotel for me, user guide, tell joke')
+    foundIndex = qnaResult.get('dia2').Sections.findIndex(s => s.Questions.join(', ') === 'book a flight from Seattle to Beijing, book a train ticket from Seattle to Portland, book a hotel for me, user guide, tell joke')
     assert.isTrue(foundIndex > -1)
 
-    assert.equal(luResult.get('dia3.lu').Sections.length, 6)
-    foundIndex = luResult.get('dia3.lu').Sections.findIndex(s => s.Name === '_Interruption')
+    assert.equal(luResult.get('dia3').Sections.length, 6)
+    foundIndex = luResult.get('dia3').Sections.findIndex(s => s.Name === '_Interruption')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('dia3.lu').Sections[foundIndex].Body, `- book a train ticket from Seattle to Portland${NEWLINE}- book a hotel for me${NEWLINE}- user guide${NEWLINE}- tell joke${NEWLINE}- sing song${NEWLINE}- tell a joke`)
+    assert.equal(luResult.get('dia3').Sections[foundIndex].Body, `- book a train ticket from Seattle to Portland${NEWLINE}- book a hotel for me${NEWLINE}- user guide${NEWLINE}- tell joke${NEWLINE}- sing song${NEWLINE}- tell a joke`)
 
-    assert.equal(qnaResult.get('dia3.qna').Sections.length, 1)
-    assert.equal(qnaResult.get('dia3.qna').Sections[0].Answer, 'intent=DeferToRecognizer_LUIS_dia3')
+    assert.equal(qnaResult.get('dia3').Sections.length, 1)
+    assert.equal(qnaResult.get('dia3').Sections[0].Answer, 'intent=DeferToRecognizer_LUIS_dia3')
 
-    assert.equal(luResult.get('dia4.lu').Sections.length, 6)
-    foundIndex = luResult.get('dia4.lu').Sections.findIndex(s => s.Name === '_Interruption')
+    assert.equal(luResult.get('dia4').Sections.length, 6)
+    foundIndex = luResult.get('dia4').Sections.findIndex(s => s.Name === '_Interruption')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('dia4.lu').Sections[foundIndex].Body, `- book a flight from Seattle to Beijing${NEWLINE}- book a hotel for me${NEWLINE}- user guide${NEWLINE}- tell joke${NEWLINE}- sing song${NEWLINE}- tell a joke`)
+    assert.equal(luResult.get('dia4').Sections[foundIndex].Body, `- book a flight from Seattle to Beijing${NEWLINE}- book a hotel for me${NEWLINE}- user guide${NEWLINE}- tell joke${NEWLINE}- sing song${NEWLINE}- tell a joke`)
 
     // test add meta data for qna files only
-    assert.equal(qnaResult.get('dia5.qna').Sections.length, 1)
-    assert.equal(qnaResult.get('dia5.qna').Sections[0].Answer, 'should add filter meta data here')
-    foundIndex = qnaResult.get('dia5.qna').Sections.findIndex(s => s.FilterPairs && s.FilterPairs[0].key === 'dialogName')
+    assert.equal(qnaResult.get('dia5').Sections.length, 1)
+    assert.equal(qnaResult.get('dia5').Sections[0].Answer, 'should add filter meta data here')
+    foundIndex = qnaResult.get('dia5').Sections.findIndex(s => s.FilterPairs && s.FilterPairs[0].key === 'dialogName')
     assert.isTrue(foundIndex > -1)
-    assert.equal(qnaResult.get('dia5.qna').Sections[foundIndex].FilterPairs[0].value, 'dia5')
+    assert.equal(qnaResult.get('dia5').Sections[foundIndex].FilterPairs[0].value, 'dia5')
 
-    foundIndex = luResult.get('main.fr-fr.lu').Sections.findIndex(s => s.Name === 'DeferToRecognizer_QnA_main')
+    foundIndex = luResult.get('main.fr-fr').Sections.findIndex(s => s.Name === 'DeferToRecognizer_QnA_main')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('main.fr-fr.lu').Sections[foundIndex].Body, `- guide de l'utilisateur`)
+    assert.equal(luResult.get('main.fr-fr').Sections[foundIndex].Body, `- guide de l'utilisateur`)
 
-    foundIndex = qnaResult.get('main.fr-fr.qna').Sections.findIndex(s => s.Answer === 'intent=DeferToRecognizer_LUIS_main')
+    foundIndex = qnaResult.get('main.fr-fr').Sections.findIndex(s => s.Answer === 'intent=DeferToRecognizer_LUIS_main')
     assert.isTrue(foundIndex > -1)
-    assert.equal(qnaResult.get('main.fr-fr.qna').Sections[foundIndex].FilterPairs[0].key, 'dialogName')
-    assert.equal(qnaResult.get('main.fr-fr.qna').Sections[foundIndex].FilterPairs[0].value, 'main')
-    assert.equal(qnaResult.get('main.fr-fr.qna').Sections[foundIndex].Questions.length, 1)
-    assert.equal(qnaResult.get('main.fr-fr.qna').Sections[foundIndex].Questions[0], 'réserver un hôtel')
+    assert.equal(qnaResult.get('main.fr-fr').Sections[foundIndex].FilterPairs[0].key, 'dialogName')
+    assert.equal(qnaResult.get('main.fr-fr').Sections[foundIndex].FilterPairs[0].value, 'main')
+    assert.equal(qnaResult.get('main.fr-fr').Sections[foundIndex].Questions.length, 1)
+    assert.equal(qnaResult.get('main.fr-fr').Sections[foundIndex].Questions[0], 'réserver un hôtel')
 
-    foundIndex = luResult.get('dia1.fr-fr.lu').Sections.findIndex(s => s.Name === '_Interruption')
+    foundIndex = luResult.get('dia1.fr-fr').Sections.findIndex(s => s.Name === '_Interruption')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('dia1.fr-fr.lu').Sections[foundIndex].Body, `- guide de l'utilisateur${NEWLINE}${NEWLINE}> Source: cross training. Please do not edit these directly!`)
+    assert.equal(luResult.get('dia1.fr-fr').Sections[foundIndex].Body, `- guide de l'utilisateur${NEWLINE}${NEWLINE}> Source: cross training. Please do not edit these directly!`)
     
-    foundIndex = luResult.get('dia1.fr-fr.lu').Sections.findIndex(s => s.Name === 'DeferToRecognizer_QnA_dia1')
+    foundIndex = luResult.get('dia1.fr-fr').Sections.findIndex(s => s.Name === 'DeferToRecognizer_QnA_dia1')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('dia1.fr-fr.lu').Sections[foundIndex].Body, '- raconter la blague')
+    assert.equal(luResult.get('dia1.fr-fr').Sections[foundIndex].Body, '- raconter la blague')
 
-    foundIndex = qnaResult.get('dia1.fr-fr.qna').Sections.findIndex(s => s.Questions.join(', ') === 'J\'ai besoin d\'un hôtel quatre étoiles, puis-je réserver un hôtel près de l\'aiguille spatiale, guide de l\'utilisateur')
+    foundIndex = qnaResult.get('dia1.fr-fr').Sections.findIndex(s => s.Questions.join(', ') === 'J\'ai besoin d\'un hôtel quatre étoiles, puis-je réserver un hôtel près de l\'aiguille spatiale, guide de l\'utilisateur')
     assert.isTrue(foundIndex > -1)
   })
 
@@ -302,29 +302,29 @@ describe('luis:cross training tests among lu and qna contents', () => {
                     
         #dia2_trigger
         - book a hotel for me`,
-      id:'./main/main.lu'}
+      id:'./main/main'}
     )
 
     luContentArray.push({
       content:
         `# FlightTime
         - which {flightTime} do you prefer`,
-      id:'./dia1/dia1.lu'}
+      id:'./dia1/dia1'}
     )
 
     luContentArray.push({
       content:
         `# HotelLevel
         - which hotel star do you prefer`,
-      id:'./dia2/dia2.lu'}
+      id:'./dia2/dia2'}
     )
 
     let crossTrainConfig = {
-      './main/main.lu': {
+      './main/main': {
         'rootDialog': true,
         'triggers': {
-          'dia1_trigger': './dia1/dia1.lu',
-          'dia2_trigger': './dia2/dia2.lu'
+          'dia1_trigger': './dia1/dia1',
+          'dia2_trigger': './dia2/dia2'
         }
       }
     }
@@ -332,9 +332,9 @@ describe('luis:cross training tests among lu and qna contents', () => {
     const trainedResult = await crossTrainer.crossTrain(luContentArray, [], crossTrainConfig)
     const luResult = trainedResult.luResult
 
-    let foundIndex = luResult.get('./dia2/dia2.lu').Sections.findIndex(s => s.Name === '_Interruption')
+    let foundIndex = luResult.get('./dia2/dia2').Sections.findIndex(s => s.Name === '_Interruption')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('./dia2/dia2.lu').Sections[foundIndex].Body, `- book a flight for me`)
+    assert.equal(luResult.get('./dia2/dia2').Sections[foundIndex].Body, `- book a flight for me`)
   })
 
   it('luis:cross training can get expected result when multiple dialog invocations occur in same trigger', async () => {
@@ -347,36 +347,36 @@ describe('luis:cross training tests among lu and qna contents', () => {
                     
         #dia2_trigger
         - book a hotel for me`,
-      id: './main/main.lu'}
+      id: './main/main'}
     )
 
     luContentArray.push({
       content:
         `# bookFlight
         - book a flight for me`,
-      id: './dia1/dia1.lu'}
+      id: './dia1/dia1'}
     )
 
     luContentArray.push({
       content:
         `# bookTrain
         - book a train ticket for me`,
-      id: './dia2/dia2.lu'}
+      id: './dia2/dia2'}
     )
 
     luContentArray.push({
       content:
         `# HotelLevel
         - I prefer 4 stars hotel`,
-      id: './dia3/dia3.lu'}
+      id: './dia3/dia3'}
     )
 
     let crossTrainConfig = {
-      './main/main.lu': {
+      './main/main': {
         'rootDialog': true,
         'triggers': {
-          'dia1_trigger': ['./dia1/dia1.lu', './dia2/dia2.lu'],
-          'dia2_trigger': './dia3/dia3.lu'
+          'dia1_trigger': ['./dia1/dia1', './dia2/dia2'],
+          'dia2_trigger': './dia3/dia3'
         }
       }
     }
@@ -384,17 +384,17 @@ describe('luis:cross training tests among lu and qna contents', () => {
     const trainedResult = await crossTrainer.crossTrain(luContentArray, [], crossTrainConfig)
     const luResult = trainedResult.luResult
 
-    let foundIndex = luResult.get('./dia1/dia1.lu').Sections.findIndex(s => s.Name === '_Interruption')
+    let foundIndex = luResult.get('./dia1/dia1').Sections.findIndex(s => s.Name === '_Interruption')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('./dia1/dia1.lu').Sections[foundIndex].Body, `- book a hotel for me`)
+    assert.equal(luResult.get('./dia1/dia1').Sections[foundIndex].Body, `- book a hotel for me`)
 
-    foundIndex = luResult.get('./dia2/dia2.lu').Sections.findIndex(s => s.Name === '_Interruption')
+    foundIndex = luResult.get('./dia2/dia2').Sections.findIndex(s => s.Name === '_Interruption')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('./dia2/dia2.lu').Sections[foundIndex].Body, '- book a hotel for me')
+    assert.equal(luResult.get('./dia2/dia2').Sections[foundIndex].Body, '- book a hotel for me')
 
-    foundIndex = luResult.get('./dia3/dia3.lu').Sections.findIndex(s => s.Name === '_Interruption')
+    foundIndex = luResult.get('./dia3/dia3').Sections.findIndex(s => s.Name === '_Interruption')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('./dia3/dia3.lu').Sections[foundIndex].Body, '- I want to travel to Seattle')
+    assert.equal(luResult.get('./dia3/dia3').Sections[foundIndex].Body, '- I want to travel to Seattle')
   })
 
   it('luis:cross training can get expected result when local intents exist', async () => {
@@ -410,7 +410,7 @@ describe('luis:cross training tests among lu and qna contents', () => {
         
         # local_intent
         - help`,
-      id: './main/main.lu'}
+      id: './main/main'}
     )
 
     luContentArray.push({
@@ -418,22 +418,22 @@ describe('luis:cross training tests among lu and qna contents', () => {
         `# bookTicket
         - book a flight for me
         - book a train ticket for me`,
-      id: './dia1/dia1.lu'}
+      id: './dia1/dia1'}
     )
 
     luContentArray.push({
       content:
         `# hotelLevel
         - I prefer 4 stars hotel`,
-      id: './dia2/dia2.lu'}
+      id: './dia2/dia2'}
     )
 
     let crossTrainConfig = {
-      './main/main.lu': {
+      './main/main': {
         'rootDialog': true,
         'triggers': {
-          'dia1_trigger': './dia1/dia1.lu',
-          'dia2_trigger': './dia2/dia2.lu'
+          'dia1_trigger': './dia1/dia1',
+          'dia2_trigger': './dia2/dia2'
         }
       }
     }
@@ -441,13 +441,13 @@ describe('luis:cross training tests among lu and qna contents', () => {
     const trainedResult = await crossTrainer.crossTrain(luContentArray, [], crossTrainConfig)
     const luResult = trainedResult.luResult
 
-    let foundIndex = luResult.get('./dia1/dia1.lu').Sections.findIndex(s => s.Name === '_Interruption')
+    let foundIndex = luResult.get('./dia1/dia1').Sections.findIndex(s => s.Name === '_Interruption')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('./dia1/dia1.lu').Sections[foundIndex].Body, `- book a hotel for me`)
+    assert.equal(luResult.get('./dia1/dia1').Sections[foundIndex].Body, `- book a hotel for me`)
 
-    foundIndex = luResult.get('./dia2/dia2.lu').Sections.findIndex(s => s.Name === '_Interruption')
+    foundIndex = luResult.get('./dia2/dia2').Sections.findIndex(s => s.Name === '_Interruption')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('./dia2/dia2.lu').Sections[foundIndex].Body, `- I want to travel to Seattle`)
+    assert.equal(luResult.get('./dia2/dia2').Sections[foundIndex].Body, `- I want to travel to Seattle`)
   })
 
   it('luis:cross training can get expected result when trigger intent or dialog is empty', async () => {
@@ -463,7 +463,7 @@ describe('luis:cross training tests among lu and qna contents', () => {
         
         # dia3_trigger
         - cancel`,
-      id: './main/main.lu'}
+      id: './main/main'}
     )
 
     luContentArray.push({
@@ -471,31 +471,31 @@ describe('luis:cross training tests among lu and qna contents', () => {
         `# bookTicket
         - book a flight for me
         - book a train ticket for me`,
-      id: './dia1/dia1.lu'}
+      id: './dia1/dia1'}
     )
 
     luContentArray.push({
       content:
         `# hotelLevel
         - I prefer 4 stars hotel`,
-      id: './dia2/dia2.lu'}
+      id: './dia2/dia2'}
     )
 
     luContentArray.push({
       content:
         `# help
         - can I help you`,
-      id: './dia3/dia3.lu'}
+      id: './dia3/dia3'}
     )
 
     let crossTrainConfig = {
-      './main/main.lu': {
+      './main/main': {
         'rootDialog': true,
         'triggers': {
-          'dia1_trigger': './dia1/dia1.lu',
-          'dia2_trigger': './dia2/dia2.lu',
+          'dia1_trigger': './dia1/dia1',
+          'dia2_trigger': './dia2/dia2',
           'dia3_trigger': '',
-          '': './dia3/dia3.lu'
+          '': './dia3/dia3'
         }
       }
     }
@@ -503,17 +503,17 @@ describe('luis:cross training tests among lu and qna contents', () => {
     const trainedResult = await crossTrainer.crossTrain(luContentArray, [], crossTrainConfig)
     const luResult = trainedResult.luResult
 
-    let foundIndex = luResult.get('./dia1/dia1.lu').Sections.findIndex(s => s.Name === '_Interruption')
+    let foundIndex = luResult.get('./dia1/dia1').Sections.findIndex(s => s.Name === '_Interruption')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('./dia1/dia1.lu').Sections[foundIndex].Body, `- book a hotel for me${NEWLINE}- cancel`)
+    assert.equal(luResult.get('./dia1/dia1').Sections[foundIndex].Body, `- book a hotel for me${NEWLINE}- cancel`)
 
-    foundIndex = luResult.get('./dia2/dia2.lu').Sections.findIndex(s => s.Name === '_Interruption')
+    foundIndex = luResult.get('./dia2/dia2').Sections.findIndex(s => s.Name === '_Interruption')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('./dia2/dia2.lu').Sections[foundIndex].Body, `- I want to travel to Seattle${NEWLINE}- cancel`)
+    assert.equal(luResult.get('./dia2/dia2').Sections[foundIndex].Body, `- I want to travel to Seattle${NEWLINE}- cancel`)
 
-    foundIndex = luResult.get('./dia3/dia3.lu').Sections.findIndex(s => s.Name === '_Interruption')
+    foundIndex = luResult.get('./dia3/dia3').Sections.findIndex(s => s.Name === '_Interruption')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('./dia3/dia3.lu').Sections[foundIndex].Body, `- I want to travel to Seattle${NEWLINE}- book a hotel for me${NEWLINE}- cancel`)
+    assert.equal(luResult.get('./dia3/dia3').Sections[foundIndex].Body, `- I want to travel to Seattle${NEWLINE}- book a hotel for me${NEWLINE}- cancel`)
   })
 
   it('luis:cross training can get expected result when multi trigger intents point to same lu file', async () => {
@@ -529,7 +529,7 @@ describe('luis:cross training tests among lu and qna contents', () => {
         
         # dia3_trigger
         - cancel`,
-      id: './main/main.lu'}
+      id: './main/main'}
     )
 
     luContentArray.push({
@@ -540,24 +540,24 @@ describe('luis:cross training tests among lu and qna contents', () => {
         
         # hotelLevel
         - I prefer 4 stars hotel`,
-      id: './dia1/dia1.lu'}
+      id: './dia1/dia1'}
     )
 
     luContentArray.push({
       content:
         `# cancelTask
         - cancel that task`,
-      id: './dia2/dia2.lu'}
+      id: './dia2/dia2'}
     )
 
     let crossTrainConfig = {
-      './main/main.lu': {
+      './main/main': {
         'rootDialog': true,
         'triggers': {
-          'dia1_trigger': './dia1/dia1.lu',
-          'dia2_trigger': './dia1/dia1.lu',
-          'dia3_trigger': './dia2/dia2.lu',
-          '': './dia2/dia2.lu'
+          'dia1_trigger': './dia1/dia1',
+          'dia2_trigger': './dia1/dia1',
+          'dia3_trigger': './dia2/dia2',
+          '': './dia2/dia2'
         }
       }
     }
@@ -565,13 +565,13 @@ describe('luis:cross training tests among lu and qna contents', () => {
     const trainedResult = await crossTrainer.crossTrain(luContentArray, [], crossTrainConfig)
     const luResult = trainedResult.luResult
 
-    let foundIndex = luResult.get('./dia1/dia1.lu').Sections.findIndex(s => s.Name === '_Interruption')
+    let foundIndex = luResult.get('./dia1/dia1').Sections.findIndex(s => s.Name === '_Interruption')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('./dia1/dia1.lu').Sections[foundIndex].Body, `- cancel`)
+    assert.equal(luResult.get('./dia1/dia1').Sections[foundIndex].Body, `- cancel`)
 
-    foundIndex = luResult.get('./dia2/dia2.lu').Sections.findIndex(s => s.Name === '_Interruption')
+    foundIndex = luResult.get('./dia2/dia2').Sections.findIndex(s => s.Name === '_Interruption')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('./dia2/dia2.lu').Sections[foundIndex].Body, `- I want to travel to Seattle${NEWLINE}- book a hotel for me`)
+    assert.equal(luResult.get('./dia2/dia2').Sections[foundIndex].Body, `- I want to travel to Seattle${NEWLINE}- book a hotel for me`)
   })
 
   it('luis:cross training can get expected result when handling patterns', async () => {
@@ -591,7 +591,7 @@ describe('luis:cross training tests among lu and qna contents', () => {
         - can you book a flight for {@ personName : userName}
         
         @ prebuilt personName`,
-      id: 'main.lu'})
+      id: 'main'})
 
     qnaContentArray.push({
       content:
@@ -608,7 +608,7 @@ describe('luis:cross training tests among lu and qna contents', () => {
         \`\`\`
             tell a funny joke
         \`\`\``,
-      id: 'main.qna'}
+      id: 'main'}
     )
 
     luContentArray.push({
@@ -620,7 +620,7 @@ describe('luis:cross training tests among lu and qna contents', () => {
         
         # hotelLocation
         - can I book a hotel near space needle`,
-      id: 'dia1.lu'}
+      id: 'dia1'}
     )
 
     luContentArray.push({
@@ -630,15 +630,15 @@ describe('luis:cross training tests among lu and qna contents', () => {
         
         # dia4_trigger
         - book a train ticket from Seattle to Portland`,
-      id: 'dia2.lu'}
+      id: 'dia2'}
     )
 
     let crossTrainConfig = {
-      'main.lu': {
+      'main': {
         'rootDialog': true,
         'triggers': {
-          'dia1_trigger': 'dia1.lu',
-          'dia2_trigger': 'dia2.lu'
+          'dia1_trigger': 'dia1',
+          'dia2_trigger': 'dia2'
         }
       }
     }
@@ -647,27 +647,27 @@ describe('luis:cross training tests among lu and qna contents', () => {
     const luResult = trainedResult.luResult
     const qnaResult = trainedResult.qnaResult
 
-    let foundIndex = luResult.get('main.lu').Sections.findIndex(s => s.Name === 'DeferToRecognizer_QnA_main')
+    let foundIndex = luResult.get('main').Sections.findIndex(s => s.Name === 'DeferToRecognizer_QnA_main')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('main.lu').Sections[foundIndex].Body, `- user guide${NEWLINE}- tell joke`)
+    assert.equal(luResult.get('main').Sections[foundIndex].Body, `- user guide${NEWLINE}- tell joke`)
 
-    foundIndex = qnaResult.get('main.qna').Sections.findIndex(s => s.Answer === 'intent=DeferToRecognizer_LUIS_main')
+    foundIndex = qnaResult.get('main').Sections.findIndex(s => s.Answer === 'intent=DeferToRecognizer_LUIS_main')
     assert.isTrue(foundIndex > -1)
-    assert.equal(qnaResult.get('main.qna').Sections[foundIndex].FilterPairs[0].key, 'dialogName')
-    assert.equal(qnaResult.get('main.qna').Sections[foundIndex].FilterPairs[0].value, 'main')
-    assert.equal(qnaResult.get('main.qna').Sections[foundIndex].Questions.length, 3)
-    assert.equal(qnaResult.get('main.qna').Sections[foundIndex].Questions[0], 'book a hotel for me')
-    assert.equal(qnaResult.get('main.qna').Sections[foundIndex].Questions[1], 'book a flight for me')
-    assert.equal(qnaResult.get('main.qna').Sections[foundIndex].Questions[2], 'book a train ticket for me')
+    assert.equal(qnaResult.get('main').Sections[foundIndex].FilterPairs[0].key, 'dialogName')
+    assert.equal(qnaResult.get('main').Sections[foundIndex].FilterPairs[0].value, 'main')
+    assert.equal(qnaResult.get('main').Sections[foundIndex].Questions.length, 3)
+    assert.equal(qnaResult.get('main').Sections[foundIndex].Questions[0], 'book a hotel for me')
+    assert.equal(qnaResult.get('main').Sections[foundIndex].Questions[1], 'book a flight for me')
+    assert.equal(qnaResult.get('main').Sections[foundIndex].Questions[2], 'book a train ticket for me')
 
 
-    foundIndex = luResult.get('dia1.lu').Sections.findIndex(s => s.Name === '_Interruption')
+    foundIndex = luResult.get('dia1').Sections.findIndex(s => s.Name === '_Interruption')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('dia1.lu').Sections[foundIndex].Body, `- book a flight for me${NEWLINE}- book a train ticket for me${NEWLINE}- user guide${NEWLINE}- tell joke`)
+    assert.equal(luResult.get('dia1').Sections[foundIndex].Body, `- book a flight for me${NEWLINE}- book a train ticket for me${NEWLINE}- user guide${NEWLINE}- tell joke`)
 
-    foundIndex = luResult.get('dia2.lu').Sections.findIndex(s => s.Name === '_Interruption')
+    foundIndex = luResult.get('dia2').Sections.findIndex(s => s.Name === '_Interruption')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('dia2.lu').Sections[foundIndex].Body, `- book a hotel for me${NEWLINE}- book a hotel for {@name}${NEWLINE}- user guide${NEWLINE}- tell joke`)
+    assert.equal(luResult.get('dia2').Sections[foundIndex].Body, `- book a hotel for me${NEWLINE}- book a hotel for {@name}${NEWLINE}- user guide${NEWLINE}- tell joke`)
   })
 
   it('luis:cross training can get expected result when all lu files are empty', async () => {
@@ -676,7 +676,7 @@ describe('luis:cross training tests among lu and qna contents', () => {
 
     luContentArray.push({
       content: `> this is comments`,
-      id: 'main.lu'})
+      id: 'main'})
 
     qnaContentArray.push({
       content:
@@ -693,12 +693,12 @@ describe('luis:cross training tests among lu and qna contents', () => {
         \`\`\`
             tell a funny joke
         \`\`\``,
-      id: 'main.qna'}
+      id: 'main'}
     )
 
     luContentArray.push({
       content: `> !# @app.name = my luis application`,
-      id: 'dia1.lu'}
+      id: 'dia1'}
     )
 
     qnaContentArray.push({
@@ -717,7 +717,7 @@ describe('luis:cross training tests among lu and qna contents', () => {
         \`\`\`
             of course you can
         \`\`\``,
-      id: 'dia1.qna'}
+      id: 'dia1'}
     )
 
     let crossTrainConfig = {}
@@ -726,21 +726,21 @@ describe('luis:cross training tests among lu and qna contents', () => {
     const luResult = trainedResult.luResult
     const qnaResult = trainedResult.qnaResult
 
-    assert.equal(luResult.get('main.lu').Sections.filter(s => s.SectionType !== sectionTypes.MODELINFOSECTION).length, 0)
+    assert.equal(luResult.get('main').Sections.filter(s => s.SectionType !== sectionTypes.MODELINFOSECTION).length, 0)
 
-    assert.equal(qnaResult.get('main.qna').Sections.length, 2)
-    assert.equal(qnaResult.get('main.qna').Sections[0].FilterPairs[1].key, 'dialogName')
-    assert.equal(qnaResult.get('main.qna').Sections[0].FilterPairs[1].value, 'main')
-    assert.equal(qnaResult.get('main.qna').Sections[1].FilterPairs[0].key, 'dialogName')
-    assert.equal(qnaResult.get('main.qna').Sections[1].FilterPairs[0].value, 'main')
+    assert.equal(qnaResult.get('main').Sections.length, 2)
+    assert.equal(qnaResult.get('main').Sections[0].FilterPairs[1].key, 'dialogName')
+    assert.equal(qnaResult.get('main').Sections[0].FilterPairs[1].value, 'main')
+    assert.equal(qnaResult.get('main').Sections[1].FilterPairs[0].key, 'dialogName')
+    assert.equal(qnaResult.get('main').Sections[1].FilterPairs[0].value, 'main')
 
-    assert.equal(luResult.get('dia1.lu').Sections.filter(s => s.SectionType !== sectionTypes.MODELINFOSECTION).length, 0)
+    assert.equal(luResult.get('dia1').Sections.filter(s => s.SectionType !== sectionTypes.MODELINFOSECTION).length, 0)
 
-    assert.equal(qnaResult.get('dia1.qna').Sections.length, 2)
-    assert.equal(qnaResult.get('dia1.qna').Sections[0].FilterPairs[0].key, 'dialogName')
-    assert.equal(qnaResult.get('dia1.qna').Sections[0].FilterPairs[0].value, 'dia1')
-    assert.equal(qnaResult.get('dia1.qna').Sections[1].FilterPairs[0].key, 'dialogName')
-    assert.equal(qnaResult.get('dia1.qna').Sections[1].FilterPairs[0].value, 'dia1')
+    assert.equal(qnaResult.get('dia1').Sections.length, 2)
+    assert.equal(qnaResult.get('dia1').Sections[0].FilterPairs[0].key, 'dialogName')
+    assert.equal(qnaResult.get('dia1').Sections[0].FilterPairs[0].value, 'dia1')
+    assert.equal(qnaResult.get('dia1').Sections[1].FilterPairs[0].key, 'dialogName')
+    assert.equal(qnaResult.get('dia1').Sections[1].FilterPairs[0].value, 'dia1')
   })
 
   it('luis:cross training can get expected result when all qna files are empty', async () => {
@@ -755,11 +755,11 @@ describe('luis:cross training tests among lu and qna contents', () => {
         # dia2_trigger
         - book a flight for me
         - book a train ticket for me`,
-      id: 'main.lu'})
+      id: 'main'})
 
     qnaContentArray.push({
       content: `> this is comment`,
-      id: 'main.qna'}
+      id: 'main'}
     )
 
     luContentArray.push({
@@ -771,12 +771,12 @@ describe('luis:cross training tests among lu and qna contents', () => {
         
         # hotelLocation
         - can I book a hotel near Space Needle`,
-      id: 'dia1.lu'}
+      id: 'dia1'}
     )
 
     qnaContentArray.push({
       content: ``,
-      id: 'dia1.qna'}
+      id: 'dia1'}
     )
 
     luContentArray.push({
@@ -786,20 +786,20 @@ describe('luis:cross training tests among lu and qna contents', () => {
         
         # bookTrain
         - book a train ticket from Seattle to Portland`,
-      id: 'dia2.lu'}
+      id: 'dia2'}
     )
 
     qnaContentArray.push({
       content:``,
-      id: 'dia2.qna'}
+      id: 'dia2'}
     )
 
     let crossTrainConfig = {
-      'main.lu': {
+      'main': {
         'rootDialog': true,
         'triggers': {
-          'dia1_trigger': 'dia1.lu',
-          'dia2_trigger': 'dia2.lu'
+          'dia1_trigger': 'dia1',
+          'dia2_trigger': 'dia2'
         }
       }
     }
@@ -808,27 +808,27 @@ describe('luis:cross training tests among lu and qna contents', () => {
     const luResult = trainedResult.luResult
     const qnaResult = trainedResult.qnaResult
 
-    assert.isTrue(luResult.get('main.lu').Sections.findIndex(s => s.Name === 'DeferToRecognizer_QnA_main') === -1)
-    assert.equal(qnaResult.get('main.qna').Sections.filter(s => s.SectionType !== sectionTypes.MODELINFOSECTION).length, 0)
+    assert.isTrue(luResult.get('main').Sections.findIndex(s => s.Name === 'DeferToRecognizer_QnA_main') === -1)
+    assert.equal(qnaResult.get('main').Sections.filter(s => s.SectionType !== sectionTypes.MODELINFOSECTION).length, 0)
 
-    let foundIndex = luResult.get('dia1.lu').Sections.findIndex(s => s.ModelInfo === '> !# @app.name = my luis application')
+    let foundIndex = luResult.get('dia1').Sections.findIndex(s => s.ModelInfo === '> !# @app.name = my luis application')
     assert.isTrue(foundIndex > -1)
 
-    foundIndex = luResult.get('dia1.lu').Sections.findIndex(s => s.Name === '_Interruption')
+    foundIndex = luResult.get('dia1').Sections.findIndex(s => s.Name === '_Interruption')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('dia1.lu').Sections[foundIndex].Body, `- book a flight for me${NEWLINE}- book a train ticket for me`)
+    assert.equal(luResult.get('dia1').Sections[foundIndex].Body, `- book a flight for me${NEWLINE}- book a train ticket for me`)
     
-    assert.isTrue(luResult.get('dia1.lu').Sections.findIndex(s => s.Name === 'DeferToRecognizer_QnA_dia1') === -1)
+    assert.isTrue(luResult.get('dia1').Sections.findIndex(s => s.Name === 'DeferToRecognizer_QnA_dia1') === -1)
 
-    assert.equal(qnaResult.get('dia1.qna').Sections.filter(s => s.SectionType !== sectionTypes.MODELINFOSECTION).length, 0)
+    assert.equal(qnaResult.get('dia1').Sections.filter(s => s.SectionType !== sectionTypes.MODELINFOSECTION).length, 0)
 
-    foundIndex = luResult.get('dia2.lu').Sections.findIndex(s => s.Name === '_Interruption')
+    foundIndex = luResult.get('dia2').Sections.findIndex(s => s.Name === '_Interruption')
     assert.isTrue(foundIndex > -1)
-    assert.equal(luResult.get('dia2.lu').Sections[foundIndex].Body, `- book a hotel for me`)
+    assert.equal(luResult.get('dia2').Sections[foundIndex].Body, `- book a hotel for me`)
     
-    assert.isTrue(luResult.get('dia2.lu').Sections.findIndex(s => s.Name === 'DeferToRecognizer_QnA_dia2') === -1)
+    assert.isTrue(luResult.get('dia2').Sections.findIndex(s => s.Name === 'DeferToRecognizer_QnA_dia2') === -1)
 
-    assert.equal(qnaResult.get('dia2.qna').Sections.filter(s => s.SectionType !== sectionTypes.MODELINFOSECTION).length, 0)
+    assert.equal(qnaResult.get('dia2').Sections.filter(s => s.SectionType !== sectionTypes.MODELINFOSECTION).length, 0)
   })
 
   it('luis:cross training can get expected result when all lu and qna files are empty', async () => {
@@ -837,21 +837,21 @@ describe('luis:cross training tests among lu and qna contents', () => {
 
     luContentArray.push({
       content: `> this is comment`,
-      id: 'main.lu'})
+      id: 'main'})
 
     qnaContentArray.push({
       content: `> this is comment`,
-      id: 'main.qna'}
+      id: 'main'}
     )
 
     luContentArray.push({
       content: `> !# @app.name = my luis application`,
-      id: 'dia1.lu'}
+      id: 'dia1'}
     )
 
     qnaContentArray.push({
       content: `> this is comment`,
-      id: 'dia1.qna'}
+      id: 'dia1'}
     )
 
     let crossTrainConfig = {}
@@ -860,10 +860,10 @@ describe('luis:cross training tests among lu and qna contents', () => {
     const luResult = trainedResult.luResult
     const qnaResult = trainedResult.qnaResult
 
-    assert.equal(luResult.get('main.lu').Sections.filter(s => s.SectionType !== sectionTypes.MODELINFOSECTION).length, 0)
-    assert.equal(qnaResult.get('main.qna').Sections.filter(s => s.SectionType !== sectionTypes.MODELINFOSECTION).length, 0)
-    assert.equal(luResult.get('dia1.lu').Sections.filter(s => s.SectionType !== sectionTypes.MODELINFOSECTION).length, 0)
-    assert.equal(qnaResult.get('dia1.qna').Sections.filter(s => s.SectionType !== sectionTypes.MODELINFOSECTION).length, 0)
+    assert.equal(luResult.get('main').Sections.filter(s => s.SectionType !== sectionTypes.MODELINFOSECTION).length, 0)
+    assert.equal(qnaResult.get('main').Sections.filter(s => s.SectionType !== sectionTypes.MODELINFOSECTION).length, 0)
+    assert.equal(luResult.get('dia1').Sections.filter(s => s.SectionType !== sectionTypes.MODELINFOSECTION).length, 0)
+    assert.equal(qnaResult.get('dia1').Sections.filter(s => s.SectionType !== sectionTypes.MODELINFOSECTION).length, 0)
   })
 
   it('luis:cross training can get expected result when customized import resolver is provided', async () => {
@@ -877,9 +877,9 @@ describe('luis:cross training tests among lu and qna contents', () => {
         }
 
         if (file.filePath.endsWith("common.lu")) {
-          luObjects.push(new luObject(`# common_intent${NEWLINE}- this is common utterance`, new luOptions(file.filePath, file.includeInCollate)))
+          luObjects.push(new luObject(`# common_intent${NEWLINE}- this is common utterance`, new luOptions('common', file.includeInCollate)))
         } else if (file.filePath.endsWith("common.qna")) {
-          luObjects.push(new luObject(`# ? common_question${NEWLINE}\`\`\`${NEWLINE}this is common answer${NEWLINE}\`\`\``, new luOptions(file.filePath, file.includeInCollate)))
+          luObjects.push(new luObject(`# ? common_question${NEWLINE}\`\`\`${NEWLINE}this is common answer${NEWLINE}\`\`\``, new luOptions('common', file.includeInCollate)))
         }
       }
       return luObjects
@@ -893,7 +893,7 @@ describe('luis:cross training tests among lu and qna contents', () => {
         `[import](common.lu)
       # dia1_trigger
       - book a hotel for me`,
-      id: path.join(rootDir, 'main.en-us.lu')
+      id: path.join(rootDir, 'main.en-us')
     })
 
     qnaContentArray.push({
@@ -903,18 +903,16 @@ describe('luis:cross training tests among lu and qna contents', () => {
       \`\`\`
       northwest of USA
       \`\`\``,
-      id: path.join(rootDir, 'main.en-us.qna')
-    }
-    )
+      id: path.join(rootDir, 'main.en-us')
+    })
 
     luContentArray.push({
       content:
         `# hotelLocation
       - hotel in Seattle
       - [import](common.lu#common_intent)`,
-      id: path.join(rootDir, 'dia1.en-us.lu')
-    }
-    )
+      id: path.join(rootDir, 'dia1.en-us')
+    })
 
     qnaContentArray.push({
       content:
@@ -923,28 +921,27 @@ describe('luis:cross training tests among lu and qna contents', () => {
       \`\`\`
       please cancel that
       \`\`\``,
-      id: path.join(rootDir, 'dia1.en-us.qna')
-    }
-    )
+      id: path.join(rootDir, 'dia1.en-us')
+    })
 
     let crossTrainConfig = {}
-    crossTrainConfig[path.join(rootDir, "main.en-us.lu")] = {}
-    crossTrainConfig[path.join(rootDir, "main.en-us.lu")].rootDialog = true
-    crossTrainConfig[path.join(rootDir, "main.en-us.lu")].triggers = {'dia1_trigger': path.join(rootDir, "dia1.en-us.lu")}
+    crossTrainConfig[path.join(rootDir, "main.en-us")] = {}
+    crossTrainConfig[path.join(rootDir, "main.en-us")].rootDialog = true
+    crossTrainConfig[path.join(rootDir, "main.en-us")].triggers = {'dia1_trigger': path.join(rootDir, "dia1.en-us")}
 
     const trainedResult = await crossTrainer.crossTrain(luContentArray, qnaContentArray, crossTrainConfig, {importResolver})
     const luResult = trainedResult.luResult
     const qnaResult = trainedResult.qnaResult
 
-    assert.equal(luResult.get(path.join(rootDir, "main.en-us.lu")).Sections.filter(s => s.SectionType === sectionTypes.SIMPLEINTENTSECTION).length, 3)
-    assert.equal(luResult.get(path.join(rootDir, "main.en-us.lu")).Sections.filter(s => s.SectionType === sectionTypes.SIMPLEINTENTSECTION)[1].Name, "common_intent")
-    assert.isTrue(luResult.get(path.join(rootDir, "main.en-us.lu")).Sections.filter(s => s.SectionType === sectionTypes.SIMPLEINTENTSECTION)[1].Body.includes(`- this is common utterance`))
-    assert.equal(luResult.get(path.join(rootDir, "dia1.en-us.lu")).Sections.filter(s => s.SectionType === sectionTypes.SIMPLEINTENTSECTION).length, 3)
-    assert.isTrue(luResult.get(path.join(rootDir, "dia1.en-us.lu")).Sections.filter(s => s.SectionType === sectionTypes.SIMPLEINTENTSECTION)[0].Body.includes(`- hotel in Seattle${NEWLINE}- this is common utterance`))
+    assert.equal(luResult.get(path.join(rootDir, "main.en-us")).Sections.filter(s => s.SectionType === sectionTypes.SIMPLEINTENTSECTION).length, 3)
+    assert.equal(luResult.get(path.join(rootDir, "main.en-us")).Sections.filter(s => s.SectionType === sectionTypes.SIMPLEINTENTSECTION)[1].Name, "common_intent")
+    assert.isTrue(luResult.get(path.join(rootDir, "main.en-us")).Sections.filter(s => s.SectionType === sectionTypes.SIMPLEINTENTSECTION)[1].Body.includes(`- this is common utterance`))
+    assert.equal(luResult.get(path.join(rootDir, "dia1.en-us")).Sections.filter(s => s.SectionType === sectionTypes.SIMPLEINTENTSECTION).length, 3)
+    assert.isTrue(luResult.get(path.join(rootDir, "dia1.en-us")).Sections.filter(s => s.SectionType === sectionTypes.SIMPLEINTENTSECTION)[0].Body.includes(`- hotel in Seattle${NEWLINE}- this is common utterance`))
 
-    assert.equal(qnaResult.get(path.join(rootDir, "main.en-us.qna")).Sections.filter(s => s.SectionType === sectionTypes.QNASECTION).length, 3)
-    assert.isTrue(qnaResult.get(path.join(rootDir, "main.en-us.qna")).Sections.filter(s => s.SectionType === sectionTypes.QNASECTION)[1].Body.includes(`# ? common_question${NEWLINE}${NEWLINE}**Filters:**${NEWLINE}- dialogName=main${NEWLINE}${NEWLINE}\`\`\`${NEWLINE}this is common answer${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}`))
-    assert.equal(qnaResult.get(path.join(rootDir, "dia1.en-us.qna")).Sections.filter(s => s.SectionType === sectionTypes.QNASECTION).length, 3)
-    assert.isTrue(qnaResult.get(path.join(rootDir, "dia1.en-us.qna")).Sections.filter(s => s.SectionType === sectionTypes.QNASECTION)[1].Body.includes(`# ? common_question${NEWLINE}${NEWLINE}**Filters:**${NEWLINE}- dialogName=dia1${NEWLINE}${NEWLINE}\`\`\`${NEWLINE}this is common answer${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}`))
+    assert.equal(qnaResult.get(path.join(rootDir, "main.en-us")).Sections.filter(s => s.SectionType === sectionTypes.QNASECTION).length, 3)
+    assert.isTrue(qnaResult.get(path.join(rootDir, "main.en-us")).Sections.filter(s => s.SectionType === sectionTypes.QNASECTION)[1].Body.includes(`# ? common_question${NEWLINE}${NEWLINE}**Filters:**${NEWLINE}- dialogName=main${NEWLINE}${NEWLINE}\`\`\`${NEWLINE}this is common answer${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}`))
+    assert.equal(qnaResult.get(path.join(rootDir, "dia1.en-us")).Sections.filter(s => s.SectionType === sectionTypes.QNASECTION).length, 3)
+    assert.isTrue(qnaResult.get(path.join(rootDir, "dia1.en-us")).Sections.filter(s => s.SectionType === sectionTypes.QNASECTION)[1].Body.includes(`# ? common_question${NEWLINE}${NEWLINE}**Filters:**${NEWLINE}- dialogName=dia1${NEWLINE}${NEWLINE}\`\`\`${NEWLINE}this is common answer${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}`))
   })
 })

--- a/packages/lu/test/utils/filehelper.test.js
+++ b/packages/lu/test/utils/filehelper.test.js
@@ -32,61 +32,61 @@ describe('utils/filehelper test', () => {
 
     it('File helper correctly build cross train config object', function () {
         const rawConfigObject = {
-            "./main/main.lu": {
+            "main": {
                 "rootDialog": true,
                 "triggers": {
-                    "dia1_trigger": ["./dia1/dia1.lu", "./dia2/dia2.lu"]
+                    "dia1_trigger": ["dia1", "dia2"]
                 }
             },
-            "./dia2/dia2.lu": {
+            "dia2": {
                 "triggers": {
                     "dia3_trigger": "",
-                    "": "./dia4/dia4.lu"
+                    "": "dia4"
                 }
             },
-            "./main/main.fr-fr.lu": {
+            "main.fr-fr": {
                 "rootDialog": true,
                 "triggers": {
-                    "dia1_trigger": "./dia1/dia1.fr-fr.lu"
+                    "dia1_trigger": "dia1.fr-fr"
                 }
             }
         }
 
-        let configObject = fileHelper.getConfigObject(rawConfigObject, path.join(__dirname, 'config.json'), '_Interruption', true)
-        assert.equal(configObject.rootIds[0].includes('main.lu'), true)
-        assert.equal(configObject.rootIds[1].includes('main.fr-fr.lu'), true)
+        let configObject = fileHelper.getConfigObject(rawConfigObject, '_Interruption', true)
+        assert.equal(configObject.rootIds[0].includes('main'), true)
+        assert.equal(configObject.rootIds[1].includes('main.fr-fr'), true)
 
         let triggerRuleKeys = [...Object.keys(configObject.triggerRules)]
-        assert.equal(triggerRuleKeys[0].includes('main.lu'), true)
-        assert.equal(triggerRuleKeys[1].includes('dia2.lu'), true)
-        assert.equal(triggerRuleKeys[2].includes('main.fr-fr.lu'), true)
+        assert.equal(triggerRuleKeys[0].includes('main'), true)
+        assert.equal(triggerRuleKeys[1].includes('dia2'), true)
+        assert.equal(triggerRuleKeys[2].includes('main.fr-fr'), true)
 
         let triggerRuleValues = [...Object.values(configObject.triggerRules)]
-        assert.equal(triggerRuleValues[0]['dia1_trigger'][0].includes('dia1.lu'), true)
-        assert.equal(triggerRuleValues[0]['dia1_trigger'][1].includes('dia2.lu'), true)
+        assert.equal(triggerRuleValues[0]['dia1_trigger'][0].includes('dia1'), true)
+        assert.equal(triggerRuleValues[0]['dia1_trigger'][1].includes('dia2'), true)
         assert.equal(triggerRuleValues[1]['dia3_trigger'][0], '')
-        assert.equal(triggerRuleValues[1][''][0].includes('dia4.lu'), true)
-        assert.equal(triggerRuleValues[2]['dia1_trigger'][0].includes('dia1.fr-fr.lu'), true)
+        assert.equal(triggerRuleValues[1][''][0].includes('dia4'), true)
+        assert.equal(triggerRuleValues[2]['dia1_trigger'][0].includes('dia1.fr-fr'), true)
 
         assert.equal(configObject.intentName, '_Interruption')
 
         assert.equal(configObject.verbose, true)
 
-        configObject = fileHelper.getConfigObject(rawConfigObject, undefined, '_Interruption', true)
-        assert.equal(configObject.rootIds[0], './main/main.lu')
-        assert.equal(configObject.rootIds[1], './main/main.fr-fr.lu')
+        configObject = fileHelper.getConfigObject(rawConfigObject, '_Interruption', true)
+        assert.equal(configObject.rootIds[0], 'main')
+        assert.equal(configObject.rootIds[1], 'main.fr-fr')
 
         triggerRuleKeys = [...Object.keys(configObject.triggerRules)]
-        assert.equal(triggerRuleKeys[0], './main/main.lu')
-        assert.equal(triggerRuleKeys[1], './dia2/dia2.lu')
-        assert.equal(triggerRuleKeys[2], './main/main.fr-fr.lu')
+        assert.equal(triggerRuleKeys[0], 'main')
+        assert.equal(triggerRuleKeys[1], 'dia2')
+        assert.equal(triggerRuleKeys[2], 'main.fr-fr')
 
         triggerRuleValues = [...Object.values(configObject.triggerRules)]
-        assert.equal(triggerRuleValues[0]['dia1_trigger'][0], './dia1/dia1.lu')
-        assert.equal(triggerRuleValues[0]['dia1_trigger'][1], './dia2/dia2.lu')
+        assert.equal(triggerRuleValues[0]['dia1_trigger'][0], 'dia1')
+        assert.equal(triggerRuleValues[0]['dia1_trigger'][1], 'dia2')
         assert.equal(triggerRuleValues[1]['dia3_trigger'][0], '')
-        assert.equal(triggerRuleValues[1][''][0], './dia4/dia4.lu')
-        assert.equal(triggerRuleValues[2]['dia1_trigger'][0], './dia1/dia1.fr-fr.lu')
+        assert.equal(triggerRuleValues[1][''][0], 'dia4')
+        assert.equal(triggerRuleValues[2]['dia1_trigger'][0], 'dia1.fr-fr')
 
         assert.equal(configObject.intentName, '_Interruption')
 

--- a/packages/luis/src/commands/luis/cross-train.ts
+++ b/packages/luis/src/commands/luis/cross-train.ts
@@ -8,6 +8,7 @@ const fs = require('fs-extra')
 const path = require('path')
 const crossTrain = require('@microsoft/bf-lu/lib/parser/cross-train/cross-train')
 const exception = require('@microsoft/bf-lu/lib/parser/utils/exception')
+const fileExtEnum = require('@microsoft/bf-lu/lib/parser/utils/helpers').FileExtTypeEnum
 
 export default class LuisCrossTrain extends Command {
   static description = 'Lu and Qna cross train tool'
@@ -44,8 +45,8 @@ export default class LuisCrossTrain extends Command {
         flags.out = path.join(process.cwd(), 'cross-trained')
       }
 
-      await this.writeFiles(trainedResult.luResult, flags.out, flags.force)
-      await this.writeFiles(trainedResult.qnaResult, flags.out, flags.force)
+      await this.writeFiles(trainedResult.luResult, flags.out, flags.force, fileExtEnum.LUFile)
+      await this.writeFiles(trainedResult.qnaResult, flags.out, flags.force, fileExtEnum.QnAFile)
     } catch (err) {
       if (err instanceof exception) {
         throw new CLIError(err.text)
@@ -54,7 +55,7 @@ export default class LuisCrossTrain extends Command {
     }
   }
 
-  async writeFiles(fileIdToLuResourceMap: any, out: string, force: boolean) {
+  async writeFiles(fileIdToLuResourceMap: any, out: string, force: boolean, fileExt: any) {
     if (fileIdToLuResourceMap) {
       let newFolder
       if (out) {
@@ -74,9 +75,9 @@ export default class LuisCrossTrain extends Command {
           if (newFolder) {
             const fileName = path.basename(fileId)
             const newFileId = path.join(newFolder, fileName)
-            validatedPath = utils.validatePath(newFileId, '', force)
+            validatedPath = utils.validatePath(newFileId + fileExt, '', force)
           } else {
-            validatedPath = utils.validatePath(fileId, '', force)
+            validatedPath = utils.validatePath(fileId + fileExt, '', force)
           }
 
           await fs.writeFile(validatedPath, fileIdToLuResourceMap.get(fileId).Content, 'utf-8')

--- a/packages/luis/test/fixtures/testcases/interruption/mapping_rules.json
+++ b/packages/luis/test/fixtures/testcases/interruption/mapping_rules.json
@@ -1,21 +1,21 @@
 {
-    "./main/main.lu": {
+    "main": {
         "rootDialog": true,
         "triggers": {
-            "dia1_trigger": "./Dia1/Dia1.lu",
-            "dia2_trigger": "./dia2/Dia2.lu"
+            "dia1_trigger": "Dia1",
+            "dia2_trigger": "Dia2"
         }
     },
-    "./dia2/dia2.lu": {
+    "dia2": {
         "triggers": {
-            "dia3_trigger": "./dia3/dia3.lu",
-            "dia4_trigger": "./dia4/dia4.lu"
+            "dia3_trigger": "dia3",
+            "dia4_trigger": "dia4"
         }
     },
-    "./main/main.fr-fr.lu": {
+    "main.fr-fr": {
         "rootDialog": true,
         "triggers": {
-            "dia1_trigger": "./dia1/dia1.fr-fr.lu"
+            "dia1_trigger": "dia1.fr-fr"
         }
     }
 }

--- a/packages/luis/test/fixtures/testcases/interruption2/config.json
+++ b/packages/luis/test/fixtures/testcases/interruption2/config.json
@@ -1,11 +1,11 @@
 {
-    "./main/main.lu": {
+    "main": {
         "rootDialog": true,
         "triggers": {
-            "dia1_trigger": "./dia1/dia1.lu",
-            "dia2_trigger": "./dia2/dia2.lu",
+            "dia1_trigger": "dia1",
+            "dia2_trigger": "dia2",
             "dia3_trigger": "",
-            "": "./dia3/dia3.lu"
+            "": "dia3"
         }
     }
 }

--- a/packages/luis/test/fixtures/testcases/interruption3/config.json
+++ b/packages/luis/test/fixtures/testcases/interruption3/config.json
@@ -1,12 +1,12 @@
 {
-    "./main/main.lu": {
+    "main": {
         "rootDialog": true,
         "triggers": {
             "dia1_trigger": [
-                "./dia1/dia1.lu",
-                "./dia2/dia2.lu"
+                "dia1",
+                "dia2"
             ],
-            "dia2_trigger": "./dia3/dia3.lu"
+            "dia2_trigger": "dia3"
         }
     }
 }

--- a/packages/luis/test/fixtures/testcases/interruption5/mapping_rules.json
+++ b/packages/luis/test/fixtures/testcases/interruption5/mapping_rules.json
@@ -1,8 +1,8 @@
 {
-    "./main/Main.lu": {
+    "Main": {
         "rootDialog": true,
         "triggers": {
-            "dia1_trigger": "./Dia1/dia1.lu"
+            "dia1_trigger": "dia1"
         }
     }
 }

--- a/packages/luis/test/fixtures/testcases/interruption6/mapping_rules.json
+++ b/packages/luis/test/fixtures/testcases/interruption6/mapping_rules.json
@@ -1,8 +1,8 @@
 {
-    "./main/Main.lu": {
+    "Main": {
         "rootDialog": true,
         "triggers": {
-            "dia1_trigger": "./Dia1/dia1.lu"
+            "dia1_trigger": "dia1"
         }
     }
 }

--- a/packages/qnamaker/src/commands/qnamaker/cross-train.ts
+++ b/packages/qnamaker/src/commands/qnamaker/cross-train.ts
@@ -8,6 +8,7 @@ const fs = require('fs-extra')
 const path = require('path')
 const crossTrain = require('@microsoft/bf-lu/lib/parser/cross-train/cross-train')
 const exception = require('@microsoft/bf-lu/lib/parser/utils/exception')
+const fileExtEnum = require('@microsoft/bf-lu/lib/parser/utils/helpers').FileExtTypeEnum
 
 export default class QnamakerCrossTrain extends Command {
   static description = 'Lu and Qna cross train tool'
@@ -44,8 +45,8 @@ export default class QnamakerCrossTrain extends Command {
         flags.out = path.join(process.cwd(), 'cross-trained')
       }
 
-      await this.writeFiles(trainedResult.luResult, flags.out, flags.force)
-      await this.writeFiles(trainedResult.qnaResult, flags.out, flags.force)
+      await this.writeFiles(trainedResult.luResult, flags.out, flags.force, fileExtEnum.LUFile)
+      await this.writeFiles(trainedResult.qnaResult, flags.out, flags.force, fileExtEnum.QnAFile)
     } catch (err) {
       if (err instanceof exception) {
         throw new CLIError(err.text)
@@ -54,7 +55,7 @@ export default class QnamakerCrossTrain extends Command {
     }
   }
 
-  async writeFiles(fileIdToLuResourceMap: any, out: string, force: boolean) {
+  async writeFiles(fileIdToLuResourceMap: any, out: string, force: boolean, fileExt: any) {
     if (fileIdToLuResourceMap) {
       let newFolder
       if (out) {
@@ -74,9 +75,9 @@ export default class QnamakerCrossTrain extends Command {
           if (newFolder) {
             const fileName = path.basename(fileId)
             const newFileId = path.join(newFolder, fileName)
-            validatedPath = utils.validatePath(newFileId, '', force)
+            validatedPath = utils.validatePath(newFileId + fileExt, '', force)
           } else {
-            validatedPath = utils.validatePath(fileId, '', force)
+            validatedPath = utils.validatePath(fileId + fileExt, '', force)
           }
 
           await fs.writeFile(validatedPath, fileIdToLuResourceMap.get(fileId).Content, 'utf-8')

--- a/packages/qnamaker/test/fixtures/testcases/interruption/mapping_rules.json
+++ b/packages/qnamaker/test/fixtures/testcases/interruption/mapping_rules.json
@@ -1,21 +1,21 @@
 {
-    "./main/main.lu": {
+    "main": {
         "rootDialog": true,
         "triggers": {
-            "dia1_trigger": "./dia1/dia1.lu",
-            "dia2_trigger": "./dia2/dia2.lu"
+            "dia1_trigger": "dia1",
+            "dia2_trigger": "dia2"
         }
     },
-    "./dia2/dia2.lu": {
+    "dia2": {
         "triggers": {
-            "dia3_trigger": "./dia3/dia3.lu",
-            "dia4_trigger": "./dia4/dia4.lu"
+            "dia3_trigger": "dia3",
+            "dia4_trigger": "dia4"
         }
     },
-    "./main/main.fr-fr.lu": {
+    "main.fr-fr": {
         "rootDialog": true,
         "triggers": {
-            "dia1_trigger": "./dia1/dia1.fr-fr.lu"
+            "dia1_trigger": "dia1.fr-fr"
         }
     }
 }

--- a/packages/qnamaker/test/fixtures/testcases/interruption2/config.json
+++ b/packages/qnamaker/test/fixtures/testcases/interruption2/config.json
@@ -1,11 +1,11 @@
 {
-    "./main/main.lu": {
+    "main": {
         "rootDialog": true,
         "triggers": {
-            "dia1_trigger": "./dia1/dia1.lu",
-            "dia2_trigger": "./dia2/dia2.lu",
+            "dia1_trigger": "dia1",
+            "dia2_trigger": "dia2",
             "dia3_trigger": "",
-            "": "./dia3/dia3.lu"
+            "": "dia3"
         }
     }
 }

--- a/packages/qnamaker/test/fixtures/testcases/interruption3/config.json
+++ b/packages/qnamaker/test/fixtures/testcases/interruption3/config.json
@@ -1,12 +1,12 @@
 {
-    "./main/main.lu": {
+    "main": {
         "rootDialog": true,
         "triggers": {
             "dia1_trigger": [
-                "./dia1/dia1.lu",
-                "./dia2/dia2.lu"
+                "dia1",
+                "dia2"
             ],
-            "dia2_trigger": "./dia3/dia3.lu"
+            "dia2_trigger": "dia3"
         }
     }
 }

--- a/packages/qnamaker/test/fixtures/testcases/interruption5/mapping_rules.json
+++ b/packages/qnamaker/test/fixtures/testcases/interruption5/mapping_rules.json
@@ -1,8 +1,8 @@
 {
-    "./main/Main.lu": {
+    "Main": {
         "rootDialog": true,
         "triggers": {
-            "dia1_trigger": "./Dia1/dia1.lu"
+            "dia1_trigger": "dia1"
         }
     }
 }


### PR DESCRIPTION
fix #1028 to leverage file name id as key-value pairs in triggering rules instead of file paths. After the changes, users can just use file names without any path or extension in config to sepcify the triggerrng rules.