### PR TITLE
Update pnpm lock yaml

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,10 +1,9 @@
 dependencies:
-  7zip-min: 1.2.0
-  '@microsoft/bf-cli-command': 4.10.0-dev.20200808.5a7c973
-  '@microsoft/bf-lu': 4.10.0-dev.20200808.5a7c973
+  '@microsoft/bf-cli-command': 4.11.0-dev.20201025.69cf2b9
+  '@microsoft/bf-lu': 4.11.0-dev.20201025.69cf2b9
   '@oclif/dev-cli': 1.22.2
   '@oclif/errors': 1.2.2
-  '@oclif/test': 1.2.6
+  '@oclif/test': 1.2.7
   '@oclif/tslint': 3.1.1_tslint@5.20.1
   '@rush-temp/bf-dispatcher': 'file:projects/bf-dispatcher.tgz'
   '@rush-temp/bf-orchestrator': 'file:projects/bf-orchestrator.tgz'
@@ -14,7 +13,7 @@ dependencies:
   '@types/fs-extra': 8.1.1
   '@types/mocha': 5.2.7
   '@types/node-fetch': 2.5.7
-  '@types/sinon': 9.0.4
+  '@types/sinon': 9.0.8
   argparse: 1.0.10
   chai: 4.2.0
   eslint: 5.16.0
@@ -23,87 +22,78 @@ dependencies:
   fast-text-encoding: 1.0.3
   fs-extra: 9.0.1
   nock: 11.9.1
-  node-fetch: 2.6.0
+  node-7z-forall: 1.0.9
+  node-fetch: 2.6.1
   nyc: 14.1.1
-  orchestrator-core: 4.11.0-dev.20201023.49095d1
+  orchestrator-core: 4.11.0-dev.20201024.0c5247b
   read-text-file: 1.1.0
   readline-sync: 1.4.10
-  sinon: 9.0.3
+  sinon: 9.2.0
   ts-md5: 1.2.7
-  tslib: 1.13.0
+  tslib: 1.14.1
   tslint: 5.20.1
 lockfileVersion: 5.1
 packages:
-  /7zip-bin/5.0.3:
-    dev: false
-    resolution:
-      integrity: sha512-GLyWIFBbGvpKPGo55JyRZAo4lVbnBiD52cKlw/0Vt+wnmKvWJkpZvsjVoaIolyBXDeAQKSicRtqFNPem9w0WYA==
-  /7zip-min/1.2.0:
-    dependencies:
-      7zip-bin: 5.0.3
-    dev: false
-    resolution:
-      integrity: sha512-KJjhnNHKKtxpD0NvoyMhXlNx+OQQWZrFtyQYrHwo0pIfo0fyydI3a6nVa7MYdwB/RT0Bpd77begiEyA5pD1kDA==
   /@azure/cognitiveservices-luis-authoring/4.0.0-preview.1:
     dependencies:
-      '@azure/ms-rest-js': 2.0.8
-      tslib: 1.13.0
+      '@azure/ms-rest-js': 2.1.0
+      tslib: 1.14.1
     dev: false
     resolution:
       integrity: sha512-HAhnf+57iHn1s7U5H7Rr51JZQINeJeT0uxtXr/Ksa6wbmZDOm+VApWnFwp/+QH1ZnW8S6Qf0roKtuTeEBjmBZA==
   /@azure/ms-rest-azure-js/2.0.1:
     dependencies:
-      '@azure/ms-rest-js': 2.0.8
-      tslib: 1.13.0
+      '@azure/ms-rest-js': 2.1.0
+      tslib: 1.14.1
     dev: false
     resolution:
       integrity: sha512-5e+A710O7gRFISoV4KI/ZyLQbKmjXxQZ1L8Z/sx7jSUQqmswjTnN4yyIZxs5JzfLVkobU0rXxbi5/LVzaI8QXQ==
-  /@azure/ms-rest-js/2.0.8:
+  /@azure/ms-rest-js/2.1.0:
     dependencies:
       '@types/node-fetch': 2.5.7
       '@types/tunnel': 0.0.1
       abort-controller: 3.0.0
       form-data: 2.5.1
-      node-fetch: 2.6.0
+      node-fetch: 2.6.1
       tough-cookie: 3.0.1
-      tslib: 1.13.0
+      tslib: 1.14.1
       tunnel: 0.0.6
       uuid: 3.4.0
       xml2js: 0.4.23
     dev: false
     resolution:
-      integrity: sha512-PO4pnYaF66IAB/RWbhrTprGyhOzDzsgcbT7z8k3O38JKlwifbrhW+8M0fzx0ScZnaacP8rZyBazYMUF9P12c0g==
+      integrity: sha512-4BXLVImYRt+jcUmEJ5LUWglI8RBNVQndY6IcyvQ4U8O4kIXdmlRz3cJdA/RpXf5rKT38KOoTO2T6Z1f6Z1HDBg==
   /@babel/code-frame/7.10.4:
     dependencies:
       '@babel/highlight': 7.10.4
     dev: false
     resolution:
       integrity: sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
-  /@babel/generator/7.11.0:
+  /@babel/generator/7.12.1:
     dependencies:
-      '@babel/types': 7.11.0
+      '@babel/types': 7.12.1
       jsesc: 2.5.2
       source-map: 0.5.7
     dev: false
     resolution:
-      integrity: sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==
+      integrity: sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==
   /@babel/helper-function-name/7.10.4:
     dependencies:
       '@babel/helper-get-function-arity': 7.10.4
       '@babel/template': 7.10.4
-      '@babel/types': 7.11.0
+      '@babel/types': 7.12.1
     dev: false
     resolution:
       integrity: sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==
   /@babel/helper-get-function-arity/7.10.4:
     dependencies:
-      '@babel/types': 7.11.0
+      '@babel/types': 7.12.1
     dev: false
     resolution:
       integrity: sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==
   /@babel/helper-split-export-declaration/7.11.0:
     dependencies:
-      '@babel/types': 7.11.0
+      '@babel/types': 7.12.1
     dev: false
     resolution:
       integrity: sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==
@@ -119,48 +109,48 @@ packages:
     dev: false
     resolution:
       integrity: sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
-  /@babel/parser/7.11.3:
+  /@babel/parser/7.12.3:
     dev: false
     engines:
       node: '>=6.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-REo8xv7+sDxkKvoxEywIdsNFiZLybwdI7hcT5uEPyQrSMB4YQ973BfC9OOrD/81MaIjh6UxdulIQXkjmiH3PcA==
+      integrity: sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==
   /@babel/template/7.10.4:
     dependencies:
       '@babel/code-frame': 7.10.4
-      '@babel/parser': 7.11.3
-      '@babel/types': 7.11.0
+      '@babel/parser': 7.12.3
+      '@babel/types': 7.12.1
     dev: false
     resolution:
       integrity: sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==
-  /@babel/traverse/7.11.0:
+  /@babel/traverse/7.12.1:
     dependencies:
       '@babel/code-frame': 7.10.4
-      '@babel/generator': 7.11.0
+      '@babel/generator': 7.12.1
       '@babel/helper-function-name': 7.10.4
       '@babel/helper-split-export-declaration': 7.11.0
-      '@babel/parser': 7.11.3
-      '@babel/types': 7.11.0
-      debug: 4.1.1
+      '@babel/parser': 7.12.3
+      '@babel/types': 7.12.1
+      debug: 4.2.0
       globals: 11.12.0
-      lodash: 4.17.19
+      lodash: 4.17.20
     dev: false
     resolution:
-      integrity: sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==
-  /@babel/types/7.11.0:
+      integrity: sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==
+  /@babel/types/7.12.1:
     dependencies:
       '@babel/helper-validator-identifier': 7.10.4
-      lodash: 4.17.19
+      lodash: 4.17.20
       to-fast-properties: 2.0.0
     dev: false
     resolution:
-      integrity: sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==
+      integrity: sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==
   /@fimbul/bifrost/0.21.0_tslint@5.20.1:
     dependencies:
       '@fimbul/ymir': 0.21.0_tsutils@3.17.1
       get-caller-file: 2.0.5
-      tslib: 1.13.0
+      tslib: 1.14.1
       tslint: 5.20.1
       tsutils: 3.17.1
     dev: false
@@ -173,7 +163,7 @@ packages:
     dependencies:
       '@fimbul/ymir': 0.21.0_tsutils@3.17.1+typescript@3.9.7
       get-caller-file: 2.0.5
-      tslib: 1.13.0
+      tslib: 1.14.1
       tslint: 5.20.1_typescript@3.9.7
       tsutils: 3.17.1_typescript@3.9.7
       typescript: 3.9.7
@@ -187,7 +177,7 @@ packages:
     dependencies:
       inversify: 5.0.1
       reflect-metadata: 0.1.13
-      tslib: 1.13.0
+      tslib: 1.14.1
       tsutils: 3.17.1
     dev: false
     peerDependencies:
@@ -199,7 +189,7 @@ packages:
     dependencies:
       inversify: 5.0.1
       reflect-metadata: 0.1.13
-      tslib: 1.13.0
+      tslib: 1.14.1
       tsutils: 3.17.1_typescript@3.9.7
       typescript: 3.9.7
     dev: false
@@ -208,64 +198,23 @@ packages:
       typescript: '>= 3.3.0 || >= 3.6.0-dev || >= 3.7.0-dev'
     resolution:
       integrity: sha512-T/y7WqPsm4n3zhT08EpB5sfdm2Kvw3gurAxr2Lr5dQeLi8ZsMlNT/Jby+ZmuuAAd1PnXYzKp+2SXgIkQIIMCUg==
-  /@microsoft/bf-cli-command/4.10.0-dev.20200808.5a7c973:
+  /@microsoft/bf-cli-command/4.11.0-dev.20201025.69cf2b9:
     dependencies:
       '@oclif/command': 1.5.20
       '@oclif/config': 1.13.3
       '@oclif/errors': 1.2.2
-      applicationinsights: 1.8.5
+      applicationinsights: 1.8.7
       chalk: 2.4.1
       cli-ux: 4.9.3
-      debug: 4.1.1
-      fs-extra: 7.0.1
-      tslib: 1.10.0
-    dev: false
-    engines:
-      node: '>=6.0.0'
-    resolution:
-      integrity: sha512-GxmxTBMi1Hl9PRTc3IBm33roin5InNI3N28+j8/eKoR0p4dUvVn0y1I78jL/A41LD8nF/I7GBQ0/ZoQZ+70GVA==
-  /@microsoft/bf-cli-command/4.11.0-dev.20201021.d59abb5:
-    dependencies:
-      '@oclif/command': 1.5.20
-      '@oclif/config': 1.13.3
-      '@oclif/errors': 1.2.2
-      applicationinsights: 1.8.5
-      chalk: 2.4.1
-      cli-ux: 4.9.3
-      debug: 4.1.1
+      debug: 4.2.0
       fs-extra: 7.0.1
       tslib: 2.0.3
     dev: false
     engines:
       node: '>=6.0.0'
     resolution:
