### PR TITLE
Optimize empty file validation and import resolver corner cases in crossTrianer

### DIFF
--- a/packages/lu/src/parser/cross-train/crossTrainer.js
+++ b/packages/lu/src/parser/cross-train/crossTrainer.js
@@ -293,7 +293,8 @@ const mergeInterruptionIntent = function (fromUtterances, toResource, intentName
 
       // add section here
       // not add the interruption intent if original file is empty
-      if (toResource.content.Content !== '') {
+      // here empty means there are no model related sections exception information section
+      if (toResource.content.Sections.filter(s => s.SectionType !== LUSectionTypes.MODELINFOSECTION).length > 0) {
         toResource.content = new SectionOperator(toResource.content).addSection(newFileContent)
       }
     }

--- a/packages/lu/src/parser/cross-train/crossTrainer.js
+++ b/packages/lu/src/parser/cross-train/crossTrainer.js
@@ -512,12 +512,15 @@ const parseAndValidateContent = async function (objectArray, verbose, importReso
   let allEmpty = true
   for (const object of objectArray) {    
     let fileContent = object.content
+    let objectId = object.id
     if (object.content && object.content !== '') {
       if (fileExt === fileExtEnum.LUFile) {
+        if (!object.id.endsWith(fileExtEnum.LUFile)) object.id += fileExtEnum.LUFile
         let result = await LuisBuilderVerbose.build([object], verbose, undefined, importResolver)
         let luisObj = new Luis(result)
         fileContent = luisObj.parseToLuContent()
       } else {
+        if (!object.id.endsWith(fileExtEnum.QnAFile)) object.id += fileExtEnum.QnAFile
         let result = await qnaBuilderVerbose.build([object], verbose, importResolver)
         fileContent = result.parseToQnAContent()
       }
@@ -541,7 +544,7 @@ const parseAndValidateContent = async function (objectArray, verbose, importReso
       }
     }
 
-    fileIdToResourceMap.set(object.id, resource)
+    fileIdToResourceMap.set(objectId, resource)
   }
 
   return {fileIdToResourceMap, allEmpty}
@@ -549,8 +552,8 @@ const parseAndValidateContent = async function (objectArray, verbose, importReso
 
 const pretreatment = function (luContents, qnaContents) {
    // Parse lu and qna objects
-   let luObjectArray = fileHelper.getParsedObjects(luContents)
-   let qnaObjectArray = fileHelper.getParsedObjects(qnaContents)
+   let luObjectArray = fileHelper.getParsedObjects(luContents, fileExtEnum.LUFile)
+   let qnaObjectArray = fileHelper.getParsedObjects(qnaContents, fileExtEnum.QnAFile)
 
    return {luObjectArray, qnaObjectArray}
 }

--- a/packages/lu/src/utils/filehelper.ts
+++ b/packages/lu/src/utils/filehelper.ts
@@ -5,12 +5,15 @@
 
 import {readTextFile} from './textfilereader'
 import Lu = require('../parser/lu/lu')
+import QnA = require('../parser/lu/qna')
 const exception = require('./../parser/utils/exception')
 const retCode = require('./../parser/utils/enums/CLI-errors')
 const fs = require('fs-extra')
 const path = require('path')
 const helpers = require('./../parser/utils/helpers')
+const fileExtEnum = require('./../parser/utils/helpers').FileExtTypeEnum
 const LUOptions = require('./../parser/lu/luOptions')
+const QnAOptions = require('./../parser/lu/qnaOptions')
 const luParser = require('./../parser/lufile/luParser')
 const LUSectionTypes = require('./../parser/utils/enums/lusectiontypes')
 const globby = require('globby')
@@ -211,10 +214,15 @@ async function getConfigFile(input: string): Promise<string> {
   return defaultConfigFile
 }
 
-export function getParsedObjects(contents: {id: string, content: string}[]) {
+export function getParsedObjects(contents: {id: string, content: string}[], extType: string) {
   const parsedObjects = contents.map(content => {
-    const opts = new LUOptions(content.id)
-    return new Lu(content.content, opts)
+    if (extType === fileExtEnum.LUFile) {
+      const opts = new LUOptions(content.id)
+      return new Lu(content.content, opts)
+    } else {
+      const opts = new QnAOptions(content.id)
+      return new QnA(content.content, opts)
+    }
   })
 
   return parsedObjects


### PR DESCRIPTION
Two changes required from composer
1. Before the change, the empty lu file validation is based on condition that content !== '' which is not exactly correct for some corner cases such as only comments or model informations are in lu file. After the changes, the empty file validation is based on non model info section count which means the file is not empty only if the sections(except model info section) length greater than 0. Without this fix, the crosstrained lu results may not be expected.
2. Add .lu or .qna extension for lu and qna object id when resolving imports if they don't have extension since composer has a customized resolver that requires the id with extension.