### PR TITLE
fix Luis:build lost error message for some cases

### DIFF
--- a/packages/lu/src/parser/lubuild/builder.ts
+++ b/packages/lu/src/parser/lubuild/builder.ts
@@ -285,7 +285,7 @@ export class Builder {
         settingsAssets.push(settings)
       }
     } catch (error) {
-      throw(new exception(retCode.errorCode.LUIS_BUILD_FAILED, `Luis build failed: ${error.message}`))
+      throw(new exception(retCode.errorCode.LUIS_BUILD_FAILED, `Luis build failed: ${error.message ?? error.text}`))
     }
 
     const settingsContent = this.generateDeclarativeAssets(settingsAssets)


### PR DESCRIPTION
Suppose we have a lu file to build
```
# Why
- help
- what can I say
- why do you need my name?
- why age?
- what do you need my profile for?
- why do you ask?
- why do you need that information? 

@ phraselist Test1
    - t1
    - q1

@ phraselist Test2
    - t2
    - q2

@ phraselist Test3
    - t3
    - q3

@ phraselist Test4
    - t4
    - q4

@ phraselist Test5
    - t5
    - q5

@ phraselist Test6
    - t6
    - q6

@ phraselist Test7
    - t7
    - q7

@ phraselist Test8
    - t8
    - q8

@ phraselist Test9
    - t9
    - q9

@ phraselist Test10
    - t10
    - q10

@ phraselist Test11
    - t11
    - q11

@ phraselist Test12
    - t12
    - q1
  ```
For previous bf-luis-cli build, this will throw an error:
`Luis build failed: undefined`

In this PR, the luis: build command will return a more detailed error message: 
`Luis build failed: [ERROR] intent Why has 12 phraselist descriptors (feature). At most 10 is allowed.`