### PR TITLE
fix: Remove CVE-2021-44906 vulnerability

### DIFF
--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -2,6 +2,7 @@
     "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/pnpm-config.schema.json",
     "globalOverrides": {
         "yarn": "^1.22.22",
-        "@oclif/config": "1.15.1"
+        "@oclif/config": "1.15.1",
+        "minimist": "^1.2.6"
     }
 }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: 5.4
 overrides:
   yarn: ^1.22.22
   '@oclif/config': 1.15.1
+  minimist: ^1.2.6
 
 specifiers:
   '@apidevtools/json-schema-ref-parser': ^9.0.1
@@ -2328,7 +2329,7 @@ packages:
     resolution: {integrity: sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==}
     deprecated: Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)
     dependencies:
-      ms: 2.1.2
+      ms: 2.1.3
     dev: false
 
   /debug/4.1.1:
@@ -3033,7 +3034,7 @@ packages:
     dependencies:
       '@nodelib/fs.stat': 2.0.3
       '@nodelib/fs.walk': 1.2.4
-      glob-parent: 5.1.0
+      glob-parent: 5.1.2
       merge2: 1.3.0
       micromatch: 4.0.2
       picomatch: 2.2.1
@@ -3386,13 +3387,6 @@ packages:
       path-dirname: 1.0.2
     dev: false
 
-  /glob-parent/5.1.0:
-    resolution: {integrity: sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==}
-    engines: {node: '>= 6'}
-    dependencies:
-      is-glob: 4.0.1
-    dev: false
-
   /glob-parent/5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -3648,7 +3642,7 @@ packages:
   /humanize-ms/1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
     dependencies:
-      ms: 2.1.2
+      ms: 2.1.3
     dev: false
 
   /hyperlinker/1.0.0:
@@ -4600,14 +4594,6 @@ packages:
       brace-expansion: 2.0.1
     dev: false
 
-  /minimist/0.0.8:
-    resolution: {integrity: sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=}
-    dev: false
-
-  /minimist/1.2.0:
-    resolution: {integrity: sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=}
-    dev: false
-
   /minimist/1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: false
@@ -4679,7 +4665,7 @@ packages:
     deprecated: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
     hasBin: true
     dependencies:
-      minimist: 0.0.8
+      minimist: 1.2.8
     dev: false
 
   /mkdirp/1.0.4:
@@ -5420,7 +5406,7 @@ packages:
     dependencies:
       deep-extend: 0.6.0
       ini: 1.3.5
-      minimist: 1.2.0
+      minimist: 1.2.8
       strip-json-comments: 2.0.1
     dev: false
 


### PR DESCRIPTION
#minor

## Description
This PR sets the version of the package **_minimist_** to ^1.2.6 and avoids the [CVE-2021-44906](https://security.snyk.io/vuln/SNYK-JS-MINIMIST-2429795) vulnerability.

## Specific Changes
  - Added global override for **_minimist_** ^1.2.6.

## Testing
The following image shows the **_minimist_** version installed after the override.
![image](https://github.com/southworks/botframework-cli/assets/122501764/961d79ed-9409-4d25-b0ff-58d85e3ff984)