### PR TITLE
support luis application list command returns a maximum 500 application 

### DIFF
--- a/packages/lu/src/parser/lubuild/core.ts
+++ b/packages/lu/src/parser/lubuild/core.ts
@@ -47,7 +47,7 @@ export class LuBuildCore {
   }
 
   public async getApplicationList() {
-    const url = `${this.endpoint}/apps`
+    const url = `${this.endpoint}/apps/?skip=0&take=500`
 
     let apps
     let retryCount = this.retryCount + 1


### PR DESCRIPTION
Luis API doc for Get applications list
https://westus.dev.cognitive.microsoft.com/docs/services/luis-programmatic-apis-v3-0-preview/operations/5890b47c39e2bb052c5b9c30

In this PR, the url in luis:application list has been modified. 