### PR TITLE
Fix bf luis:test command failures for corner cases of prebuilt entities 

### DIFF
--- a/packages/lu/src/parser/test/testhelper.ts
+++ b/packages/lu/src/parser/test/testhelper.ts
@@ -118,9 +118,11 @@ function ParseEntitiyResult(entities: any, result: any) {
         }
       }
     } else {
-      for (const subEntity of entities[name]) {
-        if (typeof subEntity === 'object') {
-          ParseEntitiyResult(subEntity, result)
+      if (typeof entities[name][Symbol.iterator] === 'function') {
+        for (const subEntity of entities[name]) {
+          if (typeof subEntity === 'object') {
+            ParseEntitiyResult(subEntity, result)
+          }
         }
       }
     }

--- a/packages/luis/test/commands/luis/test.test.ts
+++ b/packages/luis/test/commands/luis/test.test.ts
@@ -75,7 +75,7 @@ describe('luis:test cli entity test', () => {
   .nock('https://westus.api.cognitive.microsoft.com', api => api
   .post(uri => uri.includes('apps'))
   .reply(200, {
-    "query":"accept all meetings for christmas party next week.","prediction":{"topIntent":"AcceptEventEntry","intents":{"AcceptEventEntry":{"score":0.948831439},"FindCalendarEntry":{"score":0.0371829346},"None":{"score":0.00728923827},"CreateCalendarEntry":{"score":0.007234955}},"entities":{"Subject":["christmas party"],"FromDate":["next week"],"$instance":{"Subject":[{"type":"Subject","text":"christmas party","startIndex":24,"length":15,"score":0.9657892,"modelTypeId":1,"modelType":"Entity Extractor","recognitionSources":["model"]}],"FromDate":[{"type":"FromDate","text":"next week","startIndex":40,"length":9,"score":0.966946542,"modelTypeId":1,"modelType":"Entity Extractor","recognitionSources":["model"]}]}}}
+    "query":"accept all meetings for christmas party next week.","prediction":{"topIntent":"AcceptEventEntry","intents":{"AcceptEventEntry":{"score":0.948831439},"FindCalendarEntry":{"score":0.0371829346},"None":{"score":0.00728923827},"CreateCalendarEntry":{"score":0.007234955}},"entities":{"Subject":["christmas party"],"FromDate":["next week"],"ordinalV2": [{"offset": 1, "relativeTo": "current"}], "$instance":{"Subject":[{"type":"Subject","text":"christmas party","startIndex":24,"length":15,"score":0.9657892,"modelTypeId":1,"modelType":"Entity Extractor","recognitionSources":["model"]}],"FromDate":[{"type":"FromDate","text":"next week","startIndex":40,"length":9,"score":0.966946542,"modelTypeId":1,"modelType":"Entity Extractor","recognitionSources":["model"]}]}}}
   })
   )
   .nock('https://westus.api.cognitive.microsoft.com', api => api
@@ -126,7 +126,6 @@ describe('luis:test cli entity test', () => {
     expect(await compareFiles('./../../../results/AllEntity.lu', './../../fixtures/testcases/lutest/output/AllEntity.lu')).to.be.true
   })
 })
-
 
 describe('luis:test cli role test', () => {
   before(async function(){
@@ -221,8 +220,6 @@ describe('luis:test cli Hierarchical entity test', () => {
     expect(await compareFiles('./../../../results/HierarchicalEntity.lu', './../../fixtures/testcases/lutest/output/HierarchicalEntity.lu')).to.be.true
   })
 })
-
-
 
 describe('luis:test normal test', () => {
   before(async function(){

--- a/packages/luis/test/fixtures/testcases/lutest/input/AllEntity.lu
+++ b/packages/luis/test/fixtures/testcases/lutest/input/AllEntity.lu
@@ -50,7 +50,7 @@ $ToTime:simple
 
 > # PREBUILT Entity definitions
 
-$PREBUILT:ordinal
+@ PREBUILT ordinalV2
 
 $PREBUILT:personName Roles=Female, Male
 

--- a/packages/luis/test/fixtures/testcases/lutest/output/AllEntity.lu
+++ b/packages/luis/test/fixtures/testcases/lutest/output/AllEntity.lu
@@ -67,7 +67,7 @@
 
 > # PREBUILT Entity definitions
 
-@ prebuilt ordinal
+@ prebuilt ordinalV2
 
 @ prebuilt personName hasRoles Female,Male
 


### PR DESCRIPTION
Fix #1121. In some corner cases, the predicted entities will not return a standard format, e.g. the prebuilt ordinalV2 entity will return an object value like {offset: 1, relative: current} rather than string or number value, in such case, the entity parsing logic will throw exception caused by non validation. The fix is simple, just add the iterable validation for sub entities value. Test case is also adjusted to test this case.