### PR TITLE
Add runCodesignValidationInjection: false to pipelines

### DIFF
--- a/build/botframework-cli-azure-devops.yml
+++ b/build/botframework-cli-azure-devops.yml
@@ -12,6 +12,7 @@ pr: none
 trigger: none
 
 variables:
+  runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
 - template: botframework-cli-version.yml  # Template reference ${{ variables.releaseVersion }}
 #  version: define this in Azure, settable at queue time
 

--- a/build/botframework-cli-azure-devops.yml
+++ b/build/botframework-cli-azure-devops.yml
@@ -11,9 +11,8 @@ pool:
 pr: none
 trigger: none
 
-variables:
-  runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
 - template: botframework-cli-version.yml  # Template reference ${{ variables.releaseVersion }}
+  runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
 #  version: define this in Azure, settable at queue time
 
 stages:

--- a/build/botframework-cli-azure-devops.yml
+++ b/build/botframework-cli-azure-devops.yml
@@ -11,12 +11,14 @@ pool:
 pr: none
 trigger: none
 
+variables:
 - template: botframework-cli-version.yml  # Template reference ${{ variables.releaseVersion }}
-  runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
 #  version: define this in Azure, settable at queue time
 
 stages:
 - stage: Build
+  variables:
+    runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
   jobs:
   - job:
     steps:

--- a/build/botframework-cli-beta.yml
+++ b/build/botframework-cli-beta.yml
@@ -19,8 +19,10 @@ schedules:
     - beta
 
 variables:
-  runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
 - template: botframework-cli-version.yml  # Template reference ${{ variables.releaseVersion }}
+
+variables:
+  runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
 #  version: define this in Azure, settable at queue time
 
 stages:

--- a/build/botframework-cli-beta.yml
+++ b/build/botframework-cli-beta.yml
@@ -18,9 +18,8 @@ schedules:
     include:
     - beta
 
-variables:
-  runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
 - template: botframework-cli-version.yml  # Template reference ${{ variables.releaseVersion }}
+  runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
 #  version: define this in Azure, settable at queue time
 
 stages:

--- a/build/botframework-cli-beta.yml
+++ b/build/botframework-cli-beta.yml
@@ -20,13 +20,12 @@ schedules:
 
 variables:
 - template: botframework-cli-version.yml  # Template reference ${{ variables.releaseVersion }}
-
-variables:
-  runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
 #  version: define this in Azure, settable at queue time
 
 stages:
 - stage: Build
+  variables:
+    runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
   jobs:
   - job:
     steps:

--- a/build/botframework-cli-beta.yml
+++ b/build/botframework-cli-beta.yml
@@ -19,6 +19,7 @@ schedules:
     - beta
 
 variables:
+  runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
 - template: botframework-cli-version.yml  # Template reference ${{ variables.releaseVersion }}
 #  version: define this in Azure, settable at queue time
 

--- a/build/botframework-cli-beta.yml
+++ b/build/botframework-cli-beta.yml
@@ -19,8 +19,8 @@ schedules:
     - beta
 
 variables:
-- template: botframework-cli-version.yml  # Template reference ${{ variables.releaseVersion }}
   runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
+- template: botframework-cli-version.yml  # Template reference ${{ variables.releaseVersion }}
 #  version: define this in Azure, settable at queue time
 
 stages:

--- a/build/botframework-cli-beta.yml
+++ b/build/botframework-cli-beta.yml
@@ -20,7 +20,7 @@ schedules:
 
 variables:
   runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
-  - template: botframework-cli-version.yml  # Template reference ${{ variables.releaseVersion }}
+- template: botframework-cli-version.yml  # Template reference ${{ variables.releaseVersion }}
 #  version: define this in Azure, settable at queue time
 
 stages:

--- a/build/botframework-cli-beta.yml
+++ b/build/botframework-cli-beta.yml
@@ -20,7 +20,7 @@ schedules:
 
 variables:
   runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
-- template: botframework-cli-version.yml  # Template reference ${{ variables.releaseVersion }}
+  - template: botframework-cli-version.yml  # Template reference ${{ variables.releaseVersion }}
 #  version: define this in Azure, settable at queue time
 
 stages:

--- a/build/botframework-cli-beta.yml
+++ b/build/botframework-cli-beta.yml
@@ -18,6 +18,7 @@ schedules:
     include:
     - beta
 
+variables:
 - template: botframework-cli-version.yml  # Template reference ${{ variables.releaseVersion }}
   runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
 #  version: define this in Azure, settable at queue time

--- a/build/botframework-cli-beta.yml
+++ b/build/botframework-cli-beta.yml
@@ -18,7 +18,6 @@ schedules:
     include:
     - beta
 
-variables:
 - template: botframework-cli-version.yml  # Template reference ${{ variables.releaseVersion }}
   runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
 #  version: define this in Azure, settable at queue time

--- a/build/botframework-cli-daily.yml
+++ b/build/botframework-cli-daily.yml
@@ -18,9 +18,8 @@ schedules:
     include:
     - main
 
-variables:
-  runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
 - template: botframework-cli-version.yml  # Template reference ${{ variables.releaseVersion }}
+  runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
 #  version: define this in Azure, settable at queue time
 
 stages:

--- a/build/botframework-cli-daily.yml
+++ b/build/botframework-cli-daily.yml
@@ -18,12 +18,14 @@ schedules:
     include:
     - main
 
+variables:
 - template: botframework-cli-version.yml  # Template reference ${{ variables.releaseVersion }}
-  runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
 #  version: define this in Azure, settable at queue time
 
 stages:
 - stage: Build
+  variables:
+    runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
   jobs:
   - job:
     steps:

--- a/build/botframework-cli-daily.yml
+++ b/build/botframework-cli-daily.yml
@@ -19,6 +19,7 @@ schedules:
     - main
 
 variables:
+  runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
 - template: botframework-cli-version.yml  # Template reference ${{ variables.releaseVersion }}
 #  version: define this in Azure, settable at queue time
 

--- a/build/botframework-cli-rc.yml
+++ b/build/botframework-cli-rc.yml
@@ -12,6 +12,7 @@ pr: none
 trigger: none
 
 variables:
+  runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
 - template: botframework-cli-version.yml  # Template reference ${{ variables.releaseVersion }}
 #  version: define this in Azure, settable at queue time
 

--- a/build/botframework-cli-rc.yml
+++ b/build/botframework-cli-rc.yml
@@ -11,9 +11,8 @@ pool:
 pr: none
 trigger: none
 
-variables:
-  runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
 - template: botframework-cli-version.yml  # Template reference ${{ variables.releaseVersion }}
+  runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
 #  version: define this in Azure, settable at queue time
 
 stages:

--- a/build/botframework-cli-rc.yml
+++ b/build/botframework-cli-rc.yml
@@ -11,12 +11,14 @@ pool:
 pr: none
 trigger: none
 
+variables:
 - template: botframework-cli-version.yml  # Template reference ${{ variables.releaseVersion }}
-  runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
 #  version: define this in Azure, settable at queue time
 
 stages:
 - stage: Build
+  variables:
+    runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
   jobs:
   - job:
     steps:

--- a/build/botframework-cli-version.yml
+++ b/build/botframework-cli-version.yml
@@ -1,2 +1,1 @@
-variables:
-  releaseVersion: '4.12.0'
+releaseVersion: '4.12.0'

--- a/build/botframework-cli-version.yml
+++ b/build/botframework-cli-version.yml
@@ -1,1 +1,2 @@
-releaseVersion: '4.12.0'
+variables:
+  releaseVersion: '4.12.0'

--- a/build/botframework-cli.yml
+++ b/build/botframework-cli.yml
@@ -16,6 +16,7 @@ pr:
 jobs:
   - job: CLI
     variables:
+      runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
       buildVersion: '4.10.0-preview.$(Build.BuildId)'
       _version: ${{coalesce(variables.version, variables.buildVersion)}}
 


### PR DESCRIPTION
Codesign Validation is an injected task that only has value in builds that sign. In other builds, it extends the running time by 40+ seconds and has no effect. This code change causes the task to be skipped in those builds.