-      integrity: sha512-3z77uS12LDiLrl/sgYhIVTaOvV22djuqyg2wcPaZBRJjwS6YE2ArQA9xvb2UcGMUmWxPzjbTECP/e4X7ELriZA==
-  /@microsoft/bf-lu/4.10.0-dev.20200808.5a7c973:
-    dependencies:
-      '@azure/cognitiveservices-luis-authoring': 4.0.0-preview.1
-      '@azure/ms-rest-azure-js': 2.0.1
-      '@oclif/command': 1.5.20
-      '@oclif/errors': 1.2.2
-      '@types/node-fetch': 2.5.7
-      antlr4: 4.8.0
-      chalk: 2.4.1
-      console-stream: 0.1.1
-      deep-equal: 1.1.1
-      delay: 4.4.0
-      fs-extra: 8.1.0
-      get-stdin: 6.0.0
-      globby: 10.0.2
-      intercept-stdout: 0.1.2
-      lodash: 4.17.19
-      node-fetch: 2.6.0
-      semver: 5.7.1
-      tslib: 1.13.0
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    resolution:
-      integrity: sha512-rrXGtaQcGuR8qCkDmLXxJrdPaYMnOq34hViz9ZkYh+wSIWaOgDjSbZ3/NwFcgmLAXFceajN9BQRYxhkosrJZMQ==
-  /@microsoft/bf-lu/4.11.0-dev.20201021.d59abb5:
+      integrity: sha512-jhcpVBrFrFepevPZlP9iGJrUPh30E/L8yHr5wvX6jcSt/7RSVD+A7DIShDO+b8n45ii+8ZxVGqEGv7aN5ggp6g==
+  /@microsoft/bf-lu/4.11.0-dev.20201025.69cf2b9:
     dependencies:
       '@azure/cognitiveservices-luis-authoring': 4.0.0-preview.1
       '@azure/ms-rest-azure-js': 2.0.1
@@ -279,38 +228,15 @@ packages:
       get-stdin: 6.0.0
       globby: 10.0.2
       intercept-stdout: 0.1.2
-      lodash: 4.17.19
-      node-fetch: 2.6.0
+      lodash: 4.17.20
+      node-fetch: 2.6.1
       semver: 5.7.1
       tslib: 2.0.3
     dev: false
     engines:
       node: '>=8.0.0'
     resolution:
-      integrity: sha512-n22N9Vqq2lvMCm070he5oxZp4+cdD20vx5rayC1rXfzGHHKxpw8n1s2qIOU8bw8RhkCWga8EM3E6swLxiI8ybg==
-  /@microsoft/bf-lu/4.11.0-dev.20201023.4d90f4e:
-    dependencies:
-      '@azure/cognitiveservices-luis-authoring': 4.0.0-preview.1
-      '@azure/ms-rest-azure-js': 2.0.1
-      '@types/node-fetch': 2.5.7
-      antlr4: 4.8.0
-      chalk: 2.4.1
-      console-stream: 0.1.1
-      deep-equal: 1.1.1
-      delay: 4.4.0
-      fs-extra: 8.1.0
-      get-stdin: 6.0.0
-      globby: 10.0.2
-      intercept-stdout: 0.1.2
-      lodash: 4.17.19
-      node-fetch: 2.6.0
-      semver: 5.7.1
-      tslib: 2.0.3
-    dev: false
-    engines:
-      node: '>=8.0.0'
-    resolution:
-      integrity: sha512-kUbUg2nzyCcUJ7qEDXEAqlWXgRgBoJjLEAKIDAq21LD8ka9BfmCUqf3Z3yzzXf2IY6kh1eyhkZ7g/kb9dOHpmg==
+      integrity: sha512-mnMVxOiDkbXTsG7gHDbp4C65M3nELz0isvh/8MSlcnsy18q5lsvIi8lXeSONnfu3iePaUcwQfOiylXQKWtA7Ew==
   /@nodelib/fs.scandir/2.1.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.3
@@ -341,7 +267,7 @@ packages:
       '@oclif/errors': 1.3.3
       '@oclif/parser': 3.8.5
       '@oclif/plugin-help': 2.2.3
-      debug: 4.1.1
+      debug: 4.2.0
       semver: 5.7.1
     dev: false
     engines:
@@ -354,7 +280,7 @@ packages:
       '@oclif/errors': 1.3.3
       '@oclif/parser': 3.8.5
       '@oclif/plugin-help': 3.2.0
-      debug: 4.1.1
+      debug: 4.2.0
       semver: 7.3.2
     dev: false
     engines:
@@ -364,8 +290,8 @@ packages:
   /@oclif/config/1.13.3:
     dependencies:
       '@oclif/parser': 3.8.5
-      debug: 4.1.1
-      tslib: 1.13.0
+      debug: 4.2.0
+      tslib: 1.14.1
     dev: false
     engines:
       node: '>=8.0.0'
@@ -375,10 +301,10 @@ packages:
     dependencies:
       '@oclif/errors': 1.3.3
       '@oclif/parser': 3.8.5
-      debug: 4.1.1
+      debug: 4.2.0
       globby: 11.0.1
       is-wsl: 2.2.0
-      tslib: 2.0.1
+      tslib: 2.0.3
     dev: false
     engines:
       node: '>=8.0.0'
@@ -390,14 +316,14 @@ packages:
       '@oclif/config': 1.17.0
       '@oclif/errors': 1.3.3
       '@oclif/plugin-help': 2.2.3
-      cli-ux: 5.4.10
-      debug: 4.1.1
+      cli-ux: 5.5.0
+      debug: 4.2.0
       fs-extra: 7.0.1
       github-slugger: 1.3.0
-      lodash: 4.17.19
+      lodash: 4.17.20
       normalize-package-data: 2.5.0
       qqjs: 0.3.11
-      tslib: 1.13.0
+      tslib: 1.14.1
     dev: false
     engines:
       node: '>=8.10.0'
@@ -434,10 +360,10 @@ packages:
       integrity: sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==
   /@oclif/parser/3.8.5:
     dependencies:
-      '@oclif/errors': 1.3.3
+      '@oclif/errors': 1.2.2
       '@oclif/linewrap': 1.0.0
       chalk: 2.4.2
-      tslib: 1.13.0
+      tslib: 1.14.1
     dev: false
     engines:
       node: '>=8.0.0'
@@ -445,7 +371,7 @@ packages:
       integrity: sha512-yojzeEfmSxjjkAvMRj0KzspXlMjCfBzNRPkWw8ZwOSoNWoJn+OCS/m/S+yfV6BvAM4u2lTzX9Y5rCbrFIgkJLg==
   /@oclif/plugin-help/2.2.3:
     dependencies:
-      '@oclif/command': 1.8.0
+      '@oclif/command': 1.5.20
       chalk: 2.4.2
       indent-string: 4.0.0
       lodash.template: 4.5.0
@@ -480,14 +406,14 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==
-  /@oclif/test/1.2.6:
+  /@oclif/test/1.2.7:
     dependencies:
       fancy-test: 1.4.9
     dev: false
     engines:
       node: '>=8.0.0'
     resolution:
-      integrity: sha512-8BQm0VFwTf/JpDnI3x6Lbp3S4RRUvQcv8WalKm82+7FNEylWMAXFNgBuzG65cNPj11J2jhlVo0gOWGF6hbiaJQ==
+      integrity: sha512-1I8KQkOgScw18mr0zcly/OJjDW+kZnnmGXELaVBF69EZVzVgjE+Mz3EU1W29wf2rB7e8BqqtNrHzzoFu4oDuTw==
   /@oclif/tslint/3.1.1_tslint@5.20.1:
     dependencies:
       tslint-eslint-rules: 5.4.0_tslint@5.20.1
@@ -527,18 +453,18 @@ packages:
   /@sinonjs/formatio/5.0.1:
     dependencies:
       '@sinonjs/commons': 1.8.1
-      '@sinonjs/samsam': 5.1.0
+      '@sinonjs/samsam': 5.2.0
     dev: false
     resolution:
       integrity: sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==
-  /@sinonjs/samsam/5.1.0:
+  /@sinonjs/samsam/5.2.0:
     dependencies:
       '@sinonjs/commons': 1.8.1
       lodash.get: 4.4.2
       type-detect: 4.0.8
     dev: false
     resolution:
-      integrity: sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==
+      integrity: sha512-CaIcyX5cDsjcW/ab7HposFWzV1kC++4HNsfnEdFJa7cP1QIuILAKV+BgfeqRXhcnSAc76r/Rh/O5C+300BwUIw==
   /@sinonjs/text-encoding/0.7.1:
     dev: false
     resolution:
@@ -547,39 +473,35 @@ packages:
     dev: false
     resolution:
       integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==
-  /@types/chai/4.2.12:
+  /@types/chai/4.2.14:
     dev: false
     resolution:
-      integrity: sha512-aN5IAC8QNtSUdQzxu7lGBgYAOuU1tmRU4c9dIq5OKGf/SBVjXo+ffM2wEjudAWbgpOhy60nLoAGH1xm8fpCKFQ==
-  /@types/color-name/1.1.1:
-    dev: false
-    resolution:
-      integrity: sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+      integrity: sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==
   /@types/eslint-visitor-keys/1.0.0:
     dev: false
     resolution:
       integrity: sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
   /@types/fs-extra/8.1.1:
     dependencies:
-      '@types/node': 14.0.27
+      '@types/node': 14.14.5
     dev: false
     resolution:
       integrity: sha512-TcUlBem321DFQzBNuz8p0CLLKp0VvF/XH9E4KHNmgwyp4E3AfgI5cjiIVZWlbfThBop2qxFIh4+LeY6hVWWZ2w==
   /@types/glob/7.1.3:
     dependencies:
       '@types/minimatch': 3.0.3
-      '@types/node': 14.0.27
+      '@types/node': 14.14.5
     dev: false
     resolution:
       integrity: sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
-  /@types/json-schema/7.0.5:
+  /@types/json-schema/7.0.6:
     dev: false
     resolution:
-      integrity: sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
-  /@types/lodash/4.14.159:
+      integrity: sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
+  /@types/lodash/4.14.162:
     dev: false
     resolution:
-      integrity: sha512-gF7A72f7WQN33DpqOWw9geApQPh4M3PxluMtaHxWHXEGSN12/WbcEk/eNSqWNQcQhF66VSZ06vCF94CrHwXJDg==
+      integrity: sha512-alvcho1kRUnnD1Gcl4J+hK0eencvzq9rmzvFPRmP5rPHx9VVsJj6bKLTATPVf9ktgv4ujzh7T+XWKp+jhuODig==
   /@types/minimatch/3.0.3:
     dev: false
     resolution:
@@ -588,41 +510,34 @@ packages:
     dev: false
     resolution:
       integrity: sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
-  /@types/nock/11.1.0:
-    dependencies:
-      nock: 11.9.1
-    deprecated: 'This is a stub types definition. nock provides its own type definitions, so you do not need this installed.'
-    dev: false
-    resolution:
-      integrity: sha512-jI/ewavBQ7X5178262JQR0ewicPAcJhXS/iFaNJl0VHLfyosZ/kwSrsa6VNQNSO8i9d8SqdRgOtZSOKJ/+iNMw==
   /@types/node-fetch/2.5.7:
     dependencies:
