### PR TITLE
Improve error reporting of dialog:merge

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -90,7 +90,7 @@
         "999999",
         "--colors",
         "-g",
-        "dialog:merge.*missing schema.*"
+        "dialog:merge.*"
       ],
       "cwd": "${workspaceFolder}/packages/dialog",
       "internalConsoleOptions": "openOnSessionStart",

--- a/packages/dialog/src/library/schemaMerger.ts
+++ b/packages/dialog/src/library/schemaMerger.ts
@@ -502,7 +502,7 @@ export class SchemaMerger {
             this.log('')
             imports = await this.copyAssets()
         } catch (e) {
-            this.mergingError(e)
+            this.mergingError((e as string | Error))
         }
         if (this.failed) {
             this.error('*** Could not merge components ***')
@@ -629,7 +629,7 @@ export class SchemaMerger {
                     this.definitions[kind] = component
                 }
             } catch (e) {
-                this.parsingError(e)
+                this.parsingError((e as string | Error))
             }
         }
         this.currentFile = ''
@@ -752,7 +752,7 @@ export class SchemaMerger {
                             delete component.$schema
                             locale[kindName] = mergeObjects(locale[kindName], component)
                         } catch (e) {
-                            this.parsingError(e)
+                            this.parsingError((e as string | Error))
                         }
                     }
 
@@ -861,7 +861,7 @@ export class SchemaMerger {
                                 if (msg) {
                                     this.log(msg)
                                 }
-                                this.mergingError(e)
+                                this.mergingError((e as string | Error))
                             }
                         }
 
@@ -1178,7 +1178,7 @@ export class SchemaMerger {
                     this.parsingWarning('Missing package')
                 }
             } catch (e) {
-                this.parsingWarning(e.message)
+                this.parsingWarning((e as Error).message)
             } finally {
                 this.currentFile = this.currentParent().metadata.path
             }
@@ -1830,7 +1830,11 @@ export class SchemaMerger {
                                 // New source
                                 this.currentFile = path
                                 this.vlog(`Bundling ${path}`)
-                                schema.definitions[name] = await getJSON(path)
+                                const definition = await getJSON(path)
+                                if (typeof (definition) !== 'object') {
+                                    throw new Error(`Error ${val} did not resolve to JSON Schema object ${definition}`)
+                                }
+                                schema.definitions[name] = definition
                                 sources.push(name)
                             }
                             const ref = `#/definitions/${name}${pointer}`

--- a/packages/dialog/test/commands/dialog/merge.test.ts
+++ b/packages/dialog/test/commands/dialog/merge.test.ts
@@ -499,6 +499,18 @@ describe('dialog:merge', async () => {
         scope.done()
         nock.cleanAll()
     })
+
+    it('non-object ref', async() => {
+        const scope = nock('http://json-schema.org')
+            .get(/draft-07/)
+            .reply(200, '<xml></xml>')
+            .persist()
+        const [merged, lines] = await merge(['nuget/nuget3/1.0.0/*.schema'], 'app.schema')
+        assert(!merged, 'Merging should fail')
+        assert(countMatches(/did not resolve to JSON Schema/i, lines) === 1, 'Did not detect bad definition')
+        scope.done()
+        nock.cleanAll()
+    })
 })
 
 /* TODO: These tests are related to verify and need to be updated and moved there.

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -48,9 +48,6 @@
     "typescript": "^4.0.3",
     "sinon": "^9.0.2"
   },
-  "engines": {
-    "node": ">=8.0.0"
-  },
   "files": [
     "/lib",
     "/npm-shrinkwrap.json",


### PR DESCRIPTION
Fix #1289 

The fix was to make the error reporting better.
In this case a proxy error would return a string
which we would then treat as an object.

Also cleaned up a few lint issues.