### PR TITLE
Make luis application name comparison case insensitve in luis build

### DIFF
--- a/packages/lu/src/parser/lubuild/builder.ts
+++ b/packages/lu/src/parser/lubuild/builder.ts
@@ -232,7 +232,7 @@ export class Builder {
               // find if there is a matched name with current app under current authoring key
               if (!recognizer.getAppId()) {
                 for (let app of apps) {
-                  if (app.name === currentApp.name) {
+                  if (app.name.toLowerCase() === currentApp.name.toLowerCase()) {
                     recognizer.setAppId(app.id)
                     break
                   }

--- a/packages/luis/test/commands/luis/build.test.ts
+++ b/packages/luis/test/commands/luis/build.test.ts
@@ -318,6 +318,38 @@ describe('luis:build not update application if no changes', () => {
     })
 })
 
+describe('luis:build not create application if kb name id only case different', () => {
+  const existingLuisApp = require('./../../fixtures/testcases/lubuild/sandwich/luis/test(development)-sandwich.en-us.lu.json')
+  before(function () {
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('apps'))
+      .reply(200, [{
+        name: 'test(development)-sandwich.en-us.lu',
+        id: 'f8c64e2a-8635-3a09-8f78-39d7adc76ec5'
+      }])
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('apps'))
+      .reply(200, {
+        name: 'test(development)-sandwich.en-us.lu',
+        id: 'f8c64e2a-8635-3a09-8f78-39d7adc76ec5',
+        activeVersion: '0.1'
+      })
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('export'))
+      .reply(200, existingLuisApp)
+  })
+
+  test
+    .stdout()
+    .command(['luis:build', '--in', './test/fixtures/testcases/lubuild/sandwich/lufiles/sandwich.en-us.lu', '--authoringKey', uuidv1(), '--botName', 'TEST', '--log', '--suffix', 'development'])
+    .it('should not create a luis application when an app with only case different name already existed in service', ctx => {
+      expect(ctx.stdout).to.contain('Handling applications...')
+      expect(ctx.stdout).to.contain('no changes')
+    })
+})
+
 describe('luis:build write dialog and settings assets successfully if --dialog set to multiLanguage', () => {
   const existingLuisApp = require('./../../fixtures/testcases/lubuild/sandwich/luis/test(development)-sandwich.en-us.lu.json')
   before(async function () {


### PR DESCRIPTION
Fix #1044 and https://github.com/microsoft/BotFramework-Composer/issues/4627. The fix is to align with luis service to make application name case insensitive in luis build.

App name in luis service is case insensitive, for example, 'my_app_name' and 'My_App_Name' will be treated as same app name. But in current luis build, the name comparison is case sensitive. This PR is trying to make the app name comparison case insensitive in luis build to avoid such inconsistence. 

BTW, qna kb name is case sensitive in qnamaker service, so no need to change the comparison logic in qna build.