-      '@types/node': 14.0.27
+      '@types/node': 14.14.5
       form-data: 3.0.0
     dev: false
     resolution:
       integrity: sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==
-  /@types/node/10.17.28:
+  /@types/node/10.17.43:
     dev: false
     resolution:
-      integrity: sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ==
-  /@types/node/14.0.27:
+      integrity: sha512-F7xV2kxZGb3seVP3UQt3msHcoDCtDi8WNO/UCzNLhRwaYVT4yJO1ndcV+vCTnY+jiAVqyLZq/VJbRE/AhwqEag==
+  /@types/node/14.14.5:
     dev: false
     resolution:
-      integrity: sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
-  /@types/sinon/9.0.4:
+      integrity: sha512-H5Wn24s/ZOukBmDn03nnGTp18A60ny9AmCwnEcgJiTgSGsCO7k+NWP7zjCCbhlcnVCoI+co52dUAt9GMhOSULw==
+  /@types/sinon/9.0.8:
     dependencies:
-      '@types/sinonjs__fake-timers': 6.0.1
+      '@types/sinonjs__fake-timers': 6.0.2
     dev: false
     resolution:
-      integrity: sha512-sJmb32asJZY6Z2u09bl0G2wglSxDlROlAejCjsnor+LzBMz17gu8IU7vKC/vWDnv9zEq2wqADHVXFjf4eE8Gdw==
-  /@types/sinonjs__fake-timers/6.0.1:
+      integrity: sha512-IVnI820FZFMGI+u1R+2VdRaD/82YIQTdqLYC9DLPszZuynAJDtCvCtCs3bmyL66s7FqRM3+LPX7DhHnVTaagDw==
+  /@types/sinonjs__fake-timers/6.0.2:
     dev: false
     resolution:
-      integrity: sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==
+      integrity: sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==
   /@types/tunnel/0.0.1:
     dependencies:
-      '@types/node': 14.0.27
+      '@types/node': 14.14.5
     dev: false
     resolution:
       integrity: sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==
@@ -669,10 +584,10 @@ packages:
       integrity: sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==
   /@typescript-eslint/experimental-utils/2.34.0_eslint@5.16.0:
     dependencies:
-      '@types/json-schema': 7.0.5
+      '@types/json-schema': 7.0.6
       '@typescript-eslint/typescript-estree': 2.34.0
       eslint: 5.16.0
-      eslint-scope: 5.1.0
+      eslint-scope: 5.1.1
       eslint-utils: 2.1.0
     dev: false
     engines:
@@ -684,10 +599,10 @@ packages:
       integrity: sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
   /@typescript-eslint/experimental-utils/2.34.0_eslint@5.16.0+typescript@3.9.7:
     dependencies:
-      '@types/json-schema': 7.0.5
+      '@types/json-schema': 7.0.6
       '@typescript-eslint/typescript-estree': 2.34.0_typescript@3.9.7
       eslint: 5.16.0
-      eslint-scope: 5.1.0
+      eslint-scope: 5.1.1
       eslint-utils: 2.1.0
     dev: false
     engines:
@@ -736,11 +651,11 @@ packages:
       integrity: sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==
   /@typescript-eslint/typescript-estree/2.34.0:
     dependencies:
-      debug: 4.1.1
+      debug: 4.2.0
       eslint-visitor-keys: 1.3.0
       glob: 7.1.6
       is-glob: 4.0.1
-      lodash: 4.17.19
+      lodash: 4.17.20
       semver: 7.3.2
       tsutils: 3.17.1
     dev: false
@@ -755,11 +670,11 @@ packages:
       integrity: sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==
   /@typescript-eslint/typescript-estree/2.34.0_typescript@3.9.7:
     dependencies:
-      debug: 4.1.1
+      debug: 4.2.0
       eslint-visitor-keys: 1.3.0
       glob: 7.1.6
       is-glob: 4.0.1
-      lodash: 4.17.19
+      lodash: 4.17.20
       semver: 7.3.2
       tsutils: 3.17.1_typescript@3.9.7
       typescript: 3.9.7
@@ -785,51 +700,42 @@ packages:
       node: '>=6.5'
     resolution:
       integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
-  /acorn-jsx/5.2.0_acorn@6.4.1:
+  /acorn-jsx/5.3.1_acorn@6.4.2:
     dependencies:
-      acorn: 6.4.1
+      acorn: 6.4.2
     dev: false
     peerDependencies:
-      acorn: ^6.0.0 || ^7.0.0
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     resolution:
-      integrity: sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==
-  /acorn/6.4.1:
+      integrity: sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
+  /acorn/6.4.2:
     dev: false
     engines:
       node: '>=0.4.0'
     hasBin: true
     resolution:
-      integrity: sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
-  /ajv/5.5.2:
-    dependencies:
-      co: 4.6.0
-      fast-deep-equal: 1.1.0
-      fast-json-stable-stringify: 2.1.0
-      json-schema-traverse: 0.3.1
-    dev: false
-    resolution:
-      integrity: sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=
-  /ajv/6.12.3:
+      integrity: sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
+  /ajv/6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
-      uri-js: 4.2.2
+      uri-js: 4.4.0
     dev: false
     resolution:
-      integrity: sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
-  /all-unpacker/0.1.3:
+      integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+  /all-unpacker/0.1.5:
     dependencies:
       array-map: 0.0.0
       npmlog: 4.1.2
     dev: false
     optionalDependencies:
-      node-wget: 0.4.3
+      node-stream-zip: 1.11.3
+      node-wget-js: 0.4.4
       system-installer: 1.1.0
-      unzipper: 0.9.15
     requiresBuild: true
     resolution:
-      integrity: sha512-v57wZwUKl8Te2lr3WgRjCDh6lJiLDOP99ygR8G7CDK33wubxBIvTAOv92U9kIs0je/rGyZs96xVFHPnbl7ZWVw==
+      integrity: sha512-QktwQOtAQjpM5wBLFSkg20l2eseblikh7G0BTCkkphmaN29JRcO4TE3k4uJCJ0/onz2Um7TeMHuo2j4nIwKoyg==
   /ansi-colors/3.2.3:
     dev: false
     engines:
@@ -882,15 +788,14 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
-  /ansi-styles/4.2.1:
+  /ansi-styles/4.3.0:
     dependencies:
-      '@types/color-name': 1.1.1
       color-convert: 2.0.1
     dev: false
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
+      integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   /ansicolors/0.3.2:
     dev: false
     resolution:
@@ -907,7 +812,7 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==
-  /applicationinsights/1.8.5:
+  /applicationinsights/1.8.7:
     dependencies:
       cls-hooked: 4.2.2
       continuation-local-storage: 3.2.1
@@ -915,7 +820,7 @@ packages:
       diagnostic-channel-publishers: 0.4.1_diagnostic-channel@0.3.1
     dev: false
     resolution:
-      integrity: sha512-pv0qdk9phD20e3+ftCyJzfRxCVpqHxBf77SrdJWFSbBC7S9fdzPpAZyb6j4onfeKCEEAxKEajNCRNDF1pH5SJA==
+      integrity: sha512-+HENzPBdSjnWL9mc+9o+j9pEaVNI4WsH5RNvfmRLfwQYvbJumcBi4S5bUzclug5KCcFP0S4bYJOmm9MV3kv2GA==
   /aproba/1.2.0:
     dev: false
     resolution:
@@ -1004,10 +909,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
-  /aws4/1.10.0:
+  /aws4/1.10.1:
     dev: false
     resolution:
-      integrity: sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==
+      integrity: sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
   /balanced-match/1.0.0:
     dev: false
     resolution:
@@ -1022,56 +927,18 @@ packages:
     dev: false
     resolution:
       integrity: sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
-  /big-integer/1.6.48:
-    dev: false
-    engines:
-      node: '>=0.6'
-    optional: true
-    resolution:
-      integrity: sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
-  /binary/0.3.0:
-    dependencies:
-      buffers: 0.1.1
-      chainsaw: 0.1.0
-    dev: false
-    optional: true
-    resolution:
-      integrity: sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=
   /bindings/1.2.1:
     dev: false
     resolution:
       integrity: sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=
-  /bl/4.0.2:
+  /bl/4.0.3:
     dependencies:
-      buffer: 5.6.0
+      buffer: 5.6.1
       inherits: 2.0.4
       readable-stream: 3.6.0
     dev: false
     resolution:
-      integrity: sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==
-  /bluebird/3.4.7:
-    dev: false
-    optional: true
-    resolution:
-      integrity: sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=
-  /boom/4.3.1:
-    dependencies:
-      hoek: 4.2.1
-    deprecated: 'This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).'
-    dev: false
-    engines:
-      node: '>=4.0.0'
-    resolution:
-      integrity: sha1-T4owBctKfjiJ90kDD9JbluAdLjE=
-  /boom/5.2.0:
-    dependencies:
-      hoek: 4.2.1
-    deprecated: 'This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).'
-    dev: false
-    engines:
-      node: '>=4.0.0'
-    resolution:
-      integrity: sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==
+      integrity: sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==
   /brace-expansion/1.1.11:
     dependencies:
       balanced-match: 1.0.0
@@ -1095,27 +962,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
-  /buffer-indexof-polyfill/1.0.1:
-    dev: false
-    engines:
-      node: '>=0.10'
-    optional: true
-    resolution:
-      integrity: sha1-qfuAbOgUXVQoUQznLyeLs2OmOL8=
-  /buffer/5.6.0:
+  /buffer/5.6.1:
     dependencies:
       base64-js: 1.3.1
       ieee754: 1.1.13
     dev: false
     resolution:
-      integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
-  /buffers/0.1.1:
-    dev: false
-    engines:
-      node: '>=0.2.0'
-    optional: true
-    resolution:
-      integrity: sha1-skV5w77U1tOWru5tmorn9Ugqt7s=
+      integrity: sha512-2z15UUHpS9/3tk9mY/q+Rl3rydOi7yMp5XWNQnRvoz+mJwiv8brqYwp9a+nOCtma6dwuEIxljD8W3ysVBZ05Vg==
   /builtin-modules/1.1.1:
     dev: false
     engines:
@@ -1170,13 +1023,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
-  /chainsaw/0.1.0:
-    dependencies:
-      traverse: 0.3.9
-    dev: false
-    optional: true
-    resolution:
-      integrity: sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=
   /chalk/2.4.1:
     dependencies:
       ansi-styles: 3.2.1
@@ -1199,8 +1045,8 @@ packages:
       integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
   /chalk/4.1.0:
     dependencies:
-      ansi-styles: 4.2.1
-      supports-color: 7.1.0
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
     dev: false
     engines:
       node: '>=10'
@@ -1277,34 +1123,34 @@ packages:
       ansi-escapes: 3.2.0
       ansi-styles: 3.2.1
       cardinal: 2.1.1
-      chalk: 2.4.2
+      chalk: 2.4.1
       clean-stack: 2.2.0
       extract-stack: 1.0.0
       fs-extra: 7.0.1
       hyperlinker: 1.0.0
       indent-string: 3.2.0
       is-wsl: 1.1.0
