### PR TITLE
fix luis:build write out version in luis setting when the directVersionPublish is not set

### DIFF
--- a/packages/lu/src/parser/lubuild/builder.ts
+++ b/packages/lu/src/parser/lubuild/builder.ts
@@ -250,6 +250,7 @@ export class Builder {
               }
 
               let needTrainAndPublish = false
+              console.log('builder directVersionPublish', directVersionPublish)
 
               // compare models to update the model if a match found
               // otherwise create a new application
@@ -260,7 +261,7 @@ export class Builder {
                 // create a new application
                 needTrainAndPublish = await this.createApplication(currentApp, luBuildCore, recognizer, timeBucketOfRequests)
               }
-
+              console.log('builder needTrainAndPublish', needTrainAndPublish)
               if (needTrainAndPublish) {
                 // train and publish application
                 await this.trainAndPublishApplication(luBuildCore, recognizer, timeBucketOfRequests, isStaging, directVersionPublish, trainMode)
@@ -293,7 +294,7 @@ export class Builder {
     return settingsContent
   }
 
-  async writeDialogAssets(contents: any[], options: any = {}) {
+  async writeDialogAssets(contents: any[], options: any = {}, directVersionPublish?: boolean) {
     let force = options.force || false
     let out = options.out
     let luConfig = options.luConfig
@@ -302,7 +303,7 @@ export class Builder {
     let writeContents = contents.filter(c => c.id.endsWith('.dialog'))
     let settingsContents = contents.filter(c => c.id.endsWith('.json'))
 
-    if (settingsContents && settingsContents.length > 0) {
+    if (settingsContents && settingsContents.length > 0 && directVersionPublish) {
       let outPath
       if (luConfig) {
         outPath = path.join(path.resolve(path.dirname(luConfig)), settingsContents[0].id)
@@ -331,7 +332,7 @@ export class Builder {
         content.content = JSON.stringify(existingCTRecognizerObject, null, 4)
       }
 
-      if (force || !fs.existsSync(outFilePath)) {
+      if ((force || !fs.existsSync(outFilePath)) && directVersionPublish) {
         if (!fs.existsSync(path.dirname(outFilePath))) {
           fs.mkdirSync(path.dirname(outFilePath))
         }

--- a/packages/lu/src/parser/lubuild/builder.ts
+++ b/packages/lu/src/parser/lubuild/builder.ts
@@ -332,7 +332,7 @@ export class Builder {
         content.content = JSON.stringify(existingCTRecognizerObject, null, 4)
       }
 
-      if ((force || !fs.existsSync(outFilePath))) {
+      if (force || !fs.existsSync(outFilePath)) {
         if (!fs.existsSync(path.dirname(outFilePath))) {
           fs.mkdirSync(path.dirname(outFilePath))
         }

--- a/packages/luis/src/commands/luis/build.ts
+++ b/packages/luis/src/commands/luis/build.ts
@@ -68,6 +68,7 @@ export default class LuisBuild extends Command {
 
       // Flags override userConfig
       let luisBuildFlags = Object.keys(LuisBuild.flags)
+      console.log('luis config', luisBuildFlags)
 
       let {inVal, authoringKey, botName, region, out, defaultCulture, fallbackLocale, suffix, dialog, force, luConfig, deleteOldVersion, log, endpoint, schema, isStaging, directVersionPublish}
         = await utils.processInputs(flags, luisBuildFlags, this.config.configDir)
@@ -136,6 +137,7 @@ export default class LuisBuild extends Command {
       let keptVersionCount = 100
       if (deleteOldVersion) keptVersionCount = 1
 
+      console.log('directVersionPublish', directVersionPublish)
       const settingsContent = await builder.build(luContents, authoringKey, botName, {
         endpoint,
         suffix,
@@ -149,18 +151,19 @@ export default class LuisBuild extends Command {
       // write dialog assets based on config
       if (out) {
         const outputFolder = path.resolve(out)
+        console.log('luconfig for out', luConfig)
         if (dialog) {
           const dialogContents = await builder.generateDialogs(luContents, {
             fallbackLocale,
             schema,
             dialog
-          })
+          }, directVersionPublish)
 
           let writeDone = await builder.writeDialogAssets(dialogContents, {
             force,
             out: outputFolder,
             luConfig
-          })
+          }, directVersionPublish)
 
           if (writeDone) {
             this.log(`Successfully wrote .dialog files to ${outputFolder}\n`)

--- a/packages/luis/src/commands/luis/build.ts
+++ b/packages/luis/src/commands/luis/build.ts
@@ -68,7 +68,6 @@ export default class LuisBuild extends Command {
 
       // Flags override userConfig
       let luisBuildFlags = Object.keys(LuisBuild.flags)
-      console.log('luis config', luisBuildFlags)
 
       let {inVal, authoringKey, botName, region, out, defaultCulture, fallbackLocale, suffix, dialog, force, luConfig, deleteOldVersion, log, endpoint, schema, isStaging, directVersionPublish}
         = await utils.processInputs(flags, luisBuildFlags, this.config.configDir)
@@ -137,7 +136,6 @@ export default class LuisBuild extends Command {
       let keptVersionCount = 100
       if (deleteOldVersion) keptVersionCount = 1
 
-      console.log('directVersionPublish', directVersionPublish)
       const settingsContent = await builder.build(luContents, authoringKey, botName, {
         endpoint,
         suffix,
@@ -151,7 +149,6 @@ export default class LuisBuild extends Command {
       // write dialog assets based on config
       if (out) {
         const outputFolder = path.resolve(out)
-        console.log('luconfig for out', luConfig)
         if (dialog) {
           const dialogContents = await builder.generateDialogs(luContents, {
             fallbackLocale,
@@ -176,7 +173,7 @@ export default class LuisBuild extends Command {
           force,
           out: outputFolder,
           luConfig
-        })
+        }, directVersionPublish)
 
         if (writeDone) {
           this.log(`Successfully wrote settings file to ${outputFolder}\n`)

--- a/packages/luis/test/commands/luis/build.test.ts
+++ b/packages/luis/test/commands/luis/build.test.ts
@@ -576,7 +576,7 @@ describe('luis:build write dialog and settings assets successfully if --dialog s
 
   test
     .stdout()
-    .command(['luis:build', '--in', './test/fixtures/testcases/lubuild/sandwich/lufiles/sandwich.en-us.lu', '--authoringKey', uuidv1(), '--botName', 'test', '--out', './results', '--dialog', 'multiLanguage', '--log', '--suffix', 'development'])
+    .command(['luis:build', '--in', './test/fixtures/testcases/lubuild/sandwich/lufiles/sandwich.en-us.lu', '--authoringKey', uuidv1(), '--botName', 'test', '--out', './results', '--dialog', 'multiLanguage', '--log', '--suffix', 'development', '--directVersionPublish'])
     .it('should write dialog and settings assets successfully when --dialog set to multiLanguage', async ctx => {
       expect(await compareFiles('./../../../results/luis.settings.development.westus.json', './../../fixtures/testcases/lubuild/sandwich/config/luis.settings.development.westus.json')).to.be.true
       expect(await compareFiles('./../../../results/sandwich.en-us.lu.dialog', './../../fixtures/testcases/lubuild/sandwich/dialogs/sandwich.en-us.lu.dialog')).to.be.true
@@ -615,7 +615,7 @@ describe('luis:build write dialog and settings assets successfully if --dialog s
 
   test
     .stdout()
-    .command(['luis:build', '--in', './test/fixtures/testcases/lubuild/sandwich/lufiles/sandwich.en-us.lu', '--authoringKey', uuidv1(), '--botName', 'test', '--dialog', 'crosstrained', '--out', './results', '--log', '--suffix', 'development'])
+    .command(['luis:build', '--in', './test/fixtures/testcases/lubuild/sandwich/lufiles/sandwich.en-us.lu', '--authoringKey', uuidv1(), '--botName', 'test', '--dialog', 'crosstrained', '--out', './results', '--log', '--suffix', 'development', '--directVersionPublish'])
     .it('should write dialog and settings assets successfully when --dialog set to crosstrained', async ctx => {
       expect(await compareFiles('./../../../results/luis.settings.development.westus.json', './../../fixtures/testcases/lubuild/sandwich/config/luis.settings.development.westus.json')).to.be.true
       expect(await compareFiles('./../../../results/sandwich.lu.qna.dialog', './../../fixtures/testcases/lubuild/sandwich/dialogs/sandwich.lu.qna.dialog')).to.be.true
@@ -758,7 +758,7 @@ describe('luis:build create multiple applications successfully when input is a f
 
   test
     .stdout()
-    .command(['luis:build', '--in', './test/fixtures/testcases/lubuild/foo/lufiles', '--authoringKey', uuidv1(), '--botName', 'test', '--dialog', 'multiLanguage', '--out', './results', '--log', '--suffix', 'development'])
+    .command(['luis:build', '--in', './test/fixtures/testcases/lubuild/foo/lufiles', '--authoringKey', uuidv1(), '--botName', 'test', '--dialog', 'multiLanguage', '--out', './results', '--log', '--suffix', 'development', '--directVersionPublish'])
     .it('should create multiple applications and write dialog and settings assets successfully when input is a folder', async ctx => {
       expect(ctx.stdout).to.contain('foo.fr-fr.lu loaded')
       expect(ctx.stdout).to.contain('foo.lu loaded')
@@ -903,7 +903,7 @@ describe('luis:build update application succeed with parameters set from luconfi
 
   test
     .stdout()
-    .command(['luis:build', '--authoringKey', uuidv1(), '--luConfig', './test/fixtures/testcases/lubuild/luconfig/lufiles/luconfig.json', '--log', '--suffix', 'development'])
+    .command(['luis:build', '--authoringKey', uuidv1(), '--luConfig', './test/fixtures/testcases/lubuild/luconfig/lufiles/luconfig.json', '--log', '--suffix', 'development', '--directVersionPublish'])
     .it('should update a luis application when utterances changed', async ctx => {
       expect(ctx.stdout).to.contain('Handling applications...')
       expect(ctx.stdout).to.contain('creating version=0.2')
@@ -1139,7 +1139,7 @@ describe('luis:build write dialog and settings assets successfully if schema is 
 
   test
     .stdout()
-    .command(['luis:build', '--in', './test/fixtures/testcases/lubuild/sandwich/lufiles/sandwich.en-us.lu', '--authoringKey', uuidv1(), '--botName', 'test', '--out', './results', '--log', '--suffix', 'development', '--dialog', 'crosstrained', '--schema', 'https://raw.githubusercontent.com/microsoft/BotFramework-Composer/stable/Composer/packages/server/schemas/sdk.schema'])
+    .command(['luis:build', '--in', './test/fixtures/testcases/lubuild/sandwich/lufiles/sandwich.en-us.lu', '--authoringKey', uuidv1(), '--botName', 'test', '--out', './results', '--log', '--suffix', 'development', '--dialog', 'crosstrained', '--schema', 'https://raw.githubusercontent.com/microsoft/BotFramework-Composer/stable/Composer/packages/server/schemas/sdk.schema', '--directVersionPublish'])
     .it('should write dialog and settings assets successfully if schema is specified', async ctx => {
       expect(await compareFiles('./../../../results/luis.settings.development.westus.json', './../../fixtures/testcases/lubuild/sandwich/config/luis.settings.development.westus.json')).to.be.true
       expect(await compareFiles('./../../../results/sandwich.en-us.lu.dialog', './../../fixtures/testcases/lubuild/sandwich/dialogs-with-schema/sandwich.en-us.lu.dialog')).to.be.true
@@ -1197,7 +1197,7 @@ describe('luis:build write dialog and settings assets successfully when empty fi
 
   test
     .stdout()
-    .command(['luis:build', '--in', './test/fixtures/testcases/lubuild/empty-file/lufiles', '--authoringKey', uuidv1(), '--botName', 'test', '--dialog', 'crosstrained', '--out', './results', '--log', '--suffix', 'development'])
+    .command(['luis:build', '--in', './test/fixtures/testcases/lubuild/empty-file/lufiles', '--authoringKey', uuidv1(), '--botName', 'test', '--dialog', 'crosstrained', '--out', './results', '--log', '--suffix', 'development', '--directVersionPublish'])
     .it('should write dialog and settings assets successfully when empty files exist', async ctx => {
       expect(ctx.stdout).to.contain('empty.lu loaded')
       expect(ctx.stdout).to.contain('non-empty.lu loaded')
@@ -1249,11 +1249,48 @@ describe('luis:build write settings assets only successfully if --dialog is not 
 
   test
     .stdout()
-    .command(['luis:build', '--in', './test/fixtures/testcases/lubuild/sandwich/lufiles/sandwich.en-us.lu', '--authoringKey', uuidv1(), '--botName', 'test', '--out', './results', '--log', '--suffix', 'development'])
+    .command(['luis:build', '--in', './test/fixtures/testcases/lubuild/sandwich/lufiles/sandwich.en-us.lu', '--authoringKey', uuidv1(), '--botName', 'test', '--out', './results', '--log', '--suffix', 'development', '--directVersionPublish'])
     .it('should write settings assets only successfully if --dialog is not set', async ctx => {
       expect(await compareFiles('./../../../results/luis.settings.development.westus.json', './../../fixtures/testcases/lubuild/sandwich/config/luis.settings.development.westus.json')).to.be.true
       expect(await compareFiles('./../../../results/sandwich.lu.qna.dialog', './../../fixtures/testcases/lubuild/sandwich/dialogs/sandwich.lu.qna.dialog')).to.be.false
       expect(await compareFiles('./../../../results/sandwich.lu.dialog', './../../fixtures/testcases/lubuild/sandwich/dialogs/sandwich.lu.dialog')).to.be.false
+    })
+})
+
+describe('luis:build write settings assets without version if --directVersionPublish is absent', () => {
+  const existingLuisApp = require('./../../fixtures/testcases/lubuild/sandwich/luis/test(development)-sandwich.en-us.lu.json')
+  before(async function () {
+    await fs.ensureDir(path.join(__dirname, './../../../results/'))
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('apps'))
+      .reply(200, [{
+        name: 'test(development)-sandwich.en-us.lu',
+        id: 'f8c64e2a-8635-3a09-8f78-39d7adc76ec5'
+      }])
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('apps'))
+      .reply(200, {
+        name: 'test(development)-sandwich.en-us.lu',
+        id: 'f8c64e2a-8635-3a09-8f78-39d7adc76ec5',
+        activeVersion: '0.1'
+      })
+
+    nock('https://westus.api.cognitive.microsoft.com')
+      .get(uri => uri.includes('export'))
+      .reply(200, existingLuisApp)
+  })
+
+  after(async function () {
+    await fs.remove(path.join(__dirname, './../../../results/'))
+  })
+
+  test
+    .stdout()
+    .command(['luis:build', '--in', './test/fixtures/testcases/lubuild/sandwich/lufiles/sandwich.en-us.lu', '--authoringKey', uuidv1(), '--botName', 'test', '--out', './results', '--log', '--suffix', 'development'])
+    .it('should write settings assets without version info when --directVersionPublish is absent', async ctx => {
+      expect(await compareFiles('./../../../results/luis.settings.development.westus.json', './../../fixtures/testcases/lubuild/sandwich/config/luis.settings.development_no_version.westus.config')).to.be.true
     })
 })
 

--- a/packages/luis/test/fixtures/testcases/lubuild/sandwich/config/luis.settings.development_no_version.westus.config
+++ b/packages/luis/test/fixtures/testcases/lubuild/sandwich/config/luis.settings.development_no_version.westus.config
@@ -1,0 +1,7 @@
+{
+    "luis": {
+        "sandwich_en_us_lu": {
+            "appId": "f8c64e2a-8635-3a09-8f78-39d7adc76ec5"
+        }
+    }
+}


### PR DESCRIPTION
closes: #1215 
If `--directVersionPublish` flag is absent in luis:build command. The version info won't be included in the luis setting file.
