### PR TITLE
Fix luis objects with only app settings definitions are filtered out unreasonably when merging multiple luis objects

### DIFF
--- a/packages/lu/src/parser/lu/luMerger.js
+++ b/packages/lu/src/parser/lu/luMerger.js
@@ -380,12 +380,7 @@ const buildLuJsonObject = async function(luObjArray, log, luis_culture, luSearch
         let parsedContent = await parseLuFile(luOb, log, luis_culture)
         parsedFiles.push(luOb.id)
 
-        // Fix for BF-CLI #620
-        // We do not perform validation here. for parseFile V1 API route, 
-        //  the recommendation is to call validate() after parse.
-        if (haveLUISContent(parsedContent.LUISJsonStructure)) {
-            allParsedLUISContent.push(parserObject.create(parsedContent.LUISJsonStructure, undefined, undefined, luOb.id, luOb.includeInCollate))
-        }
+        allParsedLUISContent.push(parserObject.create(parsedContent.LUISJsonStructure, undefined, undefined, luOb.id, luOb.includeInCollate))
 
         allParsedQnAContent.push(parserObject.create(undefined, parsedContent.qnaJsonStructure, undefined, luOb.id, luOb.includeInCollate))
         allParsedAlterationsContent.push(parserObject.create(undefined, undefined, parsedContent.qnaAlterations, luOb.id, luOb.includeInCollate))
@@ -495,21 +490,6 @@ const updateParsedFiles = function(allParsedLUISContent, allParsedQnAContent, al
         if(matchInAlterations) matchInAlterations.includeInCollate = true;
     }
 } 
-
-const haveLUISContent = function(blob) {
-    if(!blob) return false;
-    return ((blob[LUISObjNameEnum.INTENT].length > 0) ||
-    (blob[LUISObjNameEnum.ENTITIES].length > 0) || 
-    (blob[LUISObjNameEnum.CLOSEDLISTS].length > 0) ||
-    (blob[LUISObjNameEnum.PATTERNANYENTITY].length > 0) ||
-    (blob.patterns.length > 0) ||
-    (blob[LUISObjNameEnum.UTTERANCE].length > 0) ||
-    (blob.prebuiltEntities.length > 0) ||
-    (blob[LUISObjNameEnum.REGEX].length > 0) ||
-    (blob.model_features && blob.model_features.length > 0) ||
-    (blob.phraselists && blob.phraselists.length > 0) ||
-    (blob.composites.length > 0));
-}
 
 const isNewEntity = function(luisModel, entityName){
     let simpleEntityInMaster = luisModel.entities.find(item => item.name == entityName);

--- a/packages/lu/test/parser/luis/luisBuilder.test.js
+++ b/packages/lu/test/parser/luis/luisBuilder.test.js
@@ -78,5 +78,22 @@ assert.isTrue(luisObject.validate())
         assert.equal(luisObject.content.includes(`@ intent "test intent" usesFeature bar`), true);
     })
 
-    
+    it('App settings can be merged correctly when importing lu files', async () => {
+        let luFile = `
+        > !# @app.culture = zh-cn
+        > !# @app.settings.NormalizeWordForm = true
+        > !# @app.settings.UseAllTrainingData = true
+        
+        [import greeting](./test/fixtures/testcases/collate/1.lu)`;
+
+        const luisObject = await LUISBuilder.fromLUAsync(luFile)
+
+        assert.equal(luisObject.intents[0].name, 'Greeting');
+        assert.equal(luisObject.culture, 'zh-cn');
+        assert.equal(luisObject.settings.length, 2);
+        assert.equal(luisObject.settings[0].name, 'NormalizeWordForm');
+        assert.equal(luisObject.settings[0].value, true);
+        assert.equal(luisObject.settings[1].name, 'UseAllTrainingData');
+        assert.equal(luisObject.settings[1].value, true);
+    });
 });


### PR DESCRIPTION
Fix #1100. Before the fix, luis objects with only app settings definitions will be filtered out unreasonably which caused app settings are dropped when merging other luis objects. After the fix, we removed such unreasonable filtering.