-      lodash: 4.17.19
+      lodash: 4.17.20
       password-prompt: 1.1.2
       semver: 5.7.1
       strip-ansi: 5.2.0
       supports-color: 5.5.0
       supports-hyperlinks: 1.0.1
       treeify: 1.1.0
-      tslib: 1.13.0
+      tslib: 1.14.1
     dev: false
     engines:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-/1owvF0SZ5Gn54cgrikJ0QskgTzeg30HGjkmjFoaHDJzAqFpuX1DBpFR8aLvsE1J5s9MgeYRENQK4BFwOag5VA==
-  /cli-ux/5.4.10:
+  /cli-ux/5.5.0:
     dependencies:
       '@oclif/command': 1.8.0
       '@oclif/errors': 1.3.3
       '@oclif/linewrap': 1.0.0
       '@oclif/screen': 1.0.4
       ansi-escapes: 4.3.1
-      ansi-styles: 4.2.1
+      ansi-styles: 4.3.0
       cardinal: 2.1.1
       chalk: 4.1.0
       clean-stack: 3.0.0
@@ -1315,21 +1161,21 @@ packages:
       indent-string: 4.0.0
       is-wsl: 2.2.0
       js-yaml: 3.14.0
-      lodash: 4.17.19
+      lodash: 4.17.20
       natural-orderby: 2.0.3
-      object-treeify: 1.1.26
+      object-treeify: 1.1.29
       password-prompt: 1.1.2
       semver: 7.3.2
       string-width: 4.2.0
       strip-ansi: 6.0.0
-      supports-color: 7.1.0
+      supports-color: 7.2.0
       supports-hyperlinks: 2.1.0
-      tslib: 2.0.1
+      tslib: 2.0.3
     dev: false
     engines:
       node: '>=8.0.0'
     resolution:
-      integrity: sha512-s48Efw04VtGyQEwXDrERobMc2DF2DyYQ+2nmNsM7clxOVDtbRI9OjbXRwPeS6G2aFuHy0bB8GUq5MzkmkYt7yw==
+      integrity: sha512-aXoHgEOtkem8sJmQrU/jXsojCq8uOp8++9lybCbt9mFDyPouSNawSdoPjuM00PPaSPCJThvY0VNYOQNd6gGQCA==
   /cli-width/2.2.1:
     dev: false
     resolution:
@@ -1352,13 +1198,6 @@ packages:
       node: ^4.7 || >=6.9 || >=7.3 || >=8.2.1
     resolution:
       integrity: sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==
-  /co/4.6.0:
-    dev: false
-    engines:
-      iojs: '>= 1.0.0'
-      node: '>= 0.12.0'
-    resolution:
-      integrity: sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
   /code-point-at/1.1.0:
     dev: false
     engines:
@@ -1479,13 +1318,16 @@ packages:
       node: '>=4.8'
     resolution:
       integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
-  /cryptiles/3.1.4:
+  /cross-spawn/7.0.3:
     dependencies:
-      boom: 5.2.0
-    deprecated: 'This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).'
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
     dev: false
+    engines:
+      node: '>= 8'
     resolution:
-      integrity: sha512-8I1sgZHfVwcSOY6mSGpVU3lw/GSIZvusg8dD2+OGehCJpOhQRLNcH0qb9upQnOH4XhgxxFJSg6E2kx95deb1Tw==
+      integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
   /dashdash/1.14.1:
     dependencies:
       assert-plus: 1.0.0
@@ -1506,12 +1348,19 @@ packages:
     dev: false
     resolution:
       integrity: sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  /debug/4.1.1:
+  /debug/4.2.0:
     dependencies:
       ms: 2.1.2
     dev: false
+    engines:
+      node: '>=6.0'
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     resolution:
-      integrity: sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+      integrity: sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
   /decamelize/1.2.0:
     dev: false
     engines:
@@ -1539,7 +1388,7 @@ packages:
       is-arguments: 1.0.4
       is-date-object: 1.0.2
       is-regex: 1.1.1
-      object-is: 1.1.2
+      object-is: 1.1.3
       object-keys: 1.1.1
       regexp.prototype.flags: 1.3.0
     dev: false
@@ -1651,13 +1500,6 @@ packages:
       node: '>=6.0.0'
     resolution:
       integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
-  /duplexer2/0.1.4:
-    dependencies:
-      readable-stream: 2.3.7
-    dev: false
-    optional: true
-    resolution:
-      integrity: sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=
   /ecc-jsbn/0.1.2:
     dependencies:
       jsbn: 0.1.1
@@ -1701,27 +1543,46 @@ packages:
     dev: false
     resolution:
       integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
-  /es-abstract/1.17.6:
+  /es-abstract/1.17.7:
     dependencies:
       es-to-primitive: 1.2.1
       function-bind: 1.1.1
       has: 1.0.3
       has-symbols: 1.0.1
-      is-callable: 1.2.0
+      is-callable: 1.2.2
       is-regex: 1.1.1
       object-inspect: 1.8.0
       object-keys: 1.1.1
-      object.assign: 4.1.0
-      string.prototype.trimend: 1.0.1
-      string.prototype.trimstart: 1.0.1
+      object.assign: 4.1.1
+      string.prototype.trimend: 1.0.2
+      string.prototype.trimstart: 1.0.2
     dev: false
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==
+      integrity: sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==
+  /es-abstract/1.18.0-next.1:
+    dependencies:
+      es-to-primitive: 1.2.1
+      function-bind: 1.1.1
+      has: 1.0.3
+      has-symbols: 1.0.1
+      is-callable: 1.2.2
+      is-negative-zero: 2.0.0
+      is-regex: 1.1.1
+      object-inspect: 1.8.0
+      object-keys: 1.1.1
+      object.assign: 4.1.1
+      string.prototype.trimend: 1.0.2
+      string.prototype.trimstart: 1.0.2
+    dev: false
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==
   /es-to-primitive/1.2.1:
     dependencies:
-      is-callable: 1.2.0
+      is-callable: 1.2.2
       is-date-object: 1.0.2
       is-symbol: 1.0.3
     dev: false
@@ -1852,7 +1713,7 @@ packages:
       eslint-utils: 1.4.3
       ignore: 4.0.6
       minimatch: 3.0.4
-      resolve: 1.17.0
+      resolve: 1.18.1
       semver: 5.7.1
     dev: false
     engines:
@@ -1881,22 +1742,22 @@ packages:
       integrity: sha512-hjy9LhTdtL7pz8WTrzS0CGXRkWK3VAPLDjihofj8JC+uxQLfXm0WwZPPPB7xKmcjRyoH+jruPHOCrHNEINpG/Q==
   /eslint-scope/4.0.3:
     dependencies:
-      esrecurse: 4.2.1
+      esrecurse: 4.3.0
       estraverse: 4.3.0
     dev: false
     engines:
       node: '>=4.0.0'
     resolution:
       integrity: sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
-  /eslint-scope/5.1.0:
+  /eslint-scope/5.1.1:
     dependencies:
-      esrecurse: 4.2.1
+      esrecurse: 4.3.0
       estraverse: 4.3.0
     dev: false
     engines:
       node: '>=8.0.0'
     resolution:
-      integrity: sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==
+      integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
   /eslint-utils/1.4.3:
     dependencies:
       eslint-visitor-keys: 1.3.0
@@ -1922,10 +1783,10 @@ packages:
   /eslint/5.16.0:
     dependencies:
       '@babel/code-frame': 7.10.4
-      ajv: 6.12.3
+      ajv: 6.12.6
       chalk: 2.4.2
       cross-spawn: 6.0.5
-      debug: 4.1.1
+      debug: 4.2.0
       doctrine: 3.0.0
       eslint-scope: 4.0.3
       eslint-utils: 1.4.3
@@ -1944,7 +1805,7 @@ packages:
       js-yaml: 3.14.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.3.0
-      lodash: 4.17.19
+      lodash: 4.17.20
       minimatch: 3.0.4
       mkdirp: 0.5.5
       natural-compare: 1.4.0
@@ -1965,8 +1826,8 @@ packages:
       integrity: sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==
   /espree/5.0.1:
     dependencies:
-      acorn: 6.4.1
-      acorn-jsx: 5.2.0_acorn@6.4.1
+      acorn: 6.4.2
+      acorn-jsx: 5.3.1_acorn@6.4.2
       eslint-visitor-keys: 1.3.0
     dev: false
     engines:
@@ -1988,14 +1849,14 @@ packages:
       node: '>=0.10'
     resolution:
       integrity: sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==
-  /esrecurse/4.2.1:
+  /esrecurse/4.3.0:
     dependencies:
-      estraverse: 4.3.0
+      estraverse: 5.2.0
     dev: false
     engines:
       node: '>=4.0'
     resolution:
-      integrity: sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==
+      integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
   /estraverse/4.3.0:
     dev: false
     engines:
@@ -2080,11 +1941,11 @@ packages:
       integrity: sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
   /fancy-test/1.4.9:
     dependencies:
-      '@types/chai': 4.2.12
-      '@types/lodash': 4.14.159
-      '@types/node': 14.0.27
-      '@types/sinon': 9.0.4
-      lodash: 4.17.19
+      '@types/chai': 4.2.14
+      '@types/lodash': 4.14.162
+      '@types/node': 14.14.5
+      '@types/sinon': 9.0.8
+      lodash: 4.17.20
       mock-stdin: 1.0.0
       stdout-stderr: 0.1.13
     dev: false
@@ -2092,10 +1953,6 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-Tro3lkXPX438G3t2N9BDgD3ac5iUhNnxIE8tg/KL6z7eZ5GOCexs7fDEMacduqvJWPvsRlmyQ69V1jiTVcqkXQ==
-  /fast-deep-equal/1.1.0:
-    dev: false
-    resolution:
-      integrity: sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=
   /fast-deep-equal/3.1.3:
     dev: false
     resolution:
@@ -2192,14 +2049,13 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
-  /flat/4.1.0:
+  /flat/4.1.1:
     dependencies:
       is-buffer: 2.0.4
-    deprecated: 'Fixed a prototype pollution security issue in 4.1.0, please upgrade to ^4.1.1 or ^5.0.1.'
     dev: false
     hasBin: true
     resolution:
-      integrity: sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==
+      integrity: sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==
   /flatted/2.0.2:
     dev: false
     resolution:
@@ -2306,18 +2162,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
-  /fstream/1.0.12:
-    dependencies:
-      graceful-fs: 4.2.4
-      inherits: 2.0.4
-      mkdirp: 0.5.5
-      rimraf: 2.7.1
-    dev: false
-    engines:
-      node: '>=0.6'
-    optional: true
-    resolution:
-      integrity: sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
   /function-bind/1.1.1:
     dev: false
     resolution:
@@ -2476,19 +2320,9 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
-  /har-validator/5.0.3:
-    dependencies:
-      ajv: 5.5.2
-      har-schema: 2.0.0
-    deprecated: this library is no longer supported
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=
   /har-validator/5.1.5:
     dependencies:
-      ajv: 6.12.3
+      ajv: 6.12.6
       har-schema: 2.0.0
     deprecated: this library is no longer supported
     dev: false
