### PR TITLE
Fix bug where luis:convert would incorrectly generate an error message

### DIFF
--- a/packages/lu/src/parser/luis/luisCollate.js
+++ b/packages/lu/src/parser/luis/luisCollate.js
@@ -205,6 +205,22 @@ const mergeResults = function (blob, finalCollection, type) {
                 break;
             }
 
+            if (type === LUISObjNameEnum.INTENT && finalCollection[type][fIndex].name === blobItem.name) {
+                itemExists = true;
+                (blobItem.features || []).forEach(blobFeature => {
+                    if (finalCollection[type][fIndex].features === undefined) {
+                        finalCollection[type][fIndex].features = [];
+                    }
+                    if (!finalCollection[type][fIndex].features.find(
+                        (feature) =>
+                          feature.modelName === blobFeature.modelName ||
+                          feature.featureName === blobFeature.featureName)) {
+                      finalCollection[type][fIndex].features.push(blobFeature);
+                    }
+                });
+                break;
+            }
+
             // if item name matches, merge roles if available for everything other than intent
             if (type === LUISObjNameEnum.INTENT ||
                 type === LUISObjNameEnum.PATTERNS ||

--- a/packages/lu/src/parser/luis/luisCollate.js
+++ b/packages/lu/src/parser/luis/luisCollate.js
@@ -16,7 +16,7 @@ const retCode = require('../utils/enums/CLI-errors')
  * @returns {Luis} new Luis instance
  * @throws {exception} Throws on errors. exception object includes errCode and text. 
  */
-const build =  async function(luArray, verbose, luis_culture, luSearchFn) {
+const build = async function (luArray, verbose, luis_culture, luSearchFn) {
     let mergedContent = await mergeLuFiles(luArray, verbose, luis_culture, luSearchFn)
     let parsedLUISList = mergedContent.LUISContent.filter(item => item.includeInCollate)
     if (parsedLUISList.length === 0) return new Luis()
@@ -33,12 +33,12 @@ const build =  async function(luArray, verbose, luis_culture, luSearchFn) {
  * @param {Luis} luisObject Luis instances to collate with
  * @throws {exception} Throws on errors. exception object includes errCode and text. 
  */
-const collate = function(luisList) {
+const collate = function (luisList) {
     if (luisList.length === 0) return
     let luisObject = new Luis(luisList[0])
     let hashTable = {};
     initializeHash(luisObject, hashTable)
-    for(let i = 1; i < luisList.length; i++) {
+    for (let i = 1; i < luisList.length; i++) {
         let blob = luisList[i]
         mergeResults(blob, luisObject, LUISObjNameEnum.INTENT);
         mergeResults(blob, luisObject, LUISObjNameEnum.ENTITIES);
@@ -60,11 +60,11 @@ const collate = function(luisList) {
 }
 
 module.exports = {
-    collate, 
+    collate,
     build
 }
 
-const cleanupEntities = function(luisObject) {
+const cleanupEntities = function (luisObject) {
     let consolidatedList = [];
     luisObject.composites.forEach(item => consolidatedList.push(item));
     luisObject.closedLists.forEach(item => consolidatedList.push(item));
@@ -74,12 +74,12 @@ const cleanupEntities = function(luisObject) {
     luisObject.entities.forEach((item, idx) => {
         if (consolidatedList.find(e => e.name == item.name) !== undefined) idxToRemove.push(idx);
     })
-    idxToRemove.sort((a, b) => a-b).forEach(idx => luisObject.entities.splice(idx, 1))
+    idxToRemove.sort((a, b) => a - b).forEach(idx => luisObject.entities.splice(idx, 1))
     delete luisObject.onAmbiguousLabels;
 }
 
 const mergeResultsWithHash = function (blob, finalCollection, type, hashTable) {
-    if (blob[type] === undefined || blob[type].length === 0) { 
+    if (blob[type] === undefined || blob[type].length === 0) {
         return
     }
     blob[type].forEach(function (blobItem) {
@@ -95,14 +95,14 @@ const mergeResultsWithHash = function (blob, finalCollection, type, hashTable) {
                 type !== LUISObjNameEnum.PATTERNS &&
                 type !== LUISObjNameEnum.UTTERANCE &&
                 item.name === blobItem.name) {
-                    // merge roles
-                    (blobItem.roles || []).forEach(blobRole => {
-                        if (item.roles && 
-                            !item.roles.includes(blobRole)) {
-                                item.roles.push(blobRole);
-                            }
-                    });
-            }            
+                // merge roles
+                (blobItem.roles || []).forEach(blobRole => {
+                    if (item.roles &&
+                        !item.roles.includes(blobRole)) {
+                        item.roles.push(blobRole);
+                    }
+                });
+            }
         }
     });
 }
@@ -126,17 +126,17 @@ const mergeNDepthEntities = function (blob, finalCollection) {
             })
             // de-dupe and merge children
             if (item.children !== undefined && Array.isArray(item.children) && item.children.length !== 0) {
+                if (itemExistsInFinal && itemExistsInFinal.children === undefined) {
+                    itemExistsInFinal.children = []
+                    itemExistsInFinal.explicitlyAdded = item.explicitlyAdded;
+                }
                 recursivelyMergeChildrenAndFeatures(item.children, itemExistsInFinal.children)
             }
         }
     })
 }
 
-const recursivelyMergeChildrenAndFeatures = function(srcChildren, tgtChildren) {
-    if (tgtChildren === undefined || !Array.isArray(tgtChildren) || tgtChildren.length === 0) {
-        tgtChildren = srcChildren;
-        return;
-    }
+const recursivelyMergeChildrenAndFeatures = function (srcChildren, tgtChildren) {
     (srcChildren || []).forEach(item => {
         // find child in tgt
         let itemExistsInFinal = (tgtChildren || []).find(x => x.name == item.name);
@@ -157,8 +157,8 @@ const recursivelyMergeChildrenAndFeatures = function(srcChildren, tgtChildren) {
                 }
                 item.features.forEach(f => {
                     let featureInFinal = (itemExistsInFinal.features || []).find(itFea => {
-                        return ((itFea.featureName !== undefined && itFea.featureName == f.featureName) || 
-                                (itFea.modelName !== undefined && itFea.modelName == f.modelName))
+                        return ((itFea.featureName !== undefined && itFea.featureName == f.featureName) ||
+                            (itFea.modelName !== undefined && itFea.modelName == f.modelName))
                     });
                     if (featureInFinal === undefined) {
                         itemExistsInFinal.features.push(f);
@@ -172,6 +172,9 @@ const recursivelyMergeChildrenAndFeatures = function(srcChildren, tgtChildren) {
             }
             // de-dupe and merge children
             if (item.children !== undefined && Array.isArray(item.children) && item.children.length !== 0) {
+                if (itemExistsInFinal && itemExistsInFinal.children === undefined) {
+                    itemExistsInFinal.children = []
+                }
                 recursivelyMergeChildrenAndFeatures(item.children, itemExistsInFinal.children)
             }
         }
@@ -186,7 +189,7 @@ const recursivelyMergeChildrenAndFeatures = function(srcChildren, tgtChildren) {
  * @returns {void} Nothing
  */
 const mergeResults = function (blob, finalCollection, type) {
-    if (blob[type] === undefined || blob[type].length === 0) { 
+    if (blob[type] === undefined || blob[type].length === 0) {
         return
     }
     blob[type].forEach(function (blobItem) {
@@ -200,24 +203,24 @@ const mergeResults = function (blob, finalCollection, type) {
             if (deepEqual(finalCollection[type][fIndex], blobItem)) {
                 itemExists = true;
                 break;
-            } 
+            }
 
             // if item name matches, merge roles if available for everything other than intent
-            if (type === LUISObjNameEnum.INTENT || 
-                type === LUISObjNameEnum.PATTERNS || 
+            if (type === LUISObjNameEnum.INTENT ||
+                type === LUISObjNameEnum.PATTERNS ||
                 type === LUISObjNameEnum.UTTERANCE ||
                 finalCollection[type][fIndex].name !== blobItem.name) {
-                    continue;
+                continue;
             }
-    
+
             itemExists = true;
             (blobItem.roles || []).forEach(blobRole => {
-                if (finalCollection[type][fIndex].roles && 
+                if (finalCollection[type][fIndex].roles &&
                     !finalCollection[type][fIndex].roles.includes(blobRole)) {
-                        finalCollection[type][fIndex].roles.push(blobRole);
+                    finalCollection[type][fIndex].roles.push(blobRole);
                 }
             });
-       
+
         }
         if (!itemExists) {
             finalCollection[type].push(blobItem);
@@ -267,7 +270,7 @@ const mergeResults_closedlists = function (blob, finalCollection, type) {
     });
 }
 
-const buildRegex = function(blob, FinalLUISJSON){
+const buildRegex = function (blob, FinalLUISJSON) {
     // do we have regex entities here?
     if (blob.regex_entities === undefined || blob.regex_entities.length === 0) {
         return
@@ -293,7 +296,7 @@ const buildRegex = function(blob, FinalLUISJSON){
     })
 }
 
-const buildPrebuiltEntities = function(blob, FinalLUISJSON){
+const buildPrebuiltEntities = function (blob, FinalLUISJSON) {
     // do we have prebuiltEntities here?
     if (blob.prebuiltEntities === undefined || blob.prebuiltEntities.length === 0) {
         return
@@ -318,7 +321,7 @@ const buildPrebuiltEntities = function(blob, FinalLUISJSON){
     });
 }
 
-const buildModelFeatures = function(blob, FinalLUISJSON){
+const buildModelFeatures = function (blob, FinalLUISJSON) {
     // Find what scope to use in blob
     let blobScope = blob.model_features || blob.phraselists || [];
     if (blobScope.length === 0) return;
@@ -343,7 +346,7 @@ const buildModelFeatures = function(blob, FinalLUISJSON){
     });
 }
 
-const buildComposites = function(blob, FinalLUISJSON){
+const buildComposites = function (blob, FinalLUISJSON) {
     if (blob.composites === undefined) return;
     // do we have composites? collate them correctly
     (blob.composites || []).forEach(composite => {
@@ -367,7 +370,7 @@ const buildComposites = function(blob, FinalLUISJSON){
     });
 }
 
-const buildPatternAny = function(blob, FinalLUISJSON){
+const buildPatternAny = function (blob, FinalLUISJSON) {
     if (blob.patternAnyEntities === undefined) return;
     // do we have pattern.any entities here? 
     (blob.patternAnyEntities || []).forEach(patternAny => {
@@ -385,7 +388,7 @@ const buildPatternAny = function(blob, FinalLUISJSON){
         let listEntityInMaster = FinalLUISJSON.closedLists.find(item => item.name == patternAny.name);
         let regexEntityInMaster = FinalLUISJSON.regex_entities.find(item => item.name == patternAny.name);
         let prebuiltInMaster = FinalLUISJSON.prebuiltEntities.find(item => item.name == patternAny.name);
-        if (!simpleEntityInMaster && 
+        if (!simpleEntityInMaster &&
             !compositeInMaster &&
             !listEntityInMaster &&
             !regexEntityInMaster &&
@@ -393,7 +396,7 @@ const buildPatternAny = function(blob, FinalLUISJSON){
             if (patternAnyInMaster) {
                 (patternAny.roles || []).forEach(role => !patternAnyInMaster.roles.includes(role) ? patternAnyInMaster.roles.push(role) : undefined);
             } else {
-                    FinalLUISJSON.patternAnyEntities.push(patternAny);
+                FinalLUISJSON.patternAnyEntities.push(patternAny);
             }
         } else {
             // remove the pattern.any from master if another entity type has this name.
@@ -404,10 +407,10 @@ const buildPatternAny = function(blob, FinalLUISJSON){
     })
 }
 
-const initializeHash = function(LuisJSON, hashTable = undefined) {
+const initializeHash = function (LuisJSON, hashTable = undefined) {
     for (let prop in LuisJSON) {
         if (hashTable !== undefined && (prop === LUISObjNameEnum.UTTERANCE || prop === LUISObjNameEnum.PATTERNS)) {
             (LuisJSON[prop] || []).forEach(item => hashTable[helpers.hashCode(JSON.stringify(item))] = item)
         }
-    }   
+    }
 }

--- a/packages/lu/src/parser/luis/luisCollate.js
+++ b/packages/lu/src/parser/luis/luisCollate.js
@@ -205,7 +205,7 @@ const mergeResults = function (blob, finalCollection, type) {
                 break;
             }
 
-            if (type === LUISObjNameEnum.INTENT && finalCollection[type][fIndex].name === blobItem.name) {
+            if ((type === LUISObjNameEnum.INTENT || type === LUISObjNameEnum.ENTITIES) && finalCollection[type][fIndex].name === blobItem.name) {
                 itemExists = true;
                 (blobItem.features || []).forEach(blobFeature => {
                     if (finalCollection[type][fIndex].features === undefined) {
@@ -213,12 +213,13 @@ const mergeResults = function (blob, finalCollection, type) {
                     }
                     if (!finalCollection[type][fIndex].features.find(
                         (feature) =>
-                          feature.modelName === blobFeature.modelName ||
-                          feature.featureName === blobFeature.featureName)) {
+                          (feature.modelName && feature.modelName === blobFeature.modelName) ||
+                          (feature.featureName && feature.featureName === blobFeature.featureName))) {
                       finalCollection[type][fIndex].features.push(blobFeature);
                     }
                 });
-                break;
+
+                if (type === LUISObjNameEnum.INTENT) break;
             }
 
             // if item name matches, merge roles if available for everything other than intent

--- a/packages/lu/src/parser/utils/helpers.js
+++ b/packages/lu/src/parser/utils/helpers.js
@@ -354,7 +354,6 @@ const updateModelBasedOnNDepthEntities = function(utterances, entityParentTree)
                 // Is the entity a root entity? 
                 let isRootEntity = parentsForEntity.find(t => t[0] == "$root$")
                 if (isRootEntity === undefined) {
-                    debugger
                     const errorMsg = `Every child entity labelled in an utterance must have its parent labelled in that utterance. Child entity "${entityInUtterance.entity}" does not have its parent labelled in utterance "${utterance.text}" for intent "${utterance.intent}".`;
                     throw (new exception(retCode.errorCode.INVALID_INPUT, errorMsg));
                 }

--- a/packages/lu/src/parser/utils/helpers.js
+++ b/packages/lu/src/parser/utils/helpers.js
@@ -354,6 +354,7 @@ const updateModelBasedOnNDepthEntities = function(utterances, entityParentTree)
                 // Is the entity a root entity? 
                 let isRootEntity = parentsForEntity.find(t => t[0] == "$root$")
                 if (isRootEntity === undefined) {
+                    debugger
                     const errorMsg = `Every child entity labelled in an utterance must have its parent labelled in that utterance. Child entity "${entityInUtterance.entity}" does not have its parent labelled in utterance "${utterance.text}" for intent "${utterance.intent}".`;
                     throw (new exception(retCode.errorCode.INVALID_INPUT, errorMsg));
                 }

--- a/packages/lu/test/commands/luis/convert.test.js
+++ b/packages/lu/test/commands/luis/convert.test.js
@@ -106,7 +106,7 @@ describe('luis:convert', () => {
     })
 
     it('luis:convert hierarchical entities defined after labels parsed correctly', async () => {
-        await assertToJSON('./../../fixtures/examples/newEntityIncludes.lu', './../../fixtures/verified/13.json', '13')
+        await assertToJSON('./../../fixtures/examples/newEntityIncludes.lu', './../../fixtures/verified/newEntityIncludes.json')
     })
 
     it('Parse to LU instance', async () => {

--- a/packages/lu/test/commands/luis/convert.test.js
+++ b/packages/lu/test/commands/luis/convert.test.js
@@ -105,6 +105,10 @@ describe('luis:convert', () => {
         await assertToJSON('./../../fixtures/examples/13.lu', './../../fixtures/verified/13.json', '13')
     })
 
+    it('luis:convert hierarchical entities defined after labels parsed correctly', async () => {
+        await assertToJSON('./../../fixtures/examples/newEntityIncludes.lu', './../../fixtures/verified/13.json', '13')
+    })
+
     it('Parse to LU instance', async () => {
         let luFile = `
         @ ml test

--- a/packages/lu/test/fixtures/examples/newEntityIncludes.lu
+++ b/packages/lu/test/fixtures/examples/newEntityIncludes.lu
@@ -1,0 +1,2 @@
+[labels](newEntityWithFeaturesLabels.lu)
+[definitions](newEntityWithFeatures.lu)

--- a/packages/lu/test/fixtures/examples/newEntityIncludes.lu
+++ b/packages/lu/test/fixtures/examples/newEntityIncludes.lu
@@ -1,2 +1,2 @@
-[labels](newEntityWithFeaturesLabels.lu)
-[definitions](newEntityWithFeatures.lu)
+[labels](./test/fixtures/examples/newEntityWithFeaturesLabels.lu)
+[definitions](./test/fixtures/examples/newEntityWithFeatures.lu)

--- a/packages/lu/test/fixtures/examples/newEntityWithFeaturesLabels.lu
+++ b/packages/lu/test/fixtures/examples/newEntityWithFeaturesLabels.lu
@@ -1,0 +1,6 @@
+# GetUserProfile
+- I am {@userProfile = {@userAge = 36}} years old
+- My first name is {@userProfile = {@userName = {@firstName = vishwac}}}
+- My last name is {@userProfile = {@userName = {@lastName = kannan}}}
+- First of {@userProfile = {@userName = {@firstName = vishwac}}}
+- Age of {@userProfile = {@userAge = 36}}

--- a/packages/lu/test/fixtures/verified/newEntityIncludes.json
+++ b/packages/lu/test/fixtures/verified/newEntityIncludes.json
@@ -1,0 +1,398 @@
+{
+    "intents": [
+      {
+        "name": "GetUserProfile",
+        "features": [
+          {
+            "modelName": "userProfile",
+            "isRequired": false
+          },
+          {
+            "featureName": "profileDefinition",
+            "isRequired": false
+          }
+        ]
+      },
+      {
+        "name": "Greeting"
+      }
+    ],
+    "entities": [
+      {
+        "name": "userProfile",
+        "roles": [],
+        "children": [
+          {
+            "name": "userName",
+            "children": [
+              {
+                "name": "firstName",
+                "children": [],
+                "features": [
+                  {
+                    "modelName": "personName",
+                    "isRequired": true
+                  }
+                ]
+              },
+              {
+                "name": "lastName",
+                "children": [],
+                "features": [
+                  {
+                    "modelName": "personName",
+                    "isRequired": true
+                  }
+                ]
+              }
+            ],
+            "features": [
+              {
+                "modelName": "personName",
+                "isRequired": false
+              }
+            ]
+          },
+          {
+            "name": "userAge",
+            "children": [],
+            "features": [
+              {
+                "modelName": "age",
+                "isRequired": true
+              }
+            ]
+          },
+          {
+            "name": "userCity",
+            "children": [],
+            "features": [
+              {
+                "modelName": "cities",
+                "isRequired": true
+              }
+            ]
+          },
+          {
+            "name": "userZipCode",
+            "children": [],
+            "features": [
+              {
+                "modelName": "zipCode",
+                "isRequired": true
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "composites": [],
+    "closedLists": [
+      {
+        "name": "cities",
+        "subLists": [
+          {
+            "canonicalForm": "seattle",
+            "list": [
+              "SEA",
+              "Seatac"
+            ]
+          },
+          {
+            "canonicalForm": "redmond",
+            "list": [
+              "microsoft",
+              "REA"
+            ]
+          }
+        ],
+        "roles": []
+      }
+    ],
+    "regex_entities": [
+      {
+        "name": "zipCode",
+        "regexPattern": "[0-9]{5}",
+        "roles": []
+      }
+    ],
+    "regex_features": [],
+    "utterances": [
+      {
+        "text": "I am 36 years old",
+        "intent": "GetUserProfile",
+        "entities": [
+          {
+            "entity": "userProfile",
+            "startPos": 5,
+            "endPos": 6,
+            "children": [
+              {
+                "entity": "userAge",
+                "startPos": 5,
+                "endPos": 6
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "text": "My first name is vishwac",
+        "intent": "GetUserProfile",
+        "entities": [
+          {
+            "entity": "userProfile",
+            "startPos": 17,
+            "endPos": 23,
+            "children": [
+              {
+                "entity": "userName",
+                "startPos": 17,
+                "endPos": 23,
+                "children": [
+                  {
+                    "entity": "firstName",
+                    "startPos": 17,
+                    "endPos": 23
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "text": "My last name is kannan",
+        "intent": "GetUserProfile",
+        "entities": [
+          {
+            "entity": "userProfile",
+            "startPos": 16,
+            "endPos": 21,
+            "children": [
+              {
+                "entity": "userName",
+                "startPos": 16,
+                "endPos": 21,
+                "children": [
+                  {
+                    "entity": "lastName",
+                    "startPos": 16,
+                    "endPos": 21
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "text": "First of vishwac",
+        "intent": "GetUserProfile",
+        "entities": [
+          {
+            "entity": "userProfile",
+            "startPos": 9,
+            "endPos": 15,
+            "children": [
+              {
+                "entity": "userName",
+                "startPos": 9,
+                "endPos": 15,
+                "children": [
+                  {
+                    "entity": "firstName",
+                    "startPos": 9,
+                    "endPos": 15
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "text": "Age of 36",
+        "intent": "GetUserProfile",
+        "entities": [
+          {
+            "entity": "userProfile",
+            "startPos": 7,
+            "endPos": 8,
+            "children": [
+              {
+                "entity": "userAge",
+                "startPos": 7,
+                "endPos": 8
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "text": "Hi",
+        "intent": "Greeting",
+        "entities": []
+      },
+      {
+        "text": "Hello",
+        "intent": "Greeting",
+        "entities": []
+      },
+      {
+        "text": "I'm 36 years old",
+        "intent": "GetUserProfile",
+        "entities": [
+          {
+            "entity": "userProfile",
+            "startPos": 4,
+            "endPos": 5,
+            "children": [
+              {
+                "entity": "userAge",
+                "startPos": 4,
+                "endPos": 5
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "text": "My age is 36",
+        "intent": "GetUserProfile",
+        "entities": [
+          {
+            "entity": "userProfile",
+            "startPos": 10,
+            "endPos": 11,
+            "children": [
+              {
+                "entity": "userAge",
+                "startPos": 10,
+                "endPos": 11
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "text": "My name is vishwac",
+        "intent": "GetUserProfile",
+        "entities": [
+          {
+            "entity": "userProfile",
+            "startPos": 11,
+            "endPos": 17,
+            "children": [
+              {
+                "entity": "userName",
+                "startPos": 11,
+                "endPos": 17,
+                "children": [
+                  {
+                    "entity": "firstName",
+                    "startPos": 11,
+                    "endPos": 17
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "text": "My last name is kannan",
+        "intent": "GetUserProfile",
+        "entities": [
+          {
+            "entity": "userProfile",
+            "startPos": 16,
+            "endPos": 21,
+            "children": [
+              {
+                "entity": "userName",
+                "startPos": 16,
+                "endPos": 21,
+                "children": [
+                  {
+                    "entity": "lastName",
+                    "startPos": 16,
+                    "endPos": 21
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "text": "vishwac",
+        "intent": "GetUserProfile",
+        "entities": [
+          {
+            "entity": "userProfile",
+            "startPos": 0,
+            "endPos": 6,
+            "children": [
+              {
+                "entity": "userName",
+                "startPos": 0,
+                "endPos": 6,
+                "children": [
+                  {
+                    "entity": "firstName",
+                    "startPos": 0,
+                    "endPos": 6
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "text": "36",
+        "intent": "GetUserProfile",
+        "entities": [
+          {
+            "entity": "userProfile",
+            "startPos": 0,
+            "endPos": 1,
+            "children": [
+              {
+                "entity": "userAge",
+                "startPos": 0,
+                "endPos": 1
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "patterns": [],
+    "patternAnyEntities": [],
+    "prebuiltEntities": [
+      {
+        "name": "age",
+        "roles": []
+      },
+      {
+        "name": "personName",
+        "roles": []
+      }
+    ],
+    "luis_schema_version": "7.0.0",
+    "versionId": "0.1",
+    "name": "",
+    "desc": "",
+    "culture": "en-us",
+    "phraselists": [
+      {
+        "name": "profileDefinition",
+        "words": "I'm,my,I am",
+        "mode": true,
+        "activated": true,
+        "enabledForAllModels": false
+      }
+    ]
+  }

--- a/packages/lu/test/fixtures/verified/newEntityIncludes.json
+++ b/packages/lu/test/fixtures/verified/newEntityIncludes.json
@@ -21,6 +21,20 @@
       {
         "name": "userProfile",
         "roles": [],
+        "features": [
+          {
+            "modelName": "personName",
+            "isRequired": false
+          },
+          {
+            "modelName": "cities",
+            "isRequired": false
+          },
+          {
+            "modelName": "zipCode",
+            "isRequired": false
+          }
+        ],
         "children": [
           {
             "name": "userName",

--- a/packages/luis/test/fixtures/verified/collated-luis.json
+++ b/packages/luis/test/fixtures/verified/collated-luis.json
@@ -1,24 +1,6 @@
 {
   "intents": [
     {
-      "name": "Greeting"
-    },
-    {
-      "name": "Help"
-    },
-    {
-      "name": "AskForUserName"
-    },
-    {
-      "name": "CreateAlarm"
-    },
-    {
-      "name": "DeleteAlarm"
-    },
-    {
-      "name": "CommunicationPreference"
-    },
-    {
       "name": "Greeting",
       "features": [
         {
@@ -91,7 +73,13 @@
   "entities": [
     {
       "name": "userName",
-      "roles": []
+      "roles": [],
+      "features": [
+        {
+          "featureName": "ChocolateType",
+          "isRequired": false
+        }
+      ]
     },
     {
       "name": "foodType",


### PR DESCRIPTION
Fixes #1128 

The issue was because of file order the merging would drop one of the entities which would then cause validation to fail.  In the code there was a bogus assignment which caused nothing to happen.  The case was triggered by having the definition of a hierarchical property found in a later LU file than where labels were first used.  In the case of form generation if a property definition is after form-global alphabetically then the merge would be incorrect.  In the zip files attached to the bug form-global came before woof-number.