### PR TITLE
Hash line ending agnostic and import exclusion bug

### DIFF
--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -36,7 +36,7 @@ _See code: [src/commands/dialog/index.ts](https://github.com/microsoft/botframew
 
 ## `bf dialog:merge PATTERNS`
 
-Merge `<kind>.schema` and `<kind>[.<locale>].uischema` definitions from a project and its dependencies into a single .schema for describing .dialog files and a per locale .uischema for describing how Composer shows them.  If a dependent package has an "exported" directory it is copied to /<package> in the --imports directory.
+Merge `<kind>.schema` and `<kind>[.<locale>].uischema` definitions from a project and its dependencies into a single .schema for describing .dialog files and a per locale .uischema for describing how Composer shows them.  If a dependent package has an "exported" directory it is copied to /<package> in the --imports directory. You can make use of negative patterns like !**/generated/** to exclude particular directories or files, although some directories like bin, obj and node_modules are automatically excluded.
 
 ```
 USAGE

--- a/packages/dialog/src/commands/dialog/merge.ts
+++ b/packages/dialog/src/commands/dialog/merge.ts
@@ -7,7 +7,7 @@ import { Command, flags } from '@microsoft/bf-cli-command'
 import { SchemaMerger } from '../../library/schemaMerger'
 
 export default class DialogMerge extends Command {
-    static description = 'Merge `<kind>.schema` and `<kind>[.<locale>].uischema` definitions from a project and its dependencies into a single .schema for describing .dialog files and a per locale .uischema for describing how Composer shows them.  If a dependent package has an "exported" directory it is copied to /<package> in the --imports directory.'
+    static description = 'Merge `<kind>.schema` and `<kind>[.<locale>].uischema` definitions from a project and its dependencies into a single .schema for describing .dialog files and a per locale .uischema for describing how Composer shows them.  If a dependent package has an "exported" directory it is copied to /<package> in the --imports directory. You can make use of negative patterns like !**/generated/** to exclude particular directories or files, although some directories like bin, obj and node_modules are automatically excluded.'
 
     static args = [
         { name: 'patterns', required: true, description: 'Any number of glob regex patterns to match .csproj, .nuspec or package.json files.' },

--- a/packages/dialog/src/library/hash.ts
+++ b/packages/dialog/src/library/hash.ts
@@ -9,7 +9,8 @@ import * as os from 'os'
 import * as ppath from 'path'
 
 export function computeHash(val: string): string {
-    return crypto.createHash('md5').update(val).digest('hex')
+    // We write out OS.EOL, but want hash independent of endings
+    return crypto.createHash('md5').update(val.replace(/\r/, '')).digest('hex')
 }
 
 // Normalize to OS line endings

--- a/packages/dialog/src/library/schemaMerger.ts
+++ b/packages/dialog/src/library/schemaMerger.ts
@@ -155,7 +155,7 @@ class ComponentNode {
                 patterns.push(`!${ppath.join(root, 'bin', '**')}`)
                 patterns.push(`!${ppath.join(root, 'obj', '**')}`)
             }
-            patterns.push(`!${ppath.resolve(imports)}`)
+            patterns.push(`!${ppath.join(ppath.resolve(imports), '**')}`)
             patterns.push(`!${ppath.join(root, 'test', '**')}`)
             patterns.push(`!${ppath.join(root, 'tests', '**')}`)
             patterns = [...patterns, ...negativePatterns]

--- a/packages/dialog/src/library/schemaMerger.ts
+++ b/packages/dialog/src/library/schemaMerger.ts
@@ -153,8 +153,9 @@ class ComponentNode {
                 patterns.push(`!${ppath.join(root, 'node_modules', '**')}`)
             } else if (this.metadata.path.endsWith('.csproj')) {
                 patterns.push(`!${ppath.join(root, 'bin', '**')}`)
+                patterns.push(`!${ppath.join(root, 'obj', '**')}`)
             }
-            patterns.push(`!${imports}`)
+            patterns.push(`!${ppath.resolve(imports)}`)
             patterns.push(`!${ppath.join(root, 'test', '**')}`)
             patterns.push(`!${ppath.join(root, 'tests', '**')}`)
             patterns = [...patterns, ...negativePatterns]


### PR DESCRIPTION
Made hash computation line ending agnostic by normalizing to plain line feed.  On CRLF systems this may result in a different hash than before.  We always write OS.EOL, but git might change the line endings so this change was made.
Fix bug where imports were not excluded properly if they were relative paths.  As a work-around people can add !**/imported/** to their command line.
Added obj to default exclusions.