@@ -2540,18 +2374,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=
-  /hawk/6.0.2:
-    dependencies:
-      boom: 4.3.1
-      cryptiles: 3.1.4
-      hoek: 4.2.1
-      sntp: 2.1.0
-    deprecated: This module moved to @hapi/hawk. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.
-    dev: false
-    engines:
-      node: '>=4.5.0'
-    resolution:
-      integrity: sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==
   /he/1.1.1:
     dev: false
     hasBin: true
@@ -2562,13 +2384,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
-  /hoek/4.2.1:
-    deprecated: 'This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).'
-    dev: false
-    engines:
-      node: '>=4.0.0'
-    resolution:
-      integrity: sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==
   /hosted-git-info/2.8.8:
     dev: false
     resolution:
@@ -2580,7 +2395,7 @@ packages:
   /http-call/5.3.0:
     dependencies:
       content-type: 1.0.4
-      debug: 4.1.1
+      debug: 4.2.0
       is-retry-allowed: 1.2.0
       is-stream: 2.0.0
       parse-json: 4.0.0
@@ -2693,10 +2508,10 @@ packages:
       cli-width: 2.2.1
       external-editor: 3.1.0
       figures: 2.0.0
-      lodash: 4.17.19
+      lodash: 4.17.20
       mute-stream: 0.0.7
       run-async: 2.4.1
-      rxjs: 6.6.2
+      rxjs: 6.6.3
       string-width: 2.1.1
       strip-ansi: 5.2.0
       through: 2.3.8
@@ -2737,12 +2552,18 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
-  /is-callable/1.2.0:
+  /is-callable/1.2.2:
     dev: false
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
+      integrity: sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==
+  /is-core-module/2.0.0:
+    dependencies:
+      has: 1.0.3
+    dev: false
+    resolution:
+      integrity: sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==
   /is-date-object/1.0.2:
     dev: false
     engines:
@@ -2790,6 +2611,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  /is-negative-zero/2.0.0:
+    dev: false
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=
   /is-number/7.0.0:
     dev: false
     engines:
@@ -2886,11 +2713,11 @@ packages:
       integrity: sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==
   /istanbul-lib-instrument/3.3.0:
     dependencies:
-      '@babel/generator': 7.11.0
-      '@babel/parser': 7.11.3
+      '@babel/generator': 7.12.1
+      '@babel/parser': 7.12.3
       '@babel/template': 7.10.4
-      '@babel/traverse': 7.11.0
-      '@babel/types': 7.11.0
+      '@babel/traverse': 7.12.1
+      '@babel/types': 7.12.1
       istanbul-lib-coverage: 2.0.5
       semver: 6.3.0
     dev: false
@@ -2910,7 +2737,7 @@ packages:
       integrity: sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==
   /istanbul-lib-source-maps/3.0.6:
     dependencies:
-      debug: 4.1.1
+      debug: 4.2.0
       istanbul-lib-coverage: 2.0.5
       make-dir: 2.1.0
       rimraf: 2.7.1
@@ -2969,10 +2796,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
-  /json-schema-traverse/0.3.1:
+  /json-parse-even-better-errors/2.3.1:
     dev: false
     resolution:
-      integrity: sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=
+      integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
   /json-schema-traverse/0.4.1:
     dev: false
     resolution:
@@ -3014,10 +2841,10 @@ packages:
       '0': node >=0.6.0
     resolution:
       integrity: sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
-  /just-extend/4.1.0:
+  /just-extend/4.1.1:
     dev: false
     resolution:
-      integrity: sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==
+      integrity: sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==
   /levn/0.3.0:
     dependencies:
       prelude-ls: 1.1.2
@@ -3031,11 +2858,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
-  /listenercount/1.0.1:
-    dev: false
-    optional: true
-    resolution:
-      integrity: sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=
   /load-json-file/4.0.0:
     dependencies:
       graceful-fs: 4.2.4
@@ -3050,7 +2872,7 @@ packages:
   /load-json-file/6.2.0:
     dependencies:
       graceful-fs: 4.2.4
-      parse-json: 5.0.1
+      parse-json: 5.1.0
       strip-bom: 4.0.0
       type-fest: 0.6.0
     dev: false
@@ -3156,10 +2978,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
-  /lodash/4.17.19:
+  /lodash/4.17.20:
     dev: false
     resolution:
-      integrity: sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+      integrity: sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
   /log-symbols/2.2.0:
     dependencies:
       chalk: 2.4.2
@@ -3284,7 +3106,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
-  /minizlib/2.1.0:
+  /minizlib/2.1.2:
     dependencies:
       minipass: 3.1.3
       yallist: 4.0.0
@@ -3292,7 +3114,7 @@ packages:
     engines:
       node: '>= 8'
     resolution:
-      integrity: sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==
+      integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
   /mkdirp-classic/0.5.3:
     dev: false
     resolution:
@@ -3409,7 +3231,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q==
-  /needle/2.5.0:
+  /needle/2.5.2:
     dependencies:
       debug: 3.2.6
       iconv-lite: 0.4.24
@@ -3419,7 +3241,7 @@ packages:
       node: '>= 4.4.x'
     hasBin: true
     resolution:
-      integrity: sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==
+      integrity: sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==
   /nested-error-stacks/2.1.0:
     dev: false
     resolution:
@@ -3433,16 +3255,16 @@ packages:
       '@sinonjs/commons': 1.8.1
       '@sinonjs/fake-timers': 6.0.1
       '@sinonjs/text-encoding': 0.7.1
-      just-extend: 4.1.0
+      just-extend: 4.1.1
       path-to-regexp: 1.8.0
     dev: false
     resolution:
       integrity: sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==
   /nock/11.9.1:
     dependencies:
-      debug: 4.1.1
+      debug: 4.2.0
       json-stringify-safe: 5.0.1
-      lodash: 4.17.19
+      lodash: 4.17.20
       mkdirp: 0.5.5
       propagate: 2.0.1
     dev: false
@@ -3450,30 +3272,30 @@ packages:
       node: '>= 8.0'
     resolution:
       integrity: sha512-U5wPctaY4/ar2JJ5Jg4wJxlbBfayxgKbiAeGh+a1kk6Pwnc2ZEuKviLyDSG6t0uXl56q7AALIxoM6FJrBSsVXA==
-  /node-7z-forall/1.0.5:
+  /node-7z-forall/1.0.9:
     dependencies:
-      all-unpacker: 0.1.3
-      cross-spawn: 6.0.5
+      all-unpacker: 0.1.5
+      cross-spawn: 7.0.3
       fs-extra: 8.1.0
       macos-release: 2.4.1
-      node-wget: 0.4.3
+      node-wget-js: 0.4.4
       retrying-promise: 0.0.4
       system-installer: 1.1.0
       when: 3.7.8
     dev: false
     requiresBuild: true
     resolution:
-      integrity: sha512-CbIKpG/AUclpBmfisVWH0BWFaOU12OZXi0luDFMVNxiJ3GRVbkUjMfuD0PNtl7MIuQZjFiBTnkJu3whfwjAe0w==
+      integrity: sha512-91a+c3ZAJQK+9a0/XXqdxjj1FESlVxNXzXgUVvP49VeSxTwYSYe6hMU7QaS8F9XZBYuGbPvpUXM6E7+WAHMNmA==
   /node-abi/2.19.1:
     dependencies:
       semver: 5.7.1
     dev: false
     resolution:
       integrity: sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==
-  /node-addon-api/3.0.0:
+  /node-addon-api/3.0.2:
     dev: false
     resolution:
-      integrity: sha512-sSHCgWfJ+Lui/u+0msF3oyCgvdkhxDbkCS6Q8uiJquzOimkJBvX6hl5aSSA7DR1XbMpdM8r7phjcF63sF4rkKg==
+      integrity: sha512-+D4s2HCnxPd5PjjI0STKwncjXTUKKqm74MDMz9OPXavjsGmjkvwgLtA5yoxJUdmpj52+2u+RrXgPipahKczMKg==
   /node-environment-flags/1.0.5:
     dependencies:
       object.getownpropertydescriptors: 2.1.0
@@ -3481,12 +3303,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==
-  /node-fetch/2.6.0:
+  /node-fetch/2.6.1:
     dev: false
     engines:
       node: 4.x || >=6.0.0
     resolution:
-      integrity: sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+      integrity: sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
   /node-gyp/7.0.0:
     dependencies:
       env-paths: 2.2.0
@@ -3497,7 +3319,7 @@ packages:
       request: 2.88.2
       rimraf: 2.7.1
       semver: 7.3.2
-      tar: 6.0.2
+      tar: 6.0.5
       which: 2.0.2
     dev: false
     engines:
@@ -3509,7 +3331,7 @@ packages:
     dependencies:
       detect-libc: 1.0.3
       mkdirp: 0.5.5
-      needle: 2.5.0
+      needle: 2.5.2
       nopt: 4.0.3
       npm-packlist: 1.4.8
       npmlog: 4.1.2
@@ -3521,15 +3343,22 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-7QcZa8/fpaU/BKenjcaeFF9hLz2+7S9AqyXFhlH/rilsQ/hPZKK32RtR5EQHJElgu+q5RfbJ34KriI79UWaorA==
-  /node-wget/0.4.3:
+  /node-stream-zip/1.11.3:
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    optional: true
+    resolution:
+      integrity: sha512-GY+9LxkQuIT3O7K8BTdHVGKFcBYBy2vAVcTBtkKpu+OlBef/NSb6VuIWSyLiVDfmLMkggHeRJZN0F3W0GWU/uw==
+  /node-wget-js/0.4.4:
     dependencies:
-      request: 2.85.0
+      request: 2.88.2
     dev: false
     engines:
       node: '>=0.8.6'
     hasBin: true
     resolution:
-      integrity: sha512-sltt/nc4NJeI4CuncyBFZZ7W4Wz3Q1oM8h27mYEbj5OihXMsuqJpplPl0WUZTSpXy8AyGczT08jIBsXHxdCtgg==
+      integrity: sha512-0HXEIQg7d74Dbdl09tlDQji6pi/AXgcQzXBGHshF4jPP7vA8583aNn1S3vrCh0m7NVGScA5/hdVWmJtinDiZPQ==
   /noop-logger/0.1.1:
     dev: false
     resolution:
@@ -3545,7 +3374,7 @@ packages:
   /normalize-package-data/2.5.0:
     dependencies:
       hosted-git-info: 2.8.8
-      resolve: 1.17.0
+      resolve: 1.18.1
       semver: 5.7.1
       validate-npm-package-license: 3.0.4
     dev: false
@@ -3625,10 +3454,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-OI0vm6ZGUnoGZv/tLdZ2esSVzDwUC88SNs+6JoSOMVxA+gKMB8Tk7jBwgemLx4O40lhhvZCVw1C+OYLOBOPXWw==
-  /oauth-sign/0.8.2:
-    dev: false
-    resolution:
-      integrity: sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=
   /oauth-sign/0.9.0:
     dev: false
     resolution:
@@ -3643,27 +3468,27 @@ packages:
     dev: false
     resolution:
       integrity: sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
