### PR TITLE
Throw error if no connection to luis endpoint

### DIFF
--- a/packages/lu/src/parser/lubuild/http-request.ts
+++ b/packages/lu/src/parser/lubuild/http-request.ts
@@ -75,7 +75,7 @@ const httpRequest = async function (config: any) {
       return error.response
     } else {
       // Something happened in setting up the request that triggered an Error
-      return Error(error.message)
+      throw error
     }
   }
 }


### PR DESCRIPTION
closes #1277 
As mentioned in the issue. If there is no connection to luis endpoint. The error message contains nothing. 
In this PR, if the ENOTFOUND error occurred. It will throw the correct error message.
```
[WARN] line 50:0 - line 50:7: no utterances found for intent definition: "# None"
Handling applications...
Luis build failed: getaddrinfo ENOTFOUND westus.api.cognitive.microsoft.com
```