### PR TITLE
[cherry-pick to 4.11] fix regression on multiturn extraction functionality of qna url or file import api

### DIFF
--- a/packages/lu/src/parser/qnabuild/builder.ts
+++ b/packages/lu/src/parser/qnabuild/builder.ts
@@ -301,7 +301,9 @@ export class Builder {
     url: string,
     subscriptionkey: string,
     endpoint: string,
-    kbName: string) {
+    kbName: string,
+    enableHierarchicalExtraction: boolean = false,
+    defaultAnswerUsedForExtraction: string = 'More Answers') {
     const qnaBuildCore = new QnaBuildCore(subscriptionkey, endpoint)
     const kbs = (await qnaBuildCore.getKBList()).knowledgebases
 
@@ -320,7 +322,7 @@ export class Builder {
     }
 
     // create a new kb
-    kbId = await this.createUrlKB(qnaBuildCore, url, kbName)
+    kbId = await this.createUrlKB(qnaBuildCore, url, kbName, enableHierarchicalExtraction, defaultAnswerUsedForExtraction)
 
     const kbJson = await qnaBuildCore.exportKB(kbId, 'Test')
     const kb = new KB(kbJson)
@@ -335,7 +337,9 @@ export class Builder {
     fileUri: string,
     subscriptionkey: string,
     endpoint: string,
-    kbName: string) {
+    kbName: string,
+    enableHierarchicalExtraction: boolean = false,
+    defaultAnswerUsedForExtraction: string = 'More Answers') {
     const qnaBuildCore = new QnaBuildCore(subscriptionkey, endpoint)
     const kbs = (await qnaBuildCore.getKBList()).knowledgebases
 
@@ -354,7 +358,7 @@ export class Builder {
     }
 
     // create a new kb
-    kbId = await this.createFileKB(qnaBuildCore, fileName, fileUri, kbName)
+    kbId = await this.createFileKB(qnaBuildCore, fileName, fileUri, kbName, enableHierarchicalExtraction, defaultAnswerUsedForExtraction)
 
     const kbJson = await qnaBuildCore.exportKB(kbId, 'Test')
     const kb = new KB(kbJson)
@@ -465,12 +469,17 @@ export class Builder {
     return kbId
   }
 
-  async createUrlKB(qnaBuildCore: QnaBuildCore, url: string, kbName: string) {
-    const kbJson = {
+  async createUrlKB(qnaBuildCore: QnaBuildCore, url: string, kbName: string, enableHierarchicalExtraction: boolean, defaultAnswerUsedForExtraction: string) {
+    let kbJson: any = {
       name: kbName,
       qnaList: [],
       urls: [url],
-      files: []
+      files: [],
+    }
+
+    if (enableHierarchicalExtraction) {
+      kbJson.enableHierarchicalExtraction = true
+      kbJson.defaultAnswerUsedForExtraction = defaultAnswerUsedForExtraction
     }
 
     let response = await qnaBuildCore.importKB(kbJson)
@@ -481,8 +490,8 @@ export class Builder {
     return kbId
   }
 
-  async createFileKB(qnaBuildCore: QnaBuildCore, fileName: string, fileUri: string, kbName: string) {
-    let kbJson = {
+  async createFileKB(qnaBuildCore: QnaBuildCore, fileName: string, fileUri: string, kbName: string, enableHierarchicalExtraction: boolean, defaultAnswerUsedForExtraction: string) {
+    let kbJson: any = {
       name: kbName,
       qnaList: [],
       urls: [],
@@ -490,6 +499,11 @@ export class Builder {
         fileName,
         fileUri
       }]
+    }
+
+    if (enableHierarchicalExtraction) {
+      kbJson.enableHierarchicalExtraction = true
+      kbJson.defaultAnswerUsedForExtraction = defaultAnswerUsedForExtraction
     }
 
     let response = await qnaBuildCore.importKB(kbJson)

--- a/packages/lu/test/parser/qnabuild/qnabuild.test.js
+++ b/packages/lu/test/parser/qnabuild/qnabuild.test.js
@@ -134,6 +134,87 @@ describe('builder: importUrlOrFileReference function return lu content from file
   })
 })
 
+describe('builder: importUrlOrFileReference function return lu content from file sucessfully with multiturn extraction enabled', () => {
+  before(function () {
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('qnamaker'))
+      .reply(200, {
+        knowledgebases:
+          [{
+            name: 'test.en-us.qna',
+            id: 'f8c64e2a-1111-3a09-8f78-39d7adc76ec5',
+            hostName: 'https://myqnamakerbot.azurewebsites.net'
+          }]
+      })
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .post(uri => uri.includes('createasync'))
+      .reply(202, {
+        operationId: 'f8c64e2a-aaaa-3a09-8f78-39d7adc76ec5'
+      })
+    
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('operations'))
+      .reply(200, {
+        operationState: 'Succeeded',
+        resourceLocation: 'a/b/f8c64e2a-2222-3a09-8f78-39d7adc76ec5'
+      })
+    
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('knowledgebases'))
+      .reply(200, {
+        qnaDocuments: [{
+          id: 1,
+          source: 'SurfaceManual.pdf',
+          questions: ['User Guide'],
+          answer: 'More Answers',
+          metadata: [],
+          prompts: [{
+            displayOrder: 0,
+            displayText: 'With Windows 10',
+            qnaId: 2
+          }]
+        },
+        {
+          id: 2,
+          source: 'SurfaceManual.pdf',
+          questions: ['With Windows 10'],
+          answer: '**With Windows 10**',
+          metadata: [],
+          prompts: []
+        }]
+      })
+  })
+
+  nock('https://westus.api.cognitive.microsoft.com')
+    .delete(uri => uri.includes('knowledgebases'))
+    .reply(200)
+
+  it('should return lu content from file successfully', async () => {
+    const builder = new Builder()
+    const luContent = await builder.importFileReference(
+      'SurfaceManual.pdf',
+      'https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN.pdf',
+      uuidv1(),
+      'https://westus.api.cognitive.microsoft.com/qnamaker/v4.0',
+      'mytest.en-us.qna',
+      true)
+    
+    assert.equal(luContent,
+      `> # QnA pairs${NEWLINE}${NEWLINE}` +
+      `> !# @qna.pair.source = SurfaceManual.pdf${NEWLINE}${NEWLINE}` +
+      `<a id = "1"></a>${NEWLINE}${NEWLINE}` +
+      `# ? User Guide${NEWLINE}${NEWLINE}` +
+      `\`\`\`markdown${NEWLINE}` +
+      `More Answers${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}` +
+      `> !# @qna.pair.source = SurfaceManual.pdf${NEWLINE}${NEWLINE}` +
+      `<a id = "2"></a>${NEWLINE}${NEWLINE}` +
+      `# ? With Windows 10${NEWLINE}${NEWLINE}` +
+      `\`\`\`markdown${NEWLINE}` +
+      `**With Windows 10**${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}`)
+  })
+})
+
 describe('builder: importUrlOrFileReference function return lu content from url sucessfully', () => {
   before(function () {
     nock('https://westus.api.cognitive.microsoft.com')
@@ -190,6 +271,86 @@ describe('builder: importUrlOrFileReference function return lu content from url 
                             `# ? how many sandwich types do you have${NEWLINE}${NEWLINE}` +
                             `\`\`\`markdown${NEWLINE}` +
                             `25 types${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}`)
+  })
+})
+
+describe('builder: importUrlOrFileReference function return lu content from url sucessfully with multiturn extraction enabled', () => {
+  before(function () {
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('qnamaker'))
+      .reply(200, {
+        knowledgebases:
+          [{
+            name: 'test.en-us.qna',
+            id: 'f8c64e2a-1111-3a09-8f78-39d7adc76ec5',
+            hostName: 'https://myqnamakerbot.azurewebsites.net'
+          }]
+      })
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .post(uri => uri.includes('createasync'))
+      .reply(202, {
+        operationId: 'f8c64e2a-aaaa-3a09-8f78-39d7adc76ec5'
+      })
+    
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('operations'))
+      .reply(200, {
+        operationState: 'Succeeded',
+        resourceLocation: 'a/b/f8c64e2a-2222-3a09-8f78-39d7adc76ec5'
+      })
+    
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('knowledgebases'))
+      .reply(200, {
+        qnaDocuments: [{
+          id: 1,
+          source: 'SurfaceManual.pdf',
+          questions: ['User Guide'],
+          answer: 'More Answers',
+          metadata: [],
+          prompts: [{
+            displayOrder: 0,
+            displayText: 'With Windows 10',
+            qnaId: 2
+          }]
+        },
+        {
+          id: 2,
+          source: 'SurfaceManual.pdf',
+          questions: ['With Windows 10'],
+          answer: '**With Windows 10**',
+          metadata: [],
+          prompts: []
+        }]
+      })
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .delete(uri => uri.includes('knowledgebases'))
+      .reply(200)
+  })
+
+  it('should return lu content from url successfully', async () => {
+    const builder = new Builder()
+    const luContent = await builder.importUrlReference(
+      'https://docs.microsoft.com/en-in/azure/cognitive-services/qnamaker/faqs',
+      uuidv1(),
+      'https://westus.api.cognitive.microsoft.com/qnamaker/v4.0',
+      'mytest.en-us.qna',
+      true)
+
+    assert.equal(luContent,
+      `> # QnA pairs${NEWLINE}${NEWLINE}` +
+      `> !# @qna.pair.source = SurfaceManual.pdf${NEWLINE}${NEWLINE}` +
+      `<a id = "1"></a>${NEWLINE}${NEWLINE}` +
+      `# ? User Guide${NEWLINE}${NEWLINE}` +
+      `\`\`\`markdown${NEWLINE}` +
+      `More Answers${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}` +
+      `> !# @qna.pair.source = SurfaceManual.pdf${NEWLINE}${NEWLINE}` +
+      `<a id = "2"></a>${NEWLINE}${NEWLINE}` +
+      `# ? With Windows 10${NEWLINE}${NEWLINE}` +
+      `\`\`\`markdown${NEWLINE}` +
+      `**With Windows 10**${NEWLINE}\`\`\`${NEWLINE}${NEWLINE}`)
   })
 })
 


### PR DESCRIPTION
Composer team reported a regression issue microsoft/BotFramework-Composer#4590 on the multirun extraction functionality of url and file import api in bf-lu library. This was caused by a bad [merge ](https://github.com/microsoft/botframework-cli/pull/990/files#diff-a0253f24b1d7f993c390269c8b172cea0d59a480556f55853ad675d6a5f1f78bL303)before. To avoid such regression in the future, more specific tests are added in this PR.