### PR TITLE
[#1350] Failed to parse config.json, error= {} while creating Orchetrator

### DIFF
--- a/packages/orchestratorlib/src/orchestratorhelper.ts
+++ b/packages/orchestratorlib/src/orchestratorhelper.ts
@@ -12,7 +12,7 @@ import {ITextUtteranceLabelMapDataStructure, Label, LabelStructureUtility, Label
 import {LabelResolver} from './labelresolver';
 import {UtilityLabelResolver} from './utilitylabelresolver';
 import {PrebuiltToRecognizerMap} from './resources/recognizer-map';
-import {OrchestratorBuild, OrchestratorSettings} from '.';
+import {OrchestratorBuild} from '.';
 import {Utility} from './utility';
 import {Utility as UtilityDispatcher} from '@microsoft/bf-dispatcher';
 
@@ -291,6 +291,7 @@ export class OrchestratorHelper {
     }
 
     Utility.writeStringLineToConsoleStdout(`Processing ${filePath}...`);
+    const filename: string = path.basename(filePath);
     try {
       switch (ext) {
         case '.lu':
@@ -312,9 +313,6 @@ export class OrchestratorHelper {
           break;
 
         case '.json':
-          if (filePath.endsWith(OrchestratorSettings.OrchestratorSettingsFileName)) {
-            return;
-          }
           if (OrchestratorHelper.getIntentsEntitiesUtterances(
             fs.readJsonSync(filePath),
             routingName,
@@ -324,15 +322,16 @@ export class OrchestratorHelper {
             utteranceEntityLabelDuplicateMap)) {
             return;
           }
-          if (!OrchestratorHelper.getJsonIntentsEntitiesUtterances(
+          if (OrchestratorHelper.getJsonIntentsEntitiesUtterances(
             fs.readJsonSync(filePath),
             routingName,
             utteranceLabelsMap,
             utteranceLabelDuplicateMap,
             utteranceEntityLabelsMap,
             utteranceEntityLabelDuplicateMap)) {
-            throw new Error('Failed to parse LUIS or JSON file on intent/entity labels');
+            return;
           }
+          Utility.writeStringLineToConsoleStdout(`  - Failed to parse file '${filename}'. This file will be ignored.`);
           break;
 
         case '.tsv':

--- a/packages/orchestratorlib/src/orchestratorhelper.ts
+++ b/packages/orchestratorlib/src/orchestratorhelper.ts
@@ -331,7 +331,7 @@ export class OrchestratorHelper {
             utteranceEntityLabelDuplicateMap)) {
             return;
           }
-          Utility.writeStringLineToConsoleStdout(`  - Failed to parse file '${filename}'. This file will be ignored.`);
+          Utility.writeStringLineToConsoleStdout(`  - Unsupported file extension. Skipping file '${filename}'.`);
           break;
 
         case '.tsv':

--- a/packages/orchestratorlib/test/fixtures/adaptive/UnsupportedFile.json
+++ b/packages/orchestratorlib/test/fixtures/adaptive/UnsupportedFile.json
@@ -1,0 +1,3 @@
+{ 
+    "error": "Unsupported format for data model"
+}

--- a/packages/orchestratorlib/test/orchestratorhelper.test.ts
+++ b/packages/orchestratorlib/test/orchestratorhelper.test.ts
@@ -589,6 +589,16 @@ describe('Test Suite - orchestratorhelper', () => {
     assert.ok(result.has('delete to do go shopping'), 'Incorrect result from getUtteranceLabelsMap, missing delete to do go shopping utterance');
   });
 
+  it('Test.0501 OrchestratorHelper.getUtteranceLabelsMap().InvalidFormat', async () => {
+    const inputFile: string = './test/fixtures/adaptive/UnsupportedFile.json';
+    let result: Map<string, Set<string>> = new Map<string, Set<string>>();
+    try {
+      result = (await OrchestratorHelper.getUtteranceLabelsMap(inputFile)).utteranceLabelsMap;
+      assert.fail(`Unsupported file extension. Skipping file '${inputFile}'`);
+    } catch {}
+    assert.ok(result.size === 0);
+  });
+
   it('Test.0600 OrchestratorHelper.parseQnaFile()', async () => {
     const validFile: string = './test/fixtures/parser/valid.qna';
     const inValidFile: string = './test/fixtures/parser/invalid.qna';


### PR DESCRIPTION
Fixes #1350

## Description
This PR updates how the Orchestrator processing file functionality behaves when a custom path in the `--in` argument is provided, that could have multiple JSON files that aren't supported by the Orchestrator process. By just logging out to the console if a JSON file isn't supported, instead of failing.

## Specific Changes
- Removes throw Error.
- Adds failed to parse JSON file log.
- Updates conditions around JSON files for consistency.

## Testing
The following image shows the before and after the changes.
![image](https://user-images.githubusercontent.com/62260472/190418606-1fc2cec4-dab6-4244-91a2-5a3c811e44bb.png)