### PR TITLE
Increase daily build job timeout to 120 minutes

### DIFF
--- a/build/botframework-cli-daily.yml
+++ b/build/botframework-cli-daily.yml
@@ -28,6 +28,8 @@ stages:
     runCodesignValidationInjection: false # Disables the unnecessary injected CodeSign Validation step
   jobs:
   - job:
+    timeoutInMinutes: 120 # how long to run the job before automatically cancelling
+    cancelTimeoutInMinutes: 2 # how much time to give 'run always even if cancelled tasks' before stopping them    steps:
     steps:
     - script: echo '##vso[task.setvariable variable=_version]${{ variables.releaseVersion }}-dev
     - template: bf-cli-build-test-steps.yml


### PR DESCRIPTION
Finalize CodeQL ran for 41 minutes, maxing out the build timeout period of 60 minutes.