### PR TITLE
Fix phraselist are merged incorrectly when importing them from different lu files

### DIFF
--- a/packages/lu/src/parser/luis/luisCollate.js
+++ b/packages/lu/src/parser/luis/luisCollate.js
@@ -355,9 +355,12 @@ const buildModelFeatures = function (blob, FinalLUISJSON) {
                 // error.
                 throw (new exception(retCode.errorCode.INVALID_INPUT, '[ERROR]: Phrase list : "' + modelFeature.name + '" has conflicting definitions. One marked interchangeable and another not interchangeable'));
             } else {
+                let words = modelFeatureInMaster[0].words.split(',').map(word => word.trim()).filter(word => word !== '');
                 modelFeature.words.split(',').forEach(function (word) {
-                    if (!modelFeatureInMaster[0].words.includes(word)) modelFeatureInMaster[0].words += "," + word;
-                })
+                    if (!words.find(w => w === word.trim())) words.push(word.trim());
+                });
+
+                modelFeatureInMaster[0].words = words.join(',');
             }
         }
     });

--- a/packages/lu/test/fixtures/testcases/entities.lu
+++ b/packages/lu/test/fixtures/testcases/entities.lu
@@ -1,0 +1,3 @@
+@ phraselist LowercaseList(interchangeable) disabledForAllModels
+
+@ ml LowercaseAction usesFeature LowercaseList

--- a/packages/lu/test/fixtures/testcases/phraselists2.lu
+++ b/packages/lu/test/fixtures/testcases/phraselists2.lu
@@ -1,0 +1,16 @@
+@ phraselist LowercaseList(interchangeable) disabledForAllModels = 
+    - all lowercase
+    - down case
+    - downcase
+    - lower case
+    - lower case from
+    - lower cased
+    - lowercase
+    - lowercase from
+    - lowercase letter
+    - lowercase letters
+    - lowercased
+    - lowercases
+    - lowercasing
+    - non capitalized
+    - uncapitalized

--- a/packages/lu/test/parser/luis/luisBuilder.test.js
+++ b/packages/lu/test/parser/luis/luisBuilder.test.js
@@ -110,4 +110,19 @@ assert.isTrue(luisObject.validate())
         assert.equal(luisObject.utterances[0].text, 'test 1');
         assert.equal(luisObject.utterances[1].text, 'test 2');
     });
+
+    it('Phraselist can merge correctly when defined in different imported lu files', async () => {
+        let luFile = `
+        [Import entity](./test/fixtures/testcases/entities.lu)
+        [Import phraselist](./test/fixtures/testcases/phraselists2.lu)`;
+
+        const luisObject = await LUISBuilder.fromLUAsync(luFile)
+
+        assert.equal(luisObject.entities.length, 1);
+        assert.equal(luisObject.entities[0].name, 'LowercaseAction');
+        assert.equal(luisObject.entities[0].features[0].featureName, 'LowercaseList');
+        assert.equal(luisObject.phraselists.length, 1);
+        assert.equal(luisObject.phraselists[0].name, 'LowercaseList');
+        assert.equal(luisObject.phraselists[0].words, 'all lowercase,down case,downcase,lower case,lower case from,lower cased,lowercase,lowercase from,lowercase letter,lowercase letters,lowercased,lowercases,lowercasing,non capitalized,uncapitalized');
+    });
 });


### PR DESCRIPTION
Fix #1132 that phraselist synonymous list are merged incorrectly when they are imported from different lu files.