-  /object-is/1.1.2:
+  /object-is/1.1.3:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.17.6
+      es-abstract: 1.18.0-next.1
     dev: false
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==
+      integrity: sha512-teyqLvFWzLkq5B9ki8FVWA902UER2qkxmdA4nLf+wjOLAWgxzCWZNCxpDq9MvE8MmhWNr+I8w3BN49Vx36Y6Xg==
   /object-keys/1.1.1:
     dev: false
     engines:
       node: '>= 0.4'
     resolution:
       integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
-  /object-treeify/1.1.26:
+  /object-treeify/1.1.29:
     dev: false
     engines:
       node: '>= 10'
     resolution:
-      integrity: sha512-0WTfU7SGM8umY4YPpOg+oHXL66E6dPVCr+sMR6KitPmvg8CkVrHUUZYEFtx0+5Wb0HjFEsBwBYXyGRNeX7c/oQ==
+      integrity: sha512-XnPIMyiv6fJeb/z3Bz+u43Fcw3C9fs1uoRITd8x3mau/rsSAUhx7qpIO10Q/dzJeMleJesccUSMiFx8FF+ruBA==
   /object.assign/4.1.0:
     dependencies:
       define-properties: 1.1.3
@@ -3675,10 +3500,21 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
+  /object.assign/4.1.1:
+    dependencies:
+      define-properties: 1.1.3
+      es-abstract: 1.18.0-next.1
+      has-symbols: 1.0.1
+      object-keys: 1.1.1
+    dev: false
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==
   /object.getownpropertydescriptors/2.1.0:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.17.6
+      es-abstract: 1.17.7
     dev: false
     engines:
       node: '>= 0.8'
@@ -3722,17 +3558,17 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
-  /orchestrator-core/4.11.0-dev.20201023.49095d1:
+  /orchestrator-core/4.11.0-dev.20201024.0c5247b:
     dependencies:
       bindings: 1.2.1
-      node-addon-api: 3.0.0
+      node-addon-api: 3.0.2
       node-gyp: 7.0.0
       node-pre-gyp: 0.15.0
       onnxruntime: 1.4.0
     dev: false
     requiresBuild: true
     resolution:
-      integrity: sha512-p17egAvKcnSnQUyk70ivTBCwI0UBmRoB9vePInVzVsBddexjFttSSTZGfJ62KS94orC3xPb+UCiGaWWcHbNxZA==
+      integrity: sha512-MFSwy1+vsFxkt0DdjAFyn98hng7Hsy9BbMRBvHRKdu5aM/W0lrg1LkETSEWlbmd1Edzgi+GptkdClcdMpXqyUg==
   /os-homedir/1.0.2:
     dev: false
     engines:
@@ -3816,17 +3652,17 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
-  /parse-json/5.0.1:
+  /parse-json/5.1.0:
     dependencies:
       '@babel/code-frame': 7.10.4
       error-ex: 1.3.2
-      json-parse-better-errors: 1.0.2
+      json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.1.6
     dev: false
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==
+      integrity: sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==
   /password-prompt/1.1.2:
     dependencies:
       ansi-escapes: 3.2.0
@@ -3862,6 +3698,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
+  /path-key/3.1.1:
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
   /path-parse/1.0.6:
     dev: false
     resolution:
@@ -3988,10 +3830,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
-  /punycode/1.4.1:
-    dev: false
-    resolution:
-      integrity: sha1-wNWmOycYgArY4esPpSachN1BhF4=
   /punycode/2.1.1:
     dev: false
     engines:
@@ -4001,7 +3839,7 @@ packages:
   /qqjs/0.3.11:
     dependencies:
       chalk: 2.4.2
-      debug: 4.1.1
+      debug: 4.2.0
       execa: 0.10.0
       fs-extra: 6.0.1
       get-stream: 5.2.0
@@ -4105,7 +3943,7 @@ packages:
   /regexp.prototype.flags/1.3.0:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.17.6
+      es-abstract: 1.17.7
     dev: false
     engines:
       node: '>= 0.4'
@@ -4131,40 +3969,10 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=
-  /request/2.85.0:
-    dependencies:
-      aws-sign2: 0.7.0
-      aws4: 1.10.0
-      caseless: 0.12.0
-      combined-stream: 1.0.8
-      extend: 3.0.2
-      forever-agent: 0.6.1
-      form-data: 2.3.3
-      har-validator: 5.0.3
-      hawk: 6.0.2
-      http-signature: 1.2.0
-      is-typedarray: 1.0.0
-      isstream: 0.1.2
-      json-stringify-safe: 5.0.1
-      mime-types: 2.1.27
-      oauth-sign: 0.8.2
-      performance-now: 2.1.0
-      qs: 6.5.2
-      safe-buffer: 5.2.1
-      stringstream: 0.0.6
-      tough-cookie: 2.3.4
-      tunnel-agent: 0.6.0
-      uuid: 3.4.0
-    deprecated: 'request has been deprecated, see https://github.com/request/request/issues/3142'
-    dev: false
-    engines:
-      node: '>= 4'
-    resolution:
-      integrity: sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==
   /request/2.88.2:
     dependencies:
       aws-sign2: 0.7.0
-      aws4: 1.10.0
+      aws4: 1.10.1
       caseless: 0.12.0
       combined-stream: 1.0.8
       extend: 3.0.2
@@ -4205,12 +4013,13 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
-  /resolve/1.17.0:
+  /resolve/1.18.1:
     dependencies:
+      is-core-module: 2.0.0
       path-parse: 1.0.6
     dev: false
     resolution:
-      integrity: sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
+      integrity: sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==
   /restore-cursor/2.0.0:
     dependencies:
       onetime: 2.0.1
@@ -4270,14 +4079,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
-  /rxjs/6.6.2:
+  /rxjs/6.6.3:
     dependencies:
-      tslib: 1.13.0
+      tslib: 1.14.1
     dev: false
     engines:
       npm: '>=2.0.0'
     resolution:
-      integrity: sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==
+      integrity: sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
   /safe-buffer/5.1.2:
     dev: false
     resolution:
@@ -4321,11 +4130,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
-  /setimmediate/1.0.5:
-    dev: false
-    optional: true
-    resolution:
-      integrity: sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
   /shebang-command/1.2.0:
     dependencies:
       shebang-regex: 1.0.0
@@ -4334,12 +4138,26 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
+  /shebang-command/2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
   /shebang-regex/1.0.0:
     dev: false
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+  /shebang-regex/3.0.0:
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
   /shimmer/1.2.1:
     dev: false
     resolution:
@@ -4360,18 +4178,18 @@ packages:
     dev: false
     resolution:
       integrity: sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==
-  /sinon/9.0.3:
+  /sinon/9.2.0:
     dependencies:
       '@sinonjs/commons': 1.8.1
       '@sinonjs/fake-timers': 6.0.1
       '@sinonjs/formatio': 5.0.1
-      '@sinonjs/samsam': 5.1.0
+      '@sinonjs/samsam': 5.2.0
       diff: 4.0.2
       nise: 4.0.4
-      supports-color: 7.1.0
+      supports-color: 7.2.0
     dev: false
     resolution:
-      integrity: sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==
+      integrity: sha512-eSNXz1XMcGEMHw08NJXSyTHIu6qTCOiN8x9ODACmZpNQpr0aXTBXBnI4xTzQzR+TEpOmLiKowGf9flCuKIzsbw==
   /slash/3.0.0:
     dev: false
     engines:
@@ -4388,23 +4206,14 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
-  /sntp/2.1.0:
-    dependencies:
-      hoek: 4.2.1
-    deprecated: This module moved to @hapi/sntp. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.
-    dev: false
-    engines:
-      node: '>=4.0.0'
-    resolution:
-      integrity: sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==
-  /sort-keys/4.0.0:
+  /sort-keys/4.1.0:
     dependencies:
       is-plain-obj: 2.1.0
     dev: false
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-hlJLzrn/VN49uyNkZ8+9b+0q9DjmmYcYOnbMQtpkLrYpPwRApDPZfmqbUfJnAA3sb/nRib+nDot7Zi/1ER1fuA==
+      integrity: sha512-/sRdxzkkPFUYiCrTr/2t+104nDc9AgDmEpeVYuvOWYQe3Djk1GWO6lVw3Vx2jfh1SsR0eehhd1nvFYlzt5e99w==
   /source-map-support/0.5.19:
     dependencies:
       buffer-from: 1.1.1
@@ -4438,7 +4247,7 @@ packages:
   /spdx-correct/3.1.1:
     dependencies:
       spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.5
+      spdx-license-ids: 3.0.6
     dev: false
     resolution:
       integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==
@@ -4449,14 +4258,14 @@ packages:
   /spdx-expression-parse/3.0.1:
     dependencies:
       spdx-exceptions: 2.3.0
-      spdx-license-ids: 3.0.5
+      spdx-license-ids: 3.0.6
     dev: false
     resolution:
       integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==
-  /spdx-license-ids/3.0.5:
+  /spdx-license-ids/3.0.6:
     dev: false
     resolution:
-      integrity: sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
+      integrity: sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==
   /sprintf-js/1.0.3:
     dev: false
     resolution:
@@ -4484,7 +4293,7 @@ packages:
       integrity: sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=
   /stdout-stderr/0.1.13:
     dependencies:
-      debug: 4.1.1
+      debug: 4.2.0
       strip-ansi: 6.0.0
     dev: false
     engines:
@@ -4530,20 +4339,20 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
-  /string.prototype.trimend/1.0.1:
+  /string.prototype.trimend/1.0.2:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.17.6
+      es-abstract: 1.18.0-next.1
     dev: false
     resolution:
-      integrity: sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==
-  /string.prototype.trimstart/1.0.1:
+      integrity: sha512-8oAG/hi14Z4nOVP0z6mdiVZ/wqjDtWSLygMigTzAb+7aPEDTleeFf+WrF+alzecxIRkckkJVn+dTlwzJXORATw==
+  /string.prototype.trimstart/1.0.2:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.17.6
+      es-abstract: 1.18.0-next.1
     dev: false
     resolution:
-      integrity: sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==
+      integrity: sha512-7F6CdBTl5zyu30BJFdzSTlSlLPwODC23Od+iLoVH8X6+3fvDPPuBVVj9iaB1GOsSTSIgVfsfm27R2FGrAPznWg==
   /string_decoder/1.1.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -4556,10 +4365,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  /stringstream/0.0.6:
-    dev: false
-    resolution:
-      integrity: sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==
   /strip-ansi/3.0.1:
     dependencies:
       ansi-regex: 2.1.1
@@ -4648,14 +4453,14 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
-  /supports-color/7.1.0:
+  /supports-color/7.2.0:
     dependencies:
       has-flag: 4.0.0
     dev: false
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+      integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   /supports-hyperlinks/1.0.1:
     dependencies:
       has-flag: 2.0.0
@@ -4668,7 +4473,7 @@ packages:
   /supports-hyperlinks/2.1.0:
     dependencies:
       has-flag: 4.0.0
-      supports-color: 7.1.0
+      supports-color: 7.2.0
     dev: false
     engines:
       node: '>=8'
