### PR TITLE
Enable direct version publish in luis build api

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -771,6 +771,7 @@ OPTIONS
 
   --isStaging                      Publishes luis application to staging slot if set. Default to production slot
 
+  --directVersionPublish           [default: false] Available only in direct version query. Do not publish to staging or production
 EXAMPLE
 
        $ bf luis:build --in {INPUT_FILE_OR_FOLDER} --authoringKey {AUTHORING_KEY} --botName {BOT_NAME}

--- a/packages/lu/src/parser/lubuild/builder.ts
+++ b/packages/lu/src/parser/lubuild/builder.ts
@@ -175,7 +175,7 @@ export class Builder {
     let region = options.region || 'westus'
     
     // set kept version count which means how many versions would be kept in luis service
-    let keptVersionCount = options.keptVersionCount && options.keptVersionCount > 0 ? options.keptVersionCount : maxVersionCount
+    let keptVersionCount = options.keptVersionCount && options.keptVersionCount > 0 && options.keptVersionCount <= maxVersionCount ? options.keptVersionCount : maxVersionCount
     
     // set if publish this application to staging or production slot
     // default to production
@@ -196,6 +196,10 @@ export class Builder {
 
     // set retry duration for rate limit luis API failure
     let retryDuration = options.retryDuration || 1000
+
+    // set direct version publish flag
+    // default to false
+    let directVersionPublish = options.directVersionPublish || false
 
     // settings assets like app id and version returned from luis api call
     let settingsAssets: any[] = []
@@ -253,7 +257,7 @@ export class Builder {
 
               if (needTrainAndPublish) {
                 // train and publish application
-                await this.trainAndPublishApplication(luBuildCore, recognizer, timeBucketOfRequests, isStaging)
+                await this.trainAndPublishApplication(luBuildCore, recognizer, timeBucketOfRequests, isStaging, directVersionPublish)
               }
 
               // init settings asset
@@ -421,7 +425,7 @@ export class Builder {
     return true
   }
 
-  async trainAndPublishApplication(luBuildCore: LuBuildCore, recognizer: Recognizer, timeBucket: number, isStaging: boolean) {
+  async trainAndPublishApplication(luBuildCore: LuBuildCore, recognizer: Recognizer, timeBucket: number, isStaging: boolean, directVersionPublish: boolean) {
     // send train application request
     this.handler(`${recognizer.getLuPath()} training version=${recognizer.versionId}\n`)
     await delay(timeBucket)
@@ -448,7 +452,7 @@ export class Builder {
     // publish applications
     this.handler(`${recognizer.getLuPath()} publishing version=${recognizer.versionId}\n`)
     await delay(timeBucket)
-    await luBuildCore.publishApplication(recognizer.getAppId(), recognizer.versionId, isStaging)
+    await luBuildCore.publishApplication(recognizer.getAppId(), recognizer.versionId, isStaging, directVersionPublish)
     this.handler(`${recognizer.getLuPath()} publishing finished for ${isStaging ? 'Staging' : 'Production'} slot\n`)
   }
 

--- a/packages/lu/src/parser/lubuild/core.ts
+++ b/packages/lu/src/parser/lubuild/core.ts
@@ -348,23 +348,26 @@ export class LuBuildCore {
     return status
   }
 
-  public async publishApplication(appId: string, versionId: string, isStaging: boolean) {
+  public async publishApplication(appId: string, versionId: string, isStaging: boolean, directVersionPublish: boolean) {
+    let url = this.endpoint + '/luis/authoring/v3.0-preview/apps/' + appId + '/publish'
+
+    let messageData
     let retryCount = this.retryCount + 1
-    let error
+    let error: any
     while (retryCount > 0) {
-      if (error === undefined || error.statusCode === rateLimitErrorCode) {
-        try {
-          await this.client.apps.publish(appId,
-            {
-              versionId,
-              isStaging
-            })
-          break
-        } catch (e) {
-          error = e
-          retryCount--
-          if (retryCount > 0) await delay(this.retryDuration)
-        }
+      if (error === undefined || error.code === rateLimitErrorCode.toString()) {
+        let response = await fetch(url, {method: 'POST', headers: this.headers, body: JSON.stringify({
+          versionId,
+          isStaging,
+          directVersionPublish
+        })})
+        messageData = await response.json()
+
+        if (messageData.error === undefined) break
+
+        error = messageData.error
+        retryCount--
+        if (retryCount > 0) await delay(this.retryDuration)
       } else {
         throw error
       }
@@ -373,6 +376,8 @@ export class LuBuildCore {
     if (retryCount === 0) {
       throw error
     }
+
+    return messageData
   }
 
   private updateVersionValue(versionId: string) {

--- a/packages/luis/README.md
+++ b/packages/luis/README.md
@@ -374,6 +374,7 @@ OPTIONS
 
   --isStaging                      Publishes luis application to staging slot if set. Default to production slot
 
+  --directVersionPublish           [default: false] Available only in direct version query. Do not publish to staging or production
 EXAMPLE
 
        $ bf luis:build --in {INPUT_FILE_OR_FOLDER} --authoringKey {AUTHORING_KEY} --botName {BOT_NAME}

--- a/packages/luis/src/commands/luis/build.ts
+++ b/packages/luis/src/commands/luis/build.ts
@@ -41,6 +41,7 @@ export default class LuisBuild extends Command {
     endpoint: flags.string({description: 'Luis authoring endpoint for publishing'}),
     schema: flags.string({description: 'Defines $schema for generated .dialog files'}),
     isStaging: flags.boolean({description: 'Publishes luis application to staging slot if set. Default to production slot', default: false}),
+    directVersionPublish: flags.boolean({description: 'Available only in direct version query. Do not publish to staging or production', default: false})
   }
 
   async run() {
@@ -68,7 +69,7 @@ export default class LuisBuild extends Command {
       // Flags override userConfig
       let luisBuildFlags = Object.keys(LuisBuild.flags)
 
-      let {inVal, authoringKey, botName, region, out, defaultCulture, fallbackLocale, suffix, dialog, force, luConfig, deleteOldVersion, log, endpoint, schema, isStaging}
+      let {inVal, authoringKey, botName, region, out, defaultCulture, fallbackLocale, suffix, dialog, force, luConfig, deleteOldVersion, log, endpoint, schema, isStaging, directVersionPublish}
         = await utils.processInputs(flags, luisBuildFlags, this.config.configDir)
 
       flags.stdin = await this.readStdin()
@@ -141,7 +142,8 @@ export default class LuisBuild extends Command {
         region,
         keptVersionCount,
         isStaging,
-        schema
+        schema,
+        directVersionPublish
       })
 
       // write dialog assets based on config


### PR DESCRIPTION
Enable direct version publish for luis build api and cli. For composer, call luis build api with directVersionPublish set to true in options.