### PR TITLE
support output to file for kb:export command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1617,7 +1617,9 @@ USAGE
   $ bf qnamaker:kb:export
 
 OPTIONS
+  -f, --force                        [default: false] If --out flag is provided with the path to an existing file, overwrites that file.
   -h, --help                         qnamaker:kb:export command help
+  -o, --out                          Output file path. If not specified stdout will be used as output.
   --endpoint=endpoint                Overrides public endpoint https://westus.api.cognitive.microsoft.com/qnamaker/v4.0/
   --environment=environment          [default: Prod] Specifies whether environment is Test or Prod.
 

--- a/packages/qnamaker/README.md
+++ b/packages/qnamaker/README.md
@@ -400,7 +400,9 @@ USAGE
   $ bf qnamaker:kb:export
 
 OPTIONS
+  -f, --force                        [default: false] If --out flag is provided with the path to an existing file, overwrites that file.
   -h, --help                         qnamaker:kb:export command help
+  -o, --out                          Output file path. If not specified stdout will be used as output.
   --endpoint=endpoint                Overrides public endpoint https://westus.api.cognitive.microsoft.com/qnamaker/v4.0/
   --environment=environment          [default: Prod] Specifies whether environment is Test or Prod.
 

--- a/packages/qnamaker/src/commands/qnamaker/kb/export.ts
+++ b/packages/qnamaker/src/commands/qnamaker/kb/export.ts
@@ -3,10 +3,12 @@
  * Licensed under the MIT License.
  */
 
-import {CLIError, Command, flags} from '@microsoft/bf-cli-command'
+import {CLIError, Command, flags, utils} from '@microsoft/bf-cli-command'
+import {Inputs, processInputs} from '../../../utils/qnamakerbase'
+const fs = require('fs-extra')
+const path = require('path')
 const qnamaker = require('./../../../../utils/index')
 const exportKbJSON = require('./../../../../utils/payloads/exportkb')
-import {Inputs, processInputs} from '../../../utils/qnamakerbase'
 
 export default class QnamakerKbExport extends Command {
   static description = 'Echos a knowledgebase in json or qna format to stdout'
@@ -17,6 +19,8 @@ export default class QnamakerKbExport extends Command {
     environment: flags.string({description: 'Specifies whether environment is Test or Prod.', default: 'Prod'}),
     subscriptionKey: flags.string({description: 'Specifies the qnamaker Ocp-Apim-Subscription Key (found in Keys under Resource Management section for your Qna Maker cognitive service). Overrides the subscriptionkey value present in the config'}),
     endpoint: flags.string({description: 'Overrides public endpoint https://westus.api.cognitive.microsoft.com/qnamaker/v4.0/'}),
+    out: flags.string({char: 'o', description: 'Output file path. If not specified stdout will be used as output.'}),
+    force: flags.boolean({char: 'f', description: 'If --out flag is provided with the path to an existing file, overwrites that file.', default: false}),
     help: flags.help({char: 'h', description: 'qnamaker:kb:export command help'}),
   }
 
@@ -24,14 +28,35 @@ export default class QnamakerKbExport extends Command {
     const {flags} = this.parse(QnamakerKbExport)
     let input: Inputs = await processInputs(flags, exportKbJSON, this.config.configDir)
 
-    const result = await qnamaker(input.config, input.serviceManifest, flags, input.requestBody)
+    let result = await qnamaker(input.config, input.serviceManifest, flags, input.requestBody)
     if (result.error) {
       throw new CLIError(JSON.stringify(result.error, null, 4))
     } else {
-      if (typeof result === 'string')
+      if (typeof result !== 'string') {
+        result = JSON.stringify(result, null, 2)
+      }
+
+      if (flags.out) {
+        await this.writeOutput(result, flags)
+      } else {
         this.log(result)
-      else
-        this.log(JSON.stringify(result, null, 2))
+      }
+    }
+  }
+
+  async writeOutput(result: any, flags: any) {
+    let fullPath = path.resolve(flags.out)
+    let root = path.dirname(fullPath)
+    if (!fs.existsSync(root)) {
+      fs.mkdirSync(root)
+    }
+
+    const validatedPath = utils.validatePath(fullPath, '', flags.force)
+
+    try {
+      await fs.writeFile(validatedPath, result, 'utf-8')
+    } catch (error) {
+      throw new CLIError('Unable to write file - ' + validatedPath + ' Error: ' + error.message)
     }
   }
 }

--- a/packages/qnamaker/test/fixtures/verified/exportSpecialChars.qna
+++ b/packages/qnamaker/test/fixtures/verified/exportSpecialChars.qna
@@ -1,0 +1,6 @@
+# ? Hello
+- Plus d'information sur la lettre reçu des éléctions?
+      
+```
+Plus d'information sur la lettre reçu des éléctions
+```


### PR DESCRIPTION
Fix https://github.com/microsoft/botframework-solutions/issues/3723 and https://github.com/microsoft/botframework-cli/issues/1057. Support output kb to a file for bf qnamaker:kb:export command.