### PR TITLE
bf luis:build support to republish luis app if users specify a new publishing mode

### DIFF
--- a/packages/lu/src/parser/lubuild/builder.ts
+++ b/packages/lu/src/parser/lubuild/builder.ts
@@ -236,11 +236,14 @@ export class Builder {
               const dialogFile = path.join(path.dirname(content.path), `${content.name}.dialog`)
               let recognizer = new Recognizer(content.path, content.name, dialogFile, schema)
 
+              // found existing app endpoints
+              let appEndpoints
               // find if there is a matched name with current app under current authoring key
               if (!recognizer.getAppId()) {
                 for (let app of apps) {
                   if (app.name.toLowerCase() === currentApp.name.toLowerCase()) {
                     recognizer.setAppId(app.id)
+                    appEndpoints = app.endpoints
                     break
                   }
                 }
@@ -252,7 +255,7 @@ export class Builder {
               // otherwise create a new application
               if (recognizer.getAppId() && recognizer.getAppId() !== '') {
                 // To see if need update the model
-                needTrainAndPublish = await this.updateApplication(currentApp, luBuildCore, recognizer, timeBucketOfRequests, keptVersionCount)
+                needTrainAndPublish = await this.updateApplication(currentApp, luBuildCore, recognizer, timeBucketOfRequests, keptVersionCount) || this.forcePublish(appEndpoints, recognizer.versionId, directVersionPublish, isStaging)
               } else {
                 // create a new application
                 needTrainAndPublish = await this.createApplication(currentApp, luBuildCore, recognizer, timeBucketOfRequests)
@@ -456,7 +459,7 @@ export class Builder {
     this.handler(`${recognizer.getLuPath()} publishing version=${recognizer.versionId}\n`)
     await delay(timeBucket)
     await luBuildCore.publishApplication(recognizer.getAppId(), recognizer.versionId, isStaging, directVersionPublish)
-    this.handler(`${recognizer.getLuPath()} publishing finished for ${isStaging ? 'Staging' : 'Production'} slot\n`)
+    this.handler(`${recognizer.getLuPath()} publishing finished for ${directVersionPublish ? 'directVersionPublish mode' : isStaging ? 'Staging' : 'Production'} slot\n`)
   }
 
   generateDeclarativeAssets(assets: Array<any>): Array<any> {
@@ -503,5 +506,22 @@ export class Builder {
       this.handler(`[WARN]: empty intent(s) ${emptyIntents.map((intent: any) => '# ' + intent.name).join(', ')} are filtered when handling luis application`)
       app.intents = filteredIntents
     }
+  }
+
+  forcePublish(endpoints: any, versionId: string, directVersionPublish: boolean, isStaging: boolean) {
+    let forcePublish = false
+    if (endpoints !== undefined) {
+      if (directVersionPublish && !Object.keys(endpoints).find(version => version.includes(versionId))) {
+        forcePublish = true
+      } else if (!directVersionPublish) {
+        if (isStaging && (!endpoints.STAGING || endpoints.STAGING.versionId !== versionId)) {
+          forcePublish = true
+        } else if (!isStaging && (!endpoints.PRODUCTION || endpoints.PRODUCTION.versionId !== versionId)) {
+          forcePublish = true
+        }
+      }
+    }
+
+    return forcePublish
   }
 }

--- a/packages/lu/src/parser/lubuild/builder.ts
+++ b/packages/lu/src/parser/lubuild/builder.ts
@@ -459,7 +459,7 @@ export class Builder {
     this.handler(`${recognizer.getLuPath()} publishing version=${recognizer.versionId}\n`)
     await delay(timeBucket)
     await luBuildCore.publishApplication(recognizer.getAppId(), recognizer.versionId, isStaging, directVersionPublish)
-    this.handler(`${recognizer.getLuPath()} publishing finished for ${directVersionPublish ? 'directVersionPublish mode' : isStaging ? 'Staging' : 'Production'} slot\n`)
+    this.handler(`${recognizer.getLuPath()} publishing finished for ${directVersionPublish ? 'directVersionPublish mode' : isStaging ? 'Staging slot' : 'Production slot'}\n`)
   }
 
   generateDeclarativeAssets(assets: Array<any>): Array<any> {

--- a/packages/lu/src/parser/lubuild/builder.ts
+++ b/packages/lu/src/parser/lubuild/builder.ts
@@ -511,14 +511,10 @@ export class Builder {
   forcePublish(endpoints: any, versionId: string, directVersionPublish: boolean, isStaging: boolean) {
     let forcePublish = false
     if (endpoints !== undefined) {
-      if (directVersionPublish && !Object.keys(endpoints).find(version => version.includes(versionId))) {
+      if (directVersionPublish && !Object.keys(endpoints).find(version => version.includes(versionId))
+        || !directVersionPublish && (isStaging && (!endpoints.STAGING || endpoints.STAGING.versionId !== versionId)
+          || !isStaging && (!endpoints.PRODUCTION || endpoints.PRODUCTION.versionId !== versionId))) {
         forcePublish = true
-      } else if (!directVersionPublish) {
-        if (isStaging && (!endpoints.STAGING || endpoints.STAGING.versionId !== versionId)) {
-          forcePublish = true
-        } else if (!isStaging && (!endpoints.PRODUCTION || endpoints.PRODUCTION.versionId !== versionId)) {
-          forcePublish = true
-        }
       }
     }
 

--- a/packages/luis/test/commands/luis/build.test.ts
+++ b/packages/luis/test/commands/luis/build.test.ts
@@ -286,6 +286,201 @@ describe('luis:build update application succeed when utterances added', () => {
     })
 })
 
+describe('luis:build update application succeed when only publishing mode changes(Production slot to directVersionPublish mode)', () => {
+  const existingLuisApp = require('./../../fixtures/testcases/lubuild/sandwich/luis/test(development)-sandwich.en-us.lu.json')
+  before(function () {
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('apps'))
+      .reply(200, [{
+        name: 'test(development)-sandwich.en-us.lu',
+        id: 'f8c64e2a-8635-3a09-8f78-39d7adc76ec5',
+        endpoints: {
+          PRODUCTION: {
+            versionId: '0.1'
+          }
+        }
+      }])
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('apps'))
+      .reply(200, {
+        name: 'test(development)-sandwich.en-us.lu',
+        id: 'f8c64e2a-8635-3a09-8f78-39d7adc76ec5',
+        activeVersion: '0.1'
+      })
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('export'))
+      .reply(200, existingLuisApp)
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .post(uri => uri.includes('train'))
+      .reply(202, {
+        statusId: 2,
+        status: 'UpToDate'
+      })
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('train'))
+      .reply(200, [{
+        modelId: '99999',
+        details: {
+          statusId: 0,
+          status: 'Success',
+          exampleCount: 0
+        }
+      }])
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .post(uri => uri.includes('publish'))
+      .reply(201, {
+        versionId: '0.1',
+        isStaging: false
+      })
+  })
+
+  test
+    .stdout()
+    .command(['luis:build', '--in', './test/fixtures/testcases/lubuild/sandwich/lufiles/sandwich.en-us.lu', '--authoringKey', uuidv1(), '--botName', 'test', '--log', '--suffix', 'development', '--directVersionPublish'])
+    .it('should update a luis application when only publishing mode changes(Production slot to directVersionPublish mode)', ctx => {
+      expect(ctx.stdout).to.contain('Handling applications...')
+      expect(ctx.stdout).to.contain('training version=0.1')
+      expect(ctx.stdout).to.contain('waiting for training for version=0.1')
+      expect(ctx.stdout).to.contain('publishing version=0.1')
+      expect(ctx.stdout).to.contain('publishing finished for directVersionPublish mode')
+    })
+})
+
+describe('luis:build update application succeed when only publishing mode changes(directVersionPublish mode to Production slot)', () => {
+  const existingLuisApp = require('./../../fixtures/testcases/lubuild/sandwich/luis/test(development)-sandwich.en-us.lu.json')
+  before(function () {
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('apps'))
+      .reply(200, [{
+        name: 'test(development)-sandwich.en-us.lu',
+        id: 'f8c64e2a-8635-3a09-8f78-39d7adc76ec5',
+        endpoints: {
+          "v0.1": {
+            versionId: '0.1'
+          }
+        }
+      }])
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('apps'))
+      .reply(200, {
+        name: 'test(development)-sandwich.en-us.lu',
+        id: 'f8c64e2a-8635-3a09-8f78-39d7adc76ec5',
+        activeVersion: '0.1'
+      })
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('export'))
+      .reply(200, existingLuisApp)
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .post(uri => uri.includes('train'))
+      .reply(202, {
+        statusId: 2,
+        status: 'UpToDate'
+      })
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('train'))
+      .reply(200, [{
+        modelId: '99999',
+        details: {
+          statusId: 0,
+          status: 'Success',
+          exampleCount: 0
+        }
+      }])
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .post(uri => uri.includes('publish'))
+      .reply(201, {
+        versionId: '0.1',
+        isStaging: false
+      })
+  })
+
+  test
+    .stdout()
+    .command(['luis:build', '--in', './test/fixtures/testcases/lubuild/sandwich/lufiles/sandwich.en-us.lu', '--authoringKey', uuidv1(), '--botName', 'test', '--log', '--suffix', 'development'])
+    .it('should update a luis application when only publishing mode changes(directVersionPublish mode to Production slot)', ctx => {
+      expect(ctx.stdout).to.contain('Handling applications...')
+      expect(ctx.stdout).to.contain('training version=0.1')
+      expect(ctx.stdout).to.contain('waiting for training for version=0.1')
+      expect(ctx.stdout).to.contain('publishing version=0.1')
+      expect(ctx.stdout).to.contain('publishing finished for Production slot')
+    })
+})
+
+describe('luis:build update application succeed when only publishing mode changes(Production slot to Staging slot)', () => {
+  const existingLuisApp = require('./../../fixtures/testcases/lubuild/sandwich/luis/test(development)-sandwich.en-us.lu.json')
+  before(function () {
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('apps'))
+      .reply(200, [{
+        name: 'test(development)-sandwich.en-us.lu',
+        id: 'f8c64e2a-8635-3a09-8f78-39d7adc76ec5',
+        endpoints: {
+          PRODUCTION: {
+            versionId: '0.1'
+          }
+        }
+      }])
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('apps'))
+      .reply(200, {
+        name: 'test(development)-sandwich.en-us.lu',
+        id: 'f8c64e2a-8635-3a09-8f78-39d7adc76ec5',
+        activeVersion: '0.1'
+      })
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('export'))
+      .reply(200, existingLuisApp)
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .post(uri => uri.includes('train'))
+      .reply(202, {
+        statusId: 2,
+        status: 'UpToDate'
+      })
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('train'))
+      .reply(200, [{
+        modelId: '99999',
+        details: {
+          statusId: 0,
+          status: 'Success',
+          exampleCount: 0
+        }
+      }])
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .post(uri => uri.includes('publish'))
+      .reply(201, {
+        versionId: '0.1',
+        isStaging: false
+      })
+  })
+
+  test
+    .stdout()
+    .command(['luis:build', '--in', './test/fixtures/testcases/lubuild/sandwich/lufiles/sandwich.en-us.lu', '--authoringKey', uuidv1(), '--botName', 'test', '--log', '--suffix', 'development', '--isStaging'])
+    .it('should update a luis application when only publishing mode changes(Production slot to Staging slot)', ctx => {
+      expect(ctx.stdout).to.contain('Handling applications...')
+      expect(ctx.stdout).to.contain('training version=0.1')
+      expect(ctx.stdout).to.contain('waiting for training for version=0.1')
+      expect(ctx.stdout).to.contain('publishing version=0.1')
+      expect(ctx.stdout).to.contain('publishing finished for Staging slot')
+    })
+})
+
 describe('luis:build not update application if no changes', () => {
   const existingLuisApp = require('./../../fixtures/testcases/lubuild/sandwich/luis/test(development)-sandwich.en-us.lu.json')
   before(function () {


### PR DESCRIPTION
Fix #1143. The main fix is to support republishing luis app if users specify a new publishing mode, e.g. users have first published a luis app with directionVersionPublish mode, now they can also publish the same lu content to other modes like Production slot or Staging slot. Before the fix, the republishing logic is completely controlled by content comparisons between current lu content and existing luis portal lu content which means users have no ways to republish to other modes if their lu contents have no changes.