### PR TITLE
Add range in diagnostic of reserved prebuilt entity name

### DIFF
--- a/packages/lu/src/parser/lufile/luParser.js
+++ b/packages/lu/src/parser/lufile/luParser.js
@@ -148,7 +148,8 @@ class LUParser {
             newEntitySections.forEach(section =>{
                 if (prebuilts.has(section.Name) && section.Type && section.Type !== 'prebuilt') {
                     section.Errors.push(BuildDiagnostic({
-                        message: `The model name ${section.Name} is reserved.`
+                        message: `The model name ${section.Name} is reserved.`,
+                        range: section.Range
                     }))
                 }
             });

--- a/packages/lu/test/parser/lufile/sectionapi.test.js
+++ b/packages/lu/test/parser/lufile/sectionapi.test.js
@@ -11,14 +11,17 @@ const NEWLINE = require('os').EOL;
 
 describe('luParser parse test', () => {
     let luresource = undefined;
-    it('new Entity name should not use reserved keywords', () => {
+    it.only('new Entity name should not use reserved keywords', () => {
         let fileContent = 
-        `@ ml age
-        @ prebuilt number`;
+        `@ ml age\n@ prebuilt number`;
 
         luresource = luparser.parse(fileContent);
         assert.equal(luresource.Sections[0].Errors.length, 1);
         assert.equal(luresource.Sections[0].Errors[0].Message, 'The model name age is reserved.');
+        assert.equal(luresource.Sections[0].Errors[0].Range.Start.Line, 1);
+        assert.equal(luresource.Sections[0].Errors[0].Range.Start.Character, 0);
+        assert.equal(luresource.Sections[0].Errors[0].Range.End.Line, 1);
+        assert.equal(luresource.Sections[0].Errors[0].Range.End.Character, 9);
     })
 });
 

--- a/packages/lu/test/parser/lufile/sectionapi.test.js
+++ b/packages/lu/test/parser/lufile/sectionapi.test.js
@@ -11,7 +11,7 @@ const NEWLINE = require('os').EOL;
 
 describe('luParser parse test', () => {
     let luresource = undefined;
-    it.only('new Entity name should not use reserved keywords', () => {
+    it('new Entity name should not use reserved keywords', () => {
         let fileContent = 
         `@ ml age\n@ prebuilt number`;
 


### PR DESCRIPTION
Related to #1250
The error of using a reserved entity name should throws error with range infomation. So that the Lu editor in Composer could display correct error range.