### PR TITLE
Fix lu converter to handle required feature at top level and whitespaces at child entity name correctly

### DIFF
--- a/packages/lu/src/parser/lufile/entitySection.js
+++ b/packages/lu/src/parser/lufile/entitySection.js
@@ -2,7 +2,6 @@ const EntitySectionContext = require('./generated/LUFileParser').LUFileParser.En
 const DiagnosticSeverity = require('./diagnostic').DiagnosticSeverity;
 const BuildDiagnostic = require('./diagnostic').BuildDiagnostic;
 const LUSectionTypes = require('./../utils/enums/lusectiontypes');
-const InvalidCharsInIntentOrEntityName = require('./../utils/enums/invalidchars').InvalidCharsInIntentOrEntityName;
 const BaseSection = require('./baseSection');
 const Range = require('./diagnostic').Range;
 const Position = require('./diagnostic').Position;
@@ -35,14 +34,7 @@ class EntitySection extends BaseSection {
             }));
         }
 
-        if (entityName && InvalidCharsInIntentOrEntityName.some(x => entityName.includes(x))) {
-            this.Errors.push(BuildDiagnostic({
-                message: `Invalid entity line, entity name ${entityName} cannot contain any of the following characters: [<, >, *, %, &, :, \\, $]`,
-                context: parseTree.newEntityDefinition().newEntityLine()
-            }));
-        } else {
-            return entityName;
-        }
+        return entityName;
     }
 
     ExtractType(parseTree) {

--- a/packages/lu/src/parser/lufile/newEntitySection.js
+++ b/packages/lu/src/parser/lufile/newEntitySection.js
@@ -2,7 +2,6 @@ const NewEntitySectionContext = require('./generated/LUFileParser').LUFileParser
 const DiagnosticSeverity = require('./diagnostic').DiagnosticSeverity;
 const BuildDiagnostic = require('./diagnostic').BuildDiagnostic;
 const LUSectionTypes = require('./../utils/enums/lusectiontypes');
-const InvalidCharsInIntentOrEntityName = require('./../utils/enums/invalidchars').InvalidCharsInIntentOrEntityName;
 const BaseSection = require('./baseSection');
 const Range = require('./diagnostic').Range;
 const Position = require('./diagnostic').Position;
@@ -42,14 +41,7 @@ class NewEntitySection  extends BaseSection {
             }))
         }
 
