### PR TITLE
filtering output files from luis:cross-train when encounter Composer generated source luis and qna files

### DIFF
--- a/packages/luis/src/commands/luis/cross-train.ts
+++ b/packages/luis/src/commands/luis/cross-train.ts
@@ -88,7 +88,7 @@ export default class LuisCrossTrain extends Command {
             validatedPath = utils.validatePath(fileId + fileExt, '', force)
           }
 
-          const composerSourceFileRegex = new RegExp(`[\\w-]+\\.source\\.([\\w-]+\\.)?${fileExt.substring(1)}`);
+          const composerSourceFileRegex = new RegExp(`[\\w-]+\\.source\\.([\\w-]+\\.)?${fileExt.substring(1)}`)
           if (!composerSourceFileRegex.test(validatedPath)) {
             await fs.writeFile(validatedPath, fileIdToLuResourceMap.get(fileId).Content, 'utf-8')
           }

--- a/packages/luis/src/commands/luis/cross-train.ts
+++ b/packages/luis/src/commands/luis/cross-train.ts
@@ -88,7 +88,10 @@ export default class LuisCrossTrain extends Command {
             validatedPath = utils.validatePath(fileId + fileExt, '', force)
           }
 
-          await fs.writeFile(validatedPath, fileIdToLuResourceMap.get(fileId).Content, 'utf-8')
+          const composerSourceFileRegex = new RegExp(`[\\w-]+\\.source\\.([\\w-]+\\.)?${fileExt.substring(1)}`);
+          if (!composerSourceFileRegex.test(validatedPath)) {
+            await fs.writeFile(validatedPath, fileIdToLuResourceMap.get(fileId).Content, 'utf-8')
+          }
         } catch (err) {
           throw new CLIError(`Unable to write to file ${fileId}. Error: ${err.message}`)
         }

--- a/packages/luis/test/commands/luis/crossTrain.test.ts
+++ b/packages/luis/test/commands/luis/crossTrain.test.ts
@@ -173,5 +173,6 @@ describe('luis:cross-train tests for lu and qna contents', () => {
       expect(await compareLuFiles('./../../../interruptionGen/ChitchatDialog.en-us.lu', './../../fixtures/verified/interruption9/ChitchatDialog.en-us.lu')).to.be.true
       expect(await compareLuFiles('./../../../interruptionGen/ChitchatDialog.en-us.qna', './../../fixtures/verified/interruption9/ChitchatDialog.en-us.qna')).to.be.true
       expect(fs.existsSync('./../../../interruptionGen/extra.en-us.lu')).to.be.false
+      expect(fs.existsSync('./../../../interruptionGen/chitchat_professional.source.en-us.qna')).to.be.false
     })
 })


### PR DESCRIPTION
In Composer, luis and qna files usually import another file like `xxx.source.en-us.lu` or `xxx.source.fr-fr.qna`. 
Runing luis:cross-train command in CLI will also include these source files, which is different from Composer cross-train behavior.

In this PR, the `xxx.source.en-us.lu` or `xxx.source.fr-fr.qna` will not be written to the output directory.  