@@ -4683,8 +4488,8 @@ packages:
       integrity: sha512-qW+M9sTuZaJhBPMMbo3mHRzLZaIFJwGYcn7K9R/czAtlgF6PiehZ18+sFJGZsRa2MGDJZKKKv0IaiAdV7O8tgw==
   /table/5.4.6:
     dependencies:
-      ajv: 6.12.3
-      lodash: 4.17.19
+      ajv: 6.12.6
+      lodash: 4.17.20
       slice-ansi: 2.1.0
       string-width: 3.1.0
     dev: false
@@ -4697,13 +4502,13 @@ packages:
       chownr: 1.1.4
       mkdirp-classic: 0.5.3
       pump: 3.0.0
-      tar-stream: 2.1.3
+      tar-stream: 2.1.4
     dev: false
     resolution:
       integrity: sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==
-  /tar-stream/2.1.3:
+  /tar-stream/2.1.4:
     dependencies:
-      bl: 4.0.2
+      bl: 4.0.3
       end-of-stream: 1.4.4
       fs-constants: 1.0.0
       inherits: 2.0.4
@@ -4712,7 +4517,7 @@ packages:
     engines:
       node: '>=6'
     resolution:
-      integrity: sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==
+      integrity: sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==
   /tar/4.4.13:
     dependencies:
       chownr: 1.1.4
@@ -4727,19 +4532,19 @@ packages:
       node: '>=4.5'
     resolution:
       integrity: sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
-  /tar/6.0.2:
+  /tar/6.0.5:
     dependencies:
       chownr: 2.0.0
       fs-minipass: 2.1.0
       minipass: 3.1.3
-      minizlib: 2.1.0
+      minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
     dev: false
     engines:
       node: '>= 10'
     resolution:
-      integrity: sha512-Glo3jkRtPcvpDlAs/0+hozav78yoXKFr+c4wgw62NNMO3oo4AaJdCo21Uu7lcwr55h39W2XD1LMERc64wtbItg==
+      integrity: sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==
   /test-exclude/5.2.3:
     dependencies:
       glob: 7.1.6
@@ -4789,14 +4594,6 @@ packages:
       node: '>=8.0'
     resolution:
       integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
-  /tough-cookie/2.3.4:
-    dependencies:
-      punycode: 1.4.1
-    dev: false
-    engines:
-      node: '>=0.8'
-    resolution:
-      integrity: sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==
   /tough-cookie/2.5.0:
     dependencies:
       psl: 1.8.0
@@ -4816,11 +4613,6 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==
-  /traverse/0.3.9:
-    dev: false
-    optional: true
-    resolution:
-      integrity: sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=
   /treeify/1.1.0:
     dev: false
     engines:
@@ -4847,22 +4639,14 @@ packages:
       typescript: '>=2.7'
     resolution:
       integrity: sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==
-  /tslib/1.10.0:
+  /tslib/1.14.1:
     dev: false
     resolution:
-      integrity: sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
-  /tslib/1.13.0:
-    dev: false
-    resolution:
-      integrity: sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+      integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
   /tslib/1.9.0:
     dev: false
     resolution:
       integrity: sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==
-  /tslib/2.0.1:
-    dev: false
-    resolution:
-      integrity: sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
   /tslib/2.0.3:
     dev: false
     resolution:
@@ -4870,7 +4654,7 @@ packages:
   /tslint-consistent-codestyle/1.16.0_tslint@5.20.1:
     dependencies:
       '@fimbul/bifrost': 0.21.0_tslint@5.20.1
-      tslib: 1.13.0
+      tslib: 1.14.1
       tslint: 5.20.1
       tsutils: 2.29.0
     dev: false
@@ -4882,7 +4666,7 @@ packages:
   /tslint-consistent-codestyle/1.16.0_tslint@5.20.1+typescript@3.9.7:
     dependencies:
       '@fimbul/bifrost': 0.21.0_tslint@5.20.1+typescript@3.9.7
-      tslib: 1.13.0
+      tslib: 1.14.1
       tslint: 5.20.1_typescript@3.9.7
       tsutils: 2.29.0_typescript@3.9.7
       typescript: 3.9.7
@@ -4977,9 +4761,9 @@ packages:
       js-yaml: 3.14.0
       minimatch: 3.0.4
       mkdirp: 0.5.5
-      resolve: 1.17.0
+      resolve: 1.18.1
       semver: 5.7.1
-      tslib: 1.13.0
+      tslib: 1.14.1
       tsutils: 2.29.0
     dev: false
     engines:
@@ -5000,9 +4784,9 @@ packages:
       js-yaml: 3.14.0
       minimatch: 3.0.4
       mkdirp: 0.5.5
-      resolve: 1.17.0
+      resolve: 1.18.1
       semver: 5.7.1
-      tslib: 1.13.0
+      tslib: 1.14.1
       tsutils: 2.29.0_typescript@3.9.7
       typescript: 3.9.7
     dev: false
@@ -5015,7 +4799,7 @@ packages:
       integrity: sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==
   /tsutils/2.28.0:
     dependencies:
-      tslib: 1.13.0
+      tslib: 1.14.1
     dev: false
     peerDependencies:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
@@ -5023,7 +4807,7 @@ packages:
       integrity: sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==
   /tsutils/2.28.0_typescript@3.9.7:
     dependencies:
-      tslib: 1.13.0
+      tslib: 1.14.1
       typescript: 3.9.7
     dev: false
     peerDependencies:
@@ -5032,7 +4816,7 @@ packages:
       integrity: sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==
   /tsutils/2.29.0:
     dependencies:
-      tslib: 1.13.0
+      tslib: 1.14.1
     dev: false
     peerDependencies:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
@@ -5040,7 +4824,7 @@ packages:
       integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
   /tsutils/2.29.0_typescript@3.9.7:
     dependencies:
-      tslib: 1.13.0
+      tslib: 1.14.1
       typescript: 3.9.7
     dev: false
     peerDependencies:
@@ -5049,7 +4833,7 @@ packages:
       integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
   /tsutils/3.17.1:
     dependencies:
-      tslib: 1.13.0
+      tslib: 1.14.1
     dev: false
     engines:
       node: '>= 6'
@@ -5059,7 +4843,7 @@ packages:
       integrity: sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
   /tsutils/3.17.1_typescript@3.9.7:
     dependencies:
-      tslib: 1.13.0
+      tslib: 1.14.1
       typescript: 3.9.7
     dev: false
     engines:
@@ -5135,27 +4919,12 @@ packages:
       node: '>= 10.0.0'
     resolution:
       integrity: sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
-  /unzipper/0.9.15:
-    dependencies:
-      big-integer: 1.6.48
-      binary: 0.3.0
-      bluebird: 3.4.7
-      buffer-indexof-polyfill: 1.0.1
-      duplexer2: 0.1.4
-      fstream: 1.0.12
-      listenercount: 1.0.1
-      readable-stream: 2.3.7
-      setimmediate: 1.0.5
-    dev: false
-    optional: true
-    resolution:
-      integrity: sha512-2aaUvO4RAeHDvOCuEtth7jrHFaCKTSXPqUkXwADaLBzGbgZGzUDccoEdJ5lW+3RmfpOZYNx0Rw6F6PUzM6caIA==
-  /uri-js/4.2.2:
+  /uri-js/4.4.0:
     dependencies:
       punycode: 2.1.1
     dev: false
     resolution:
-      integrity: sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+      integrity: sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==
   /util-deprecate/1.0.2:
     dev: false
     resolution:
@@ -5260,7 +5029,7 @@ packages:
       integrity: sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
   /wrap-ansi/7.0.0:
     dependencies:
-      ansi-styles: 4.2.1
+      ansi-styles: 4.3.0
       string-width: 4.2.0
       strip-ansi: 6.0.0
     dev: false
@@ -5295,7 +5064,7 @@ packages:
       graceful-fs: 4.2.4
       is-plain-obj: 2.1.0
       make-dir: 3.1.0
-      sort-keys: 4.0.0
+      sort-keys: 4.1.0
       write-file-atomic: 3.0.3
     dev: false
     engines:
@@ -5350,8 +5119,8 @@ packages:
       integrity: sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
   /yargs-unparser/1.6.0:
     dependencies:
-      flat: 4.1.0
-      lodash: 4.17.19
+      flat: 4.1.1
+      lodash: 4.17.20
       yargs: 13.3.2
     dev: false
     engines:
@@ -5381,17 +5150,17 @@ packages:
       integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
   'file:projects/bf-dispatcher.tgz':
     dependencies:
-      '@microsoft/bf-lu': 4.10.0-dev.20200808.5a7c973
+      '@microsoft/bf-lu': 4.11.0-dev.20201025.69cf2b9
       '@oclif/command': 1.5.20
       '@oclif/config': 1.13.3
       '@oclif/dev-cli': 1.22.2
       '@oclif/plugin-help': 2.2.3
-      '@oclif/test': 1.2.6
+      '@oclif/test': 1.2.7
       '@oclif/tslint': 3.1.1_tslint@5.20.1+typescript@3.9.7
       '@types/argparse': 1.0.38
-      '@types/chai': 4.2.12
+      '@types/chai': 4.2.14
       '@types/mocha': 5.2.7
-      '@types/node': 10.17.28
+      '@types/node': 10.17.43
       argparse: 1.0.10
       chai: 4.2.0
       globby: 10.0.2
@@ -5401,7 +5170,7 @@ packages:
       rimraf: 3.0.2
       ts-md5: 1.2.7
       ts-node: 8.10.2_typescript@3.9.7
-      tslib: 1.13.0
+      tslib: 1.14.1
       tslint: 5.20.1_typescript@3.9.7
       typescript: 3.9.7
     dev: false
@@ -5412,19 +5181,19 @@ packages:
     version: 0.0.0
   'file:projects/bf-orchestrator-cli.tgz':
     dependencies:
-      '@microsoft/bf-cli-command': 4.10.0-dev.20200808.5a7c973
-      '@microsoft/bf-lu': 4.10.0-dev.20200808.5a7c973
+      '@microsoft/bf-cli-command': 4.11.0-dev.20201025.69cf2b9
+      '@microsoft/bf-lu': 4.11.0-dev.20201025.69cf2b9
       '@oclif/command': 1.8.0
       '@oclif/config': 1.17.0
       '@oclif/dev-cli': 1.22.2
       '@oclif/errors': 1.2.2
       '@oclif/plugin-help': 2.2.3
-      '@oclif/test': 1.2.6
-      '@types/chai': 4.2.12
+      '@oclif/test': 1.2.7
+      '@types/chai': 4.2.14
       '@types/fs-extra': 8.1.1
       '@types/mocha': 5.2.7
-      '@types/node': 10.17.28
-      '@types/sinon': 9.0.4
+      '@types/node': 10.17.43
+      '@types/sinon': 9.0.8
       chai: 4.2.0
       eslint: 5.16.0
       eslint-config-oclif: 3.1.0_eslint@5.16.0
@@ -5435,9 +5204,9 @@ packages:
       nyc: 14.1.1
       read-text-file: 1.1.0
       rimraf: 3.0.2
-      sinon: 9.0.3
+      sinon: 9.2.0
       ts-node: 8.10.2_typescript@3.9.7
-      tslib: 1.13.0
+      tslib: 1.14.1
       typescript: 3.9.7
     dev: false
     name: '@rush-temp/bf-orchestrator-cli'
@@ -5447,16 +5216,14 @@ packages:
     version: 0.0.0
   'file:projects/bf-orchestrator.tgz':
     dependencies:
-      7zip-min: 1.2.0
-      '@microsoft/bf-lu': 4.11.0-dev.20201023.4d90f4e
-      '@oclif/test': 1.2.6
-      '@types/chai': 4.2.12
+      '@microsoft/bf-lu': 4.11.0-dev.20201025.69cf2b9
+      '@oclif/test': 1.2.7
+      '@types/chai': 4.2.14
       '@types/fs-extra': 8.1.1
       '@types/mocha': 5.2.7
-      '@types/nock': 11.1.0
-      '@types/node': 10.17.28
+      '@types/node': 10.17.43
       '@types/node-fetch': 2.5.7
-      '@types/sinon': 9.0.4
+      '@types/sinon': 9.0.8
       chai: 4.2.0
       eslint: 5.16.0
       eslint-config-oclif: 3.1.0_eslint@5.16.0
@@ -5465,50 +5232,44 @@ packages:
       fs-extra: 9.0.1
       mocha: 6.2.3
       nock: 11.9.1
-      node-7z-forall: 1.0.5
-      node-fetch: 2.6.0
+      node-7z-forall: 1.0.9
+      node-fetch: 2.6.1
       nyc: 14.1.1
-      orchestrator-core: 4.11.0-dev.20201023.49095d1
+      orchestrator-core: 4.11.0-dev.20201024.0c5247b
       read-text-file: 1.1.0
       rimraf: 2.7.1
-      sinon: 9.0.3
+      sinon: 9.2.0
       ts-node: 8.10.2_typescript@3.9.7
-      tslib: 1.13.0
+      tslib: 1.14.1
       typescript: 3.9.7
     dev: false
     name: '@rush-temp/bf-orchestrator'
     resolution:
-      integrity: sha512-27V4RxB/OdTfIeDVfFMhIYPcUDPMasOqFky+42ZhzWzP9lta4gErC/oR6xrVcm52lFtQljGaGFpixkpjRccfrQ==
+      integrity: sha512-IkhI5DyWgylAooYaiceTXUmLl/qxL2c7U60a2cg+yBZqgquVP8jaeW8tuEjALJ81D/CxhuHICTFAFmadSIrNSQ==
       tarball: 'file:projects/bf-orchestrator.tgz'
     version: 0.0.0
   'file:projects/bf-sampler-cli.tgz':
     dependencies:
-      '@microsoft/bf-cli-command': 4.11.0-dev.20201021.d59abb5
-      '@microsoft/bf-lu': 4.11.0-dev.20201021.d59abb5
+      '@microsoft/bf-cli-command': 4.11.0-dev.20201025.69cf2b9
+      '@microsoft/bf-lu': 4.11.0-dev.20201025.69cf2b9
       '@oclif/command': 1.8.0
       '@oclif/config': 1.17.0
       '@oclif/dev-cli': 1.22.2
       '@oclif/errors': 1.2.2
       '@oclif/plugin-help': 2.2.3
-      '@oclif/test': 1.2.6
-      '@types/chai': 4.2.12
+      '@oclif/test': 1.2.7
       '@types/fs-extra': 8.1.1
       '@types/mocha': 5.2.7
-      '@types/node': 10.17.28
-      '@types/sinon': 9.0.4
-      chai: 4.2.0
+      '@types/node': 10.17.43
       eslint: 5.16.0
       eslint-config-oclif: 3.1.0_eslint@5.16.0
       eslint-config-oclif-typescript: 0.1.0_eslint@5.16.0+typescript@3.9.7
       fs-extra: 9.0.1
-      globby: 10.0.2
       mocha: 5.2.0
       nyc: 14.1.1
-      read-text-file: 1.1.0
       rimraf: 3.0.2
-      sinon: 9.0.3
       ts-node: 8.10.2_typescript@3.9.7
-      tslib: 1.13.0
+      tslib: 1.14.1
       typescript: 3.9.7
     dev: false
     name: '@rush-temp/bf-sampler-cli'
@@ -5516,9 +5277,7 @@ packages:
       integrity: sha512-a06m0FqpH0ZrFA3pHGJdQ/MfDYzPWcOiIlZcAQIPZQrxgfEBdNMV6KY67TB9dUeNMbUMR1OwGx4AdQeWDbD+5A==
       tarball: 'file:projects/bf-sampler-cli.tgz'
     version: 0.0.0
-registry: ''
 specifiers:
-  7zip-min: ~1.2.0
   '@microsoft/bf-cli-command': next
   '@microsoft/bf-lu': next
   '@oclif/dev-cli': ^1.22.2
@@ -5542,9 +5301,10 @@ specifiers:
   fast-text-encoding: ^1.0.3
   fs-extra: ~9.0.0
   nock: ^11.7.0
+  node-7z-forall: ^1.0.8
   node-fetch: ~2.6.0
   nyc: ^14.1.1
-  orchestrator-core: 4.11.0-dev.20201023.49095d1
+  orchestrator-core: 4.11.0-dev.20201024.0c5247b
   read-text-file: ~1.1.0
   readline-sync: ^1.4.10
   sinon: ^9.0.2

--- a/packages/dispatcher/src/mathematics/confusion_matrix/MultiLabelObjectConfusionMatrixBase.ts
+++ b/packages/dispatcher/src/mathematics/confusion_matrix/MultiLabelObjectConfusionMatrixBase.ts
@@ -58,7 +58,7 @@ implements IMultiLabelObjectConfusionMatrix {
 
     // ---- NOTE ---- label set is usually very small, mostly 1, so a linear search is sufficiently fast.
     public isLabelObjectInArray(labels: Label[], label: Label): boolean {
-        for(const labelEntry of labels) {
+        for (const labelEntry of labels) {
             if (label.equals(labelEntry)) {
                 return true;
             }

--- a/packages/orchestrator/test/commands/orchestrator.test.ts
+++ b/packages/orchestrator/test/commands/orchestrator.test.ts
@@ -10,6 +10,7 @@ describe('orchestrator', () => {
   .timeout(1000000)
   .stdout()
   .command(['orchestrator'])
+  .exit(1)
   .it('should print the help contents when nothing is passed as an argument', (ctx: any) => {
     expect(ctx.stdout)
     .to.contain('Display Orchestrator CLI available commands')
@@ -25,6 +26,7 @@ describe('orchestrator', () => {
   .timeout(1000000)
   .stdout()
   .command(['orchestrator', '--help'])
+  .exit(1)
   .it('should print the help contents when --help is passed as an argument', (ctx: any) => {
     expect(ctx.stdout)
     .to.contain('Display Orchestrator CLI available commands')

--- a/packages/orchestrator/test/commands/orchestrator/basemodel.test.ts
+++ b/packages/orchestrator/test/commands/orchestrator/basemodel.test.ts
@@ -19,6 +19,7 @@ describe('orchestrator:basemodel:get', () => {
   test
   .stdout()
   .command(['orchestrator:basemodel:get', '--help'])
+  .exit(1)
   .it('should print the help contents when --help is passed as an argument', (ctx: any) => {
     expect(ctx.stdout).to.contain('Gets Orchestrator base model');
   });
@@ -26,6 +27,7 @@ describe('orchestrator:basemodel:get', () => {
   test
   .stdout()
   .command(['orchestrator:basemodel:list', '--help'])
+  .exit(1)
   .it('should print the help contents when --help is passed as an argument', (ctx: any) => {
     expect(ctx.stdout).to.contain('Lists all Orchestrator base model versions');
   });

--- a/packages/orchestrator/test/commands/orchestrator/build.test.ts
+++ b/packages/orchestrator/test/commands/orchestrator/build.test.ts
@@ -19,6 +19,7 @@ describe('orchestrator:build', () => {
   test
   .stdout()
   .command(['orchestrator:build', '--help'])
+  .exit(1)
   .it('should print the help contents when --help is passed as an argument', (ctx: any) => {
     expect(ctx.stdout).to.contain('Creates Orchestrator snapshot file and Orchestrator dialog definition file (optional) for each lu file in');
   });

--- a/packages/orchestrator/test/commands/orchestrator/create.test.ts
+++ b/packages/orchestrator/test/commands/orchestrator/create.test.ts
@@ -19,6 +19,7 @@ describe('orchestrator:create', () => {
   test
   .stdout()
   .command(['orchestrator:create', '--help'])
+  .exit(1)
   .it('should print the help contents when --help is passed as an argument', (ctx: any) => {
     expect(ctx.stdout).to.contain('Creates Orchestrator example file from .lu/.qna files, which represent bot modules');
   });

--- a/packages/orchestrator/test/commands/orchestrator/interactive.test.ts
+++ b/packages/orchestrator/test/commands/orchestrator/interactive.test.ts
@@ -19,6 +19,7 @@ describe('orchestrator:interactive', () => {
   test
   .stdout()
   .command(['orchestrator:interactive', '--help'])
+  .exit(1)
   .it('should print the help contents when --help is passed as an argument', (ctx: any) => {
     expect(ctx.stdout).to.contain('Real-time interaction with Orchestrator model and analysis. Can return score of given utterance using previously created orchestrator examples');
   });

--- a/packages/orchestrator/test/commands/orchestrator/query.test.ts
+++ b/packages/orchestrator/test/commands/orchestrator/query.test.ts
@@ -9,6 +9,7 @@ describe('orchestrator:query', () => {
   test
   .stdout()
   .command(['orchestrator:query', '--help'])
+  .exit(1)
   .it('should print the help contents when --help is passed as an argument', (ctx: any) => {
     expect(ctx.stdout).to.contain('Query Orchestrator base model and a snapshot/train file');
   });

--- a/packages/orchestrator/test/commands/orchestrator/test.test.ts
+++ b/packages/orchestrator/test/commands/orchestrator/test.test.ts
@@ -10,6 +10,7 @@ describe('orchestrator:test', () => {
   test
   .stdout()
   .command(['orchestrator:test', '--help'])
+  .exit(1)
   .it('should print the help contents when --help is passed as an argument', (ctx: any) => {
     expect(ctx.stdout).to.contain('The "test" command can operate in three modes');
   });


### PR DESCRIPTION
Update pnpm-lock.yaml to latest so that bf-lu can upgrade to the latest version that includes some fixes consumed by bf-sampler-cli package. Please notice that bf-cli-command is also updated to align with bf-lu. After bf-cli-command updated, there are some changes need to take in orchestator cli tests because of this PR https://github.com/microsoft/botframework-cli/pull/1022. In cli, any command that display help message or throw exception will throw a exit code due to above PR. So I added .exit(1) in every cli help and exception tests to catch this exit, otherwise tests will fail. Here to erase the impact on orchestrator cli tests that display help message, I also added .exit(1) in related cli tests to make them pass. I run these orchestrator cli tests locally and they pass well. Please feel free to ping me if these changes are not reasonable.