-        if (entityName && InvalidCharsInIntentOrEntityName.some(x => entityName.includes(x))) {
-            this.Errors.push(BuildDiagnostic({
-                message: `Invalid entity line, entity name ${entityName} cannot contain any of the following characters: [<, >, *, %, &, :, \\, $]`,
-                context: parseTree.newEntityDefinition().newEntityLine()
-            }));
-        } else {
-            return entityName;
-        }
+        return entityName;
     }
 
     ExtractType(parseTree) {

--- a/packages/lu/src/parser/lufile/parseFileContents.js
+++ b/packages/lu/src/parser/lufile/parseFileContents.js
@@ -27,6 +27,7 @@ const luisEntityTypeMap = require('./../utils/enums/luisEntityTypeNameMap');
 const qnaContext = require('../qna/qnamaker/qnaContext');
 const qnaPrompt = require('../qna/qnamaker/qnaPrompt');
 const LUResource = require('./luResource');
+const InvalidCharsInIntentOrEntityName = require('./../utils/enums/invalidchars').InvalidCharsInIntentOrEntityName;
 
 const plAllowedTypes = ["composite", "ml"];
 const featureTypeEnum = {
@@ -924,6 +925,16 @@ const parseAndHandleSimpleIntentSection = function (parsedContent, luResource, c
         let references = luResource.Sections.filter(s => s.SectionType === SectionType.REFERENCESECTION);
         for (const intent of intents) {
             let intentName = intent.Name;
+            if (InvalidCharsInIntentOrEntityName.some(x => intentName.includes(x))) {
+                let errorMsg = `Invalid intent line, intent name ${intentName} cannot contain any of the following characters: [<, >, *, %, &, :, \\, $]`;
+                let error = BuildDiagnostic({
+                    message: errorMsg,
+                    line: intent.Range.Start.Line
+                })
+    
+                throw (new exception(retCode.errorCode.INVALID_INPUT, error.toString(), [error]));
+            }
+
             // insert only if the intent is not already present.
             addItemIfNotPresent(parsedContent.LUISJsonStructure, LUISObjNameEnum.INTENT, intentName);
             for (const utteranceAndEntities of intent.UtteranceAndEntitiesMap) {
@@ -953,6 +964,22 @@ const parseAndHandleSimpleIntentSection = function (parsedContent, luResource, c
                     // examine and add these to filestoparse list.
                     parsedContent.additionalFilesToParse.push(new fileToParse(parsedLinkUriInUtterance.fileName, false));
                 }
+               
+                (utteranceAndEntities.entities || []).forEach(entity => {
+                    let errors = []
+                    if (InvalidCharsInIntentOrEntityName.some(x => entity.entity.includes(x))) {
+                        let errorMsg = `Invalid utterance line, entity name ${entity.entity} in this utterance cannot contain any of the following characters: [<, >, *, %, &, :, \\, $]`;
+                        let error = BuildDiagnostic({
+                            message: errorMsg,
+                            range: utteranceAndEntities.range
+                        });
+                        errors.push(error);
+                    }
+
+                    if (errors.length > 0) {
+                        throw (new exception(retCode.errorCode.INVALID_LINE, errors.map(error => error.toString()).join('\n'), errors));
+                    }
+                })
 
                 if (utteranceAndEntities.entities.length > 0) {
                     let entitiesFound = utteranceAndEntities.entities;
@@ -1358,6 +1385,15 @@ const parseAndHandleEntityV2 = function (parsedContent, luResource, log, locale,
                     throw (new exception(retCode.errorCode.INVALID_INPUT, error.toString(), [error]));
                 };
 
+                if (entityType !== EntityTypeEnum.PHRASELIST && InvalidCharsInIntentOrEntityName.some(x => entityName.includes(x))) {
+                    let errorMsg = `Invalid entity line, entity name ${entityName} cannot contain any of the following characters: [<, >, *, %, &, :, \\, $]`;
+                    let error = BuildDiagnostic({
+                        message: errorMsg,
+                        line: entity.Range.Start.Line
+                    })
+                    throw (new exception(retCode.errorCode.INVALID_INPUT, error.toString(), [error]));
+                }
+
                 if (entityType === entityName) {
                     let errorMsg = `Entity name "${entityName}" cannot be the same as entity type "${entityType}"`;
                     let error = BuildDiagnostic({
@@ -1640,6 +1676,16 @@ const handlePhraseList = function(parsedContent, entityName, entityType, entityR
       });
       throw (new exception(retCode.errorCode.INVALID_INPUT, error.toString(), [error]));
     }
+
+    // phraselist name can only contain letters (a-z, A-Z), numbers (0-9) and symbols @ # _ . , ^ \\ [ ]
+    if (!/[a-zA-Z0-9@#_,.,^\\\[\]]+$/.test(entityName.toLowerCase().includes('interchangeable') ? entityName.split(/\(.*\)/g)[0] : entityName)) {
+        const error = BuildDiagnostic({
+            message: `Invalid phraselist line, phraselist name ${entityName} can only contain letters (a-z, A-Z), numbers (0-9) and symbols @ # _ . , ^ \\ [ ]`,
+            line: range.Start.Line
+        });
+        throw (new exception(retCode.errorCode.INVALID_INPUT, error.toString(), [error]));
+    };
+
     let isPLEnabledForAllModels = undefined;
     let isPLEnabled = undefined;
     if (entityRoles.length !== 0) {
@@ -1946,6 +1992,16 @@ const parseAndHandleEntitySection = function (parsedContent, luResource, log, lo
         for (const entity of entities) {
             let entityName = entity.Name;
             let entityType = entity.Type;
+
+            if (entityType !== EntityTypeEnum.PHRASELIST && InvalidCharsInIntentOrEntityName.some(x => entityName.includes(x))) {
+                let errorMsg = `Invalid entity line, entity name ${entityName} cannot contain any of the following characters: [<, >, *, %, &, :, \\, $]`;
+                let error = BuildDiagnostic({
+                    message: errorMsg,
+                    line: entity.Range.Start.Line
+                })
+                throw (new exception(retCode.errorCode.INVALID_INPUT, error.toString(), [error]));
+            }
+
             let parsedRoleAndType = helpers.getRolesAndType(entityType);
             let entityRoles = parsedRoleAndType.roles;
             entityType = parsedRoleAndType.entityType;

--- a/packages/lu/src/parser/lufile/parseFileContents.js
+++ b/packages/lu/src/parser/lufile/parseFileContents.js
@@ -1455,7 +1455,7 @@ const handleNDepthEntity = function(parsedContent, entityName, entityRoles, enti
     entityLines.forEach(child => {
         currentParentEntity = undefined;
         defLine++;
-        let captureGroups = /^((?<leadingSpaces>[ ]*)|(?<leadingTabs>[\t]*))-\s*@\s*(?<instanceOf>[^\s]+) (?<entityName>(?:'[^']+')|(?:"[^"]+")|(?:[^ '"=]+))(?: uses?[fF]eatures? (?<features>[^=]+))?\s*=?\s*$/g;
+        let captureGroups = /^((?<leadingSpaces>[ ]*)|(?<leadingTabs>[\t]*))-\s*@\s*(?<instanceOf>(?:'[^']+')|(?:"[^"]+")|(?:[^ '"=]+)) (?<entityName>(?:'[^']+')|(?:"[^"]+")|(?:[^ '"=]+))(?: uses?[fF]eatures? (?<features>[^=]+))?\s*=?\s*$/g;
         let groupsFound = captureGroups.exec(child);
         if (!groupsFound) {
             let errorMsg = `Invalid child entity definition found for "${child.trim()}". Child definitions must start with '- @' and only include a type, name and optionally one or more usesFeature(s) definition.`;
@@ -1466,7 +1466,7 @@ const handleNDepthEntity = function(parsedContent, entityName, entityRoles, enti
             throw (new exception(retCode.errorCode.INVALID_INPUT, error.toString(), [error]));
         }
         let childEntityName = groupsFound.groups.entityName.replace(/^['"]/g, '').replace(/['"]$/g, '');
-        let childEntityType = groupsFound.groups.instanceOf.trim();
+        let childEntityType = groupsFound.groups.instanceOf.trim().replace(/^['"]/g, '').replace(/['"]$/g, '');
         let childFeatures = groupsFound.groups.features ? groupsFound.groups.features.trim().split(/[,;]/g).map(item => item.trim()).filter(s => s) : undefined;
 
         // Get current tab level

--- a/packages/lu/src/parser/lufile/visitor.js
+++ b/packages/lu/src/parser/lufile/visitor.js
@@ -46,12 +46,6 @@ class Visitor {
     static recurselyResolveTokenizedUtterance(tokUtt, entities, errorMsgs, srcUtterance) {
         for (const item of tokUtt) {
             if (item === Object(item)) {
-                let entityName = item.entityName.trim()
-                if (entityName && InvalidCharsInIntentOrEntityName.some(x => entityName.includes(x))) {
-                    errorMsgs.push(`Invalid utterance line, entity name ${entityName} cannot contain any of the following characters: [<, >, *, %, &, :, \\, $]`);
-                    continue;
-                }
-
                 if (item.entityValue === undefined) {
                     // we have a pattern.any entity
                     const patternStr = item.role ? `{${item.entityName}:${item.role}}` : `{${item.entityName}}`

--- a/packages/lu/src/parser/luis/luConverter.js
+++ b/packages/lu/src/parser/luis/luConverter.js
@@ -234,7 +234,7 @@ const parseEntitiesToLu =  function(luisJson){
                 }
                 fileContent += NEWLINE + NEWLINE;
             }
-            fileContent += `@ ${getEntityType(entity.features)} ${writeEntityName(entity.name)}`;
+            fileContent += `@ ml ${writeEntityName(entity.name)}`;
             fileContent += addRolesAndFeatures(entity);
             fileContent += NEWLINE + NEWLINE;
         } else {
@@ -417,7 +417,7 @@ const addAppMetaData = function(LUISJSON) {
 const handleNDepthEntity = function(entity) {
     let fileContent = '';
     const BASE_TAB_STOP = 1;
-    fileContent += `@ ${getEntityType(entity.features)} ${writeEntityName(entity.name)}`;
+    fileContent += `@ ml ${writeEntityName(entity.name)}`;
     fileContent += addRolesAndFeatures(entity);
     fileContent += NEWLINE;
     fileContent += addNDepthChildDefinitions(entity.children, BASE_TAB_STOP, fileContent) + NEWLINE + NEWLINE
@@ -434,7 +434,7 @@ const addNDepthChildDefinitions = function(childCollection, tabStop, fileContent
     (childCollection || []).forEach(child => {
         myFileContent += "".padStart(tabStop * 4, ' ');
         myFileContent += `- @ ${getEntityType(child.features)} ${writeEntityName(child.name)}`;
-        myFileContent += addRolesAndFeatures(child);
+        myFileContent += addRolesAndFeatures(child, true);
         myFileContent += NEWLINE;
         if (child.children && child.children.length !== 0) {
             myFileContent += addNDepthChildDefinitions(child.children, tabStop + 1, myFileContent);
@@ -446,7 +446,7 @@ const getEntityType = function(features) {
     // find constraint
     let constraint = (features || []).find(feature => feature.isRequired == true);
     if (constraint !== undefined) {
-        return constraint.modelName;
+        return writeEntityName(constraint.modelName);
     } else {
         return EntityTypeEnum.ML;
     }
@@ -454,9 +454,10 @@ const getEntityType = function(features) {
 /**
  * Helper to construt role and features list for an entity
  * @param {Object} entity 
+ * @param {boolean} isInNDepth
  * @returns {String} file content to include.
  */
-const addRolesAndFeatures = function(entity) {
+const addRolesAndFeatures = function(entity, isInNDepth = false) {
     let roleAndFeatureContent = ''
     if (entity.roles && entity.roles.length > 0) {
         roleAndFeatureContent += ` ${entity.roles.length > 1 ? `hasRoles` : `hasRole`} `;
@@ -474,8 +475,11 @@ const addRolesAndFeatures = function(entity) {
         if (item.featureName) featuresList.push(item.featureName);
         if (item.modelName) {
             if (item.isRequired !== undefined) {
-                if (item.isRequired !== true) 
+                if (item.isRequired !== true) {
                     featuresList.push(item.modelName);
+                } else if (!isInNDepth) {
+                    featuresList.push(item.modelName + '*');
+                }           
             } else {
                 featuresList.push(item.modelName);
             }

--- a/packages/lu/src/parser/utils/helpers.js
+++ b/packages/lu/src/parser/utils/helpers.js
@@ -569,6 +569,16 @@ const addIsRequiredProperty = function(item, phraseListInFinal = []) {
             delete feature.modelName;
         }
 
+        if (feature.featureName && feature.featureName.endsWith('*')) {
+            feature.featureName = feature.featureName.slice(0, feature.featureName.length - 1);
+            feature.isRequired = true;
+        }
+
+        if (feature.modelName && feature.modelName.endsWith('*')) {
+            feature.modelName = feature.modelName.slice(0, feature.modelName.length - 1);
+            feature.isRequired = true;
+        }
+
         delete feature.featureType;
         delete feature.modelType;
     });

--- a/packages/lu/test/commands/luis/convert.test.js
+++ b/packages/lu/test/commands/luis/convert.test.js
@@ -195,6 +195,22 @@ describe('luis:convert version 7 upgrade test', () => {
     it('Child entities names with spaces in them parse correctly to .lu format', async () => {
         await assertToLu('./../../fixtures/testcases/Child_Entity_With_Spaces.json', './../../fixtures/verified/Child_Entity_With_Spaces.lu')
     })
+
+    it('luis:convert successfully converts LUIS JSON model with required feature defined at top level to .lu format)', async () => {
+        await assertToJSON('./../../fixtures/verified/requiredFeatureAtTopLevel.lu', './../../fixtures/verified/requiredFeatureAtTopLevel.json')
+    })
+
+    it('luis:convert successfully converts .lu format with required feature defined at top level to LUIS JSON model', async () => {
+        await assertToLu('./../../fixtures/verified/requiredFeatureAtTopLevel.json', './../../fixtures/verified/requiredFeatureAtTopLevel.lu')
+    })
+
+    it('luis:convert successfully converts LUIS JSON model with space in child entity definition to .lu format', async () => {
+        await assertToJSON('./../../fixtures/verified/childEntityDefinitionWithSpace.lu', './../../fixtures/verified/childEntityDefinitionWithSpace.json')
+    })
+
+    it('luis:convert successfully converts .lu format with space in child entity definition to LUIS JSON model', async () => {
+        await assertToLu('./../../fixtures/verified/childEntityDefinitionWithSpace.json', './../../fixtures/verified/childEntityDefinitionWithSpace.lu')
+    })
   })
 
 describe('luis:convert negative tests', () => {

--- a/packages/lu/test/commands/luis/convert.test.js
+++ b/packages/lu/test/commands/luis/convert.test.js
@@ -272,8 +272,43 @@ describe('luis:convert negative tests', () => {
                 LuisBuilder.fromLUAsync(res)
                     .then(res => done(res))
                     .catch(err => {
-                        assert.isTrue(err.text.includes('[ERROR] line 2:0 - line 2:26: Invalid utterance line, entity name @addto*Property cannot contain any of the following characters: [<, >, *, %, &, :, \\, $]'))
-                        assert.isTrue(err.text.includes('[ERROR] line 4:0 - line 4:20: Invalid entity line, entity name delete$Property cannot contain any of the following characters: [<, >, *, %, &, :, \\, $]'))
+                        assert.isTrue(err.text.includes('[ERROR] line 2:0 - line 2:26: Invalid utterance line, entity name @addto*Property in this utterance cannot contain any of the following characters: [<, >, *, %, &, :, \\, $]'))
+                        done()
+                    })
+            })
+    })
+
+    it('luis:convert should show ERR message when entity name defined at top level contains invalid char', (done) => {
+        loadLuFile('./../../fixtures/testcases/bad6.lu')
+            .then(res => {
+                LuisBuilder.fromLUAsync(res)
+                    .then(res => done(res))
+                    .catch(err => {
+                        assert.isTrue(err.text.includes('[ERROR] line 1:0 - line 1:1: Invalid entity line, entity name location* cannot contain any of the following characters: [<, >, *, %, &, :, \\, $]'))
+                        done()
+                    })
+            })
+    })
+
+    it('luis:convert should show ERR message when intent name contains invalid char', (done) => {
+        loadLuFile('./../../fixtures/testcases/bad7.lu')
+            .then(res => {
+                LuisBuilder.fromLUAsync(res)
+                    .then(res => done(res))
+                    .catch(err => {
+                        assert.isTrue(err.text.includes('[ERROR] line 1:0 - line 1:1: Invalid intent line, intent name greeting* cannot contain any of the following characters: [<, >, *, %, &, :, \\, $]'))
+                        done()
+                    })
+            })
+    })
+
+    it('luis:convert should show ERR message when phraselist name contains invalid char', (done) => {
+        loadLuFile('./../../fixtures/testcases/bad8.lu')
+            .then(res => {
+                LuisBuilder.fromLUAsync(res)
+                    .then(res => done(res))
+                    .catch(err => {
+                        assert.isTrue(err.text.includes('[ERROR] line 1:0 - line 1:1: Invalid phraselist line, phraselist name pl* can only contain letters (a-z, A-Z), numbers (0-9) and symbols @ # _ . , ^ \\ [ ]'))
                         done()
                     })
             })

--- a/packages/lu/test/fixtures/testcases/bad5.lu
+++ b/packages/lu/test/fixtures/testcases/bad5.lu
@@ -1,4 +1,2 @@
 # greeting
 - hi {@addto*Property=foo}
-
-@ ml delete$Property

--- a/packages/lu/test/fixtures/testcases/bad6.lu
+++ b/packages/lu/test/fixtures/testcases/bad6.lu
@@ -1,0 +1,1 @@
+@ ml location*

--- a/packages/lu/test/fixtures/testcases/bad7.lu
+++ b/packages/lu/test/fixtures/testcases/bad7.lu
@@ -1,0 +1,2 @@
+# greeting*
+- hi

--- a/packages/lu/test/fixtures/testcases/bad8.lu
+++ b/packages/lu/test/fixtures/testcases/bad8.lu
@@ -1,0 +1,2 @@
+@ phraselist pl*
+    - a,b,c

--- a/packages/lu/test/fixtures/verified/childEntityDefinitionWithSpace.json
+++ b/packages/lu/test/fixtures/verified/childEntityDefinitionWithSpace.json
@@ -1,0 +1,40 @@
+{
+  "intents": [],
+  "entities": [
+    {
+      "name": "some entity",
+      "roles": []
+    },
+    {
+      "name": "another entity",
+      "roles": [],
+      "children": [
+        {
+          "name": "child entity",
+          "children": [],
+          "features": [
+            {
+              "modelName": "some entity",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "composites": [],
+  "closedLists": [],
+  "regex_entities": [],
+  "regex_features": [],
+  "utterances": [],
+  "patterns": [],
+  "patternAnyEntities": [],
+  "prebuiltEntities": [],
+  "luis_schema_version": "7.0.0",
+  "versionId": "0.1",
+  "name": "LuTest",
+  "desc": "",
+  "culture": "en-us",
+  "tokenizerVersion": "1.0.0",
+  "phraselists": []
+}

--- a/packages/lu/test/fixtures/verified/childEntityDefinitionWithSpace.lu
+++ b/packages/lu/test/fixtures/verified/childEntityDefinitionWithSpace.lu
@@ -1,0 +1,31 @@
+
+> LUIS application information
+> !# @app.name = LuTest
+> !# @app.versionId = 0.1
+> !# @app.culture = en-us
+> !# @app.luis_schema_version = 7.0.0
+> !# @app.tokenizerVersion = 1.0.0
+
+
+> # Intent definitions
+
+> # Entity definitions
+
+@ ml "some entity"
+
+@ ml "another entity"
+    - @ "some entity" "child entity"
+
+
+
+> # PREBUILT Entity definitions
+
+
+> # Phrase list definitions
+
+
+> # List entities
+
+> # RegEx entities
+
+

--- a/packages/lu/test/fixtures/verified/requiredFeatureAtTopLevel.json
+++ b/packages/lu/test/fixtures/verified/requiredFeatureAtTopLevel.json
@@ -1,0 +1,60 @@
+{
+  "intents": [],
+  "entities": [
+    {
+      "name": "some entity",
+      "roles": []
+    },
+    {
+      "name": "some_entity",
+      "roles": []
+    },
+    {
+      "name": "some_entity_2",
+      "roles": []
+    },
+    {
+      "name": "another entity",
+      "roles": [],
+      "features": [
+        {
+          "modelName": "some entity",
+          "isRequired": true
+        },
+        {
+          "modelName": "some_entity_2",
+          "isRequired": false
+        }
+      ]
+    },
+    {
+      "name": "another_entity_2",
+      "roles": [],
+      "features": [
+        {
+          "modelName": "some_entity",
+          "isRequired": true
+        },
+        {
+          "modelName": "some_entity_2",
+          "isRequired": false
+        }
+      ]
+    }
+  ],
+  "composites": [],
+  "closedLists": [],
+  "regex_entities": [],
+  "regex_features": [],
+  "utterances": [],
+  "patterns": [],
+  "patternAnyEntities": [],
+  "prebuiltEntities": [],
+  "luis_schema_version": "7.0.0",
+  "versionId": "0.1",
+  "name": "LuTest",
+  "desc": "",
+  "culture": "en-us",
+  "tokenizerVersion": "1.0.0",
+  "phraselists": []
+}

--- a/packages/lu/test/fixtures/verified/requiredFeatureAtTopLevel.lu
+++ b/packages/lu/test/fixtures/verified/requiredFeatureAtTopLevel.lu
@@ -1,0 +1,35 @@
+
+> LUIS application information
+> !# @app.name = LuTest
+> !# @app.versionId = 0.1
+> !# @app.culture = en-us
+> !# @app.luis_schema_version = 7.0.0
+> !# @app.tokenizerVersion = 1.0.0
+
+
+> # Intent definitions
+
+> # Entity definitions
+
+@ ml "some entity"
+
+@ ml some_entity
+
+@ ml some_entity_2
+
+@ ml "another entity" usesFeatures "some entity*",some_entity_2
+
+@ ml another_entity_2 usesFeatures some_entity*,some_entity_2
+
+
+> # PREBUILT Entity definitions
+
+
+> # Phrase list definitions
+
+
+> # List entities
+
+> # RegEx entities
+
+


### PR DESCRIPTION
Fix #1137 and #1138. The main fixes are listed as below:

- Fix the top level **required("isRequired": true)** feature not converted correctly issue
Before the fix, for the luis json below
```
"entities": [
  {
    "name": "another_entity",
    "features": [
      {
        "modelName": "some_entity",
        "isRequired": true
      }
    ]
  },
  {
    "name": "some_entity"
  }
]
```

It will be converted to below lu format, but the first line below will be recognized as `@ <entity_name> <role>` when converting back to json, so this will cause inconsistency between lu and json converting.
```
@ some_entity another_entity
@ ml some_entity
```

After the fix, the above json will be converted to below. Here `*` appended to feature name is used to identify if it's required or not. When converting this lu format to json, it will use `*` to decide filling the isRequired with true.
```
@ ml another_entity useFeature some_entity*
@ ml some_entity
```

- Fix the whitespace issue in child entity name. This is easy to fix, just apply the `writeEntityName` function that was handling entity name whitespace to ensure quotation marks are added correctly.

New test cases are added to verify the fixes. All existing tests remain unchanged.