### PR TITLE
Add patch fix to axios to support https proxy

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -31,6 +31,7 @@ dependencies:
   applicationinsights: 1.7.3
   argparse: 1.0.10
   axios: 0.21.1
+  axios-https-proxy: 0.1.1_axios@0.21.1
   botbuilder-lg: 4.12.0
   botframework-schema: 4.7.2
   camelcase: 4.1.0
@@ -1263,6 +1264,15 @@ packages:
     dev: false
     resolution:
       integrity: sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
+  /axios-https-proxy/0.1.1_axios@0.21.1:
+    dependencies:
+      axios: 0.21.1
+      https-proxy-agent: 2.2.4
+    dev: false
+    peerDependencies:
+      axios: ^0.18.0
+    resolution:
+      integrity: sha512-slFaor1FTRhO6V6r2ewuWLBRIF33Lkg+wRmUVJPWRe0JRgBKevBSlgjDInp+AeKGKZjyT7k3l44l67CvEme1Cg==
   /axios/0.21.1:
     dependencies:
       follow-redirects: 1.13.0
@@ -7400,6 +7410,8 @@ packages:
       '@types/node': 10.17.17
       '@types/node-fetch': 2.5.5
       antlr4: 4.8.0
+      axios: 0.21.1
+      axios-https-proxy: 0.1.1_axios@0.21.1
       chai: 4.2.0
       chalk: 2.4.1
       console-stream: 0.1.1
@@ -7424,7 +7436,7 @@ packages:
     dev: false
     name: '@rush-temp/bf-lu'
     resolution:
-      integrity: sha512-idgtiuhAkB8CwVNp0iQcGkBUCIbsmQab6zQujW1T1AOUwPZjE1Aml1y9NUizV4G5batuOhygJvtZHcYB4UZrKQ==
+      integrity: sha512-YEzrI4a1MkTCI9DAKeOSjWkcY7ZZGwxramK3Ui5r93OZKknL+Bo7V3Y1NZoVl4B5IxdWobd3eurR2707dFD83w==
       tarball: 'file:projects/bf-lu.tgz'
     version: 0.0.0
   'file:projects/bf-luis-cli.tgz':
@@ -7468,7 +7480,7 @@ packages:
     dev: false
     name: '@rush-temp/bf-luis-cli'
     resolution:
-      integrity: sha512-fg5B1E3kaqUNQDT45ZWxBSAHE/gNVmIAbz2VCKEcK1/xK7DYLvcGlX5bFMC4AaYw7vSnJZ4Q5S3JYugPG6TinQ==
+      integrity: sha512-hi+iOx5Yq08FxsCiGuAIZzdB1/4wcaP/qnDaXfBNMsoT1AB/hjHydm0OyRR/QtBwjFAxMzUCafPmHKqD3JdhPw==
       tarball: 'file:projects/bf-luis-cli.tgz'
     version: 0.0.0
   'file:projects/bf-orchestrator-cli.tgz':
@@ -7582,7 +7594,7 @@ packages:
     dev: false
     name: '@rush-temp/bf-qnamaker'
     resolution:
-      integrity: sha512-XZ3HKrN0Wmk+5WLyi9NfLxhOMPTkQN5R0H+Js+0vM2jaq00NmpGinUalQTDvYrJrgaTIsentVSedsEUHyUU/JQ==
+      integrity: sha512-4493Sz8sTpkTWkPegzzpmpFadoboXwalx1Yj9hLwJLuw/csHob4JzWS0Ota83j6lWkfy0NtObDUb7GJrZtN5xg==
       tarball: 'file:projects/bf-qnamaker.tgz'
     version: 0.0.0
   'file:projects/botframework-cli.tgz':
@@ -7655,6 +7667,7 @@ specifiers:
   applicationinsights: ^1.0.8
   argparse: ~1.0.10
   axios: ~0.21.1
+  axios-https-proxy: ^0.1.1
   botbuilder-lg: 4.12.0
   botframework-schema: ^4.5.1
   camelcase: ^4.1.0

--- a/packages/lu/package.json
+++ b/packages/lu/package.json
@@ -36,6 +36,7 @@
     "@types/node-fetch": "~2.5.5",
     "antlr4": "~4.8.0",
     "axios": "~0.21.1",
+    "axios-https-proxy": "^0.1.1",
     "chalk": "2.4.1",
     "console-stream": "^0.1.1",
     "deep-equal": "^1.0.1",

--- a/packages/lu/src/parser/lubuild/http-request.ts
+++ b/packages/lu/src/parser/lubuild/http-request.ts
@@ -3,7 +3,9 @@
  * Licensed under the MIT License.
  */
 
-import axios from 'axios'
+const axios = require('axios')
+const axiosHttpsProxy = require('axios-https-proxy')
+axios.interceptors.request.use(axiosHttpsProxy)
 
 export default {
   async get(

--- a/packages/lu/src/parser/qnabuild/serviceBase.js
+++ b/packages/lu/src/parser/qnabuild/serviceBase.js
@@ -3,9 +3,11 @@
  * Licensed under the MIT License.
  */
 
-const axios = require('axios');
+const axios = require('axios')
+const axiosHttpsProxy = require('axios-https-proxy')
 const os = require('os')
 const packageJSON = require('./../../../package')
+axios.interceptors.request.use(axiosHttpsProxy)
 
 /**
  * Base class for all services


### PR DESCRIPTION
Given the axios has an [issue ](https://github.com/axios/axios/issues/2072)targeting https protocol, we need to add a patch fix to axios based on fix here https://www.npmjs.com/package/axios-https-proxy to